### PR TITLE
add checkAuth redirectPath support

### DIFF
--- a/documentation/docs/api-references/providers/auth-provider.md
+++ b/documentation/docs/api-references/providers/auth-provider.md
@@ -323,6 +323,21 @@ const authProvider = {
 
 <br />
 
+- A custom `redirectPath` can be given to `Promise` reject from the `checkAuth`. If you want to redirect yourself to a certain URL.
+
+```tsx {5}
+const authProvider = {
+   ...
+    checkAuth: () => {
+        localStorage.getItem("auth") ?
+        Promise.resolve() : 
+        Promise.reject({ redirectPath: "/custom-url" });
+    },
+   ...
+};
+```
+<br/>
+
 `checkAuth` method will be accessible via `useAuthenticated` auth hook.
 
 ```tsx twoslash

--- a/documentation/docs/api-references/providers/auth-provider.md
+++ b/documentation/docs/api-references/providers/auth-provider.md
@@ -329,9 +329,9 @@ const authProvider = {
 const authProvider = {
    ...
     checkAuth: () => {
-        localStorage.getItem("auth") ?
-        Promise.resolve() : 
-        Promise.reject({ redirectPath: "/custom-url" });
+        localStorage.getItem("auth")
+            ? Promise.resolve()
+            : Promise.reject({ redirectPath: "/custom-url" });
     },
    ...
 };

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -138,30 +138,35 @@ export const Refine: React.FC<RefineProps> = ({
     }
 
     return (
-        <QueryClientProvider client={queryClient}>
-            <AuthContextProvider {...authProvider} isProvided={!!authProvider}>
-                <DataContextProvider {...dataProvider}>
-                    <ResourceContextProvider resources={resources}>
-                        <TranslationContextProvider i18nProvider={i18nProvider}>
-                            <ConfigProvider {...configProviderProps}>
-                                <NotificationContextProvider>
-                                    <RefineContextProvider
-                                        mutationMode={mutationMode}
-                                        warnWhenUnsavedChanges={
-                                            warnWhenUnsavedChanges
-                                        }
-                                        syncWithLocation={syncWithLocation}
-                                        Title={Title}
-                                        undoableTimeout={undoableTimeout}
-                                        Layout={Layout}
-                                        Sider={Sider}
-                                        Footer={Footer}
-                                        Header={Header}
-                                        OffLayoutArea={OffLayoutArea}
-                                        hasDashboard={!!DashboardPage}
-                                    >
-                                        <UnsavedWarnContextProvider>
-                                            <MainRouter>
+        <MainRouter>
+            <QueryClientProvider client={queryClient}>
+                <AuthContextProvider
+                    {...authProvider}
+                    isProvided={!!authProvider}
+                >
+                    <DataContextProvider {...dataProvider}>
+                        <ResourceContextProvider resources={resources}>
+                            <TranslationContextProvider
+                                i18nProvider={i18nProvider}
+                            >
+                                <ConfigProvider {...configProviderProps}>
+                                    <NotificationContextProvider>
+                                        <RefineContextProvider
+                                            mutationMode={mutationMode}
+                                            warnWhenUnsavedChanges={
+                                                warnWhenUnsavedChanges
+                                            }
+                                            syncWithLocation={syncWithLocation}
+                                            Title={Title}
+                                            undoableTimeout={undoableTimeout}
+                                            Layout={Layout}
+                                            Sider={Sider}
+                                            Footer={Footer}
+                                            Header={Header}
+                                            OffLayoutArea={OffLayoutArea}
+                                            hasDashboard={!!DashboardPage}
+                                        >
+                                            <UnsavedWarnContextProvider>
                                                 <>
                                                     <RouteProvider
                                                         resources={resources}
@@ -175,17 +180,20 @@ export const Refine: React.FC<RefineProps> = ({
                                                     />
                                                     <RouteChangeHandler />
                                                 </>
-                                            </MainRouter>
-                                        </UnsavedWarnContextProvider>
-                                    </RefineContextProvider>
-                                </NotificationContextProvider>
-                            </ConfigProvider>
-                        </TranslationContextProvider>
-                    </ResourceContextProvider>
-                </DataContextProvider>
-            </AuthContextProvider>
-            <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
-        </QueryClientProvider>
+                                            </UnsavedWarnContextProvider>
+                                        </RefineContextProvider>
+                                    </NotificationContextProvider>
+                                </ConfigProvider>
+                            </TranslationContextProvider>
+                        </ResourceContextProvider>
+                    </DataContextProvider>
+                </AuthContextProvider>
+                <ReactQueryDevtools
+                    initialIsOpen={false}
+                    position="bottom-right"
+                />
+            </QueryClientProvider>
+        </MainRouter>
     );
 };
 

--- a/packages/core/src/contexts/auth/index.tsx
+++ b/packages/core/src/contexts/auth/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useQueryClient } from "react-query";
 
+import { useNavigation } from "@hooks";
 import { IAuthContext } from "../../interfaces";
 
 const defaultProvider: IAuthContext = {
@@ -23,6 +24,7 @@ export const AuthContextProvider: React.FC<Partial<IAuthContext>> = ({
     isProvided,
     children,
 }) => {
+    const { replace } = useNavigation();
     const [isAuthenticated, setAuthenticated] = useState(false);
     const queryClient = useQueryClient();
 
@@ -58,6 +60,11 @@ export const AuthContextProvider: React.FC<Partial<IAuthContext>> = ({
             await checkAuth(params);
             setAuthenticated(true);
         } catch (error) {
+            const { redirectPath } = error;
+
+            if (redirectPath) {
+                replace(redirectPath);
+            }
             setAuthenticated(false);
             throw error;
         }

--- a/packages/core/src/contexts/auth/index.tsx
+++ b/packages/core/src/contexts/auth/index.tsx
@@ -60,7 +60,7 @@ export const AuthContextProvider: React.FC<Partial<IAuthContext>> = ({
             await checkAuth(params);
             setAuthenticated(true);
         } catch (error) {
-            const { redirectPath } = error;
+            const { redirectPath } = error as { redirectPath?: string };
 
             if (redirectPath) {
                 replace(redirectPath);

--- a/packages/core/src/hooks/auth/useAuthenticated/index.spec.ts
+++ b/packages/core/src/hooks/auth/useAuthenticated/index.spec.ts
@@ -1,8 +1,18 @@
 import { renderHook } from "@testing-library/react-hooks";
+import ReactRouterDom from "react-router-dom";
 
 import { TestWrapper } from "@test";
 
 import { useAuthenticated } from "./";
+
+const mHistory = {
+    replace: jest.fn(),
+};
+
+jest.mock("react-router-dom", () => ({
+    ...(jest.requireActual("react-router-dom") as typeof ReactRouterDom),
+    useHistory: jest.fn(() => mHistory),
+}));
 
 describe("useAuthenticated Hook", () => {
     it("returns authenticated true", async () => {
@@ -47,5 +57,30 @@ describe("useAuthenticated Hook", () => {
         });
 
         expect(result.current?.isError).toBeTruthy();
+    });
+
+    it("returns authenticated false and called checkError with custom redirect path", async () => {
+        const checkErrorMock = jest.fn();
+        const { result, waitFor } = renderHook(() => useAuthenticated(), {
+            wrapper: TestWrapper({
+                authProvider: {
+                    login: () => Promise.resolve(),
+                    checkAuth: () =>
+                        Promise.reject({ redirectPath: "/custom-url" }),
+                    checkError: checkErrorMock,
+                    getPermissions: () => Promise.resolve(),
+                    logout: () => Promise.resolve(),
+                    getUserIdentity: () => Promise.resolve({ id: 1 }),
+                },
+            }),
+        });
+
+        await waitFor(() => {
+            return result.current?.isFetched;
+        });
+
+        expect(result.current?.isError).toBeTruthy();
+
+        expect(mHistory.replace).toBeCalledWith("/custom-url", undefined);
     });
 });


### PR DESCRIPTION
Test me! 'MASTER'
[Link to ADD-CHECK-AUTH-REDIRECT-PATH-SUPPORT](https://add-che-refine.pankod.com)

Please provide enough information so that others can review your pull request:

We should be able to customize the URL where the user will be redirected when `checkAuth` fails.
It is redirected to root by default.

**Test plan (required)**

```
 checkAuth: () => {
        localStorage.getItem("auth") ? Promise.resolve() : Promise.reject({ redirectPath: "/custom-login-page" });
    },
```

**Closing issues**

#1126 

Test documentation! 'MASTER'
[Link to ADD-CHECK-AUTH-REDIRECT-PATH-SUPPORT](https://add-che-doc-refine.pankod.com)