### PR TITLE
Customizable React Query Devtools

### DIFF
--- a/documentation/docs/api-references/components/refine-config.md
+++ b/documentation/docs/api-references/components/refine-config.md
@@ -477,8 +477,8 @@ const App: React.FC = () =>
         <Refine
             dataProvider={dataProvider(API_URL)}
             reactQueryDevtoolConfig={{
-                panelProps: { style: { background: "blue" } },
-                closeButtonProps: { onClick: () => console.log("On close") },
+                position: "bottom-left",
+                initialIsOpen: true,
             }}
         >
          ...

--- a/documentation/docs/api-references/components/refine-config.md
+++ b/documentation/docs/api-references/components/refine-config.md
@@ -456,6 +456,35 @@ const App: React.FC = () =>
         </Refine>
     );
 ```
+### `reactQueryDevtoolConfig`
+
+Config for customize React Query Devtools.
+
+**refine** uses some defaults that applies to react-query devtool:
+
+```ts
+{
+    initialIsOpen: false,
+    position: "bottom-right"
+}
+```
+[Refer to the Devtools documentation for detailed information. &#8594](https://react-query.tanstack.com/devtools#options)
+
+
+```tsx {4-10}
+const App: React.FC = () => 
+    (
+        <Refine
+            dataProvider={dataProvider(API_URL)}
+            reactQueryDevtoolConfig={{
+                panelProps: { style: { background: "blue" } },
+                closeButtonProps: { onClick: () => console.log("On close") },
+            }}
+        >
+         ...
+        </Refine>
+    );
+```
 
 ### `notificationConfig`
 

--- a/documentation/docs/api-references/components/refine-config.md
+++ b/documentation/docs/api-references/components/refine-config.md
@@ -471,7 +471,7 @@ Config for customize React Query Devtools.
 [Refer to the Devtools documentation for detailed information. &#8594](https://react-query.tanstack.com/devtools#options)
 
 
-```tsx {4-10}
+```tsx {4-7}
 const App: React.FC = () => 
     (
         <Refine

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -10,6 +10,7 @@ import {
     MutationCache,
     DefaultOptions,
 } from "react-query";
+
 import { ReactQueryDevtools } from "react-query/devtools";
 
 import { AuthContextProvider } from "@contexts/auth";
@@ -43,6 +44,7 @@ interface QueryClientConfig {
     mutationCache?: MutationCache;
     defaultOptions?: DefaultOptions;
 }
+
 export interface RefineProps {
     authProvider?: IAuthContext;
     dataProvider: IDataContextProvider;
@@ -65,6 +67,7 @@ export interface RefineProps {
     Title?: React.FC<TitleProps>;
     reactQueryClientConfig?: QueryClientConfig;
     notifcationConfig?: ConfigProps;
+    reactQueryDevtoolConfig?: any;
 }
 
 /**
@@ -96,6 +99,7 @@ export const Refine: React.FC<RefineProps> = ({
     Footer,
     OffLayoutArea,
     reactQueryClientConfig,
+    reactQueryDevtoolConfig,
     notifcationConfig,
 }) => {
     const queryClient = new QueryClient({
@@ -191,6 +195,7 @@ export const Refine: React.FC<RefineProps> = ({
                 <ReactQueryDevtools
                     initialIsOpen={false}
                     position="bottom-right"
+                    {...reactQueryDevtoolConfig}
                 />
             </QueryClientProvider>
         </MainRouter>


### PR DESCRIPTION
Test me! 'MASTER'
[Link to CUSTOMIZABLE-REACT-QUERY](https://customi-refine.pankod.com)

React Query Devtools can now be customized passing `reactQueryDevtoolConfig` property.

**Closing issues**

closes #1197


Test documentation! 'MASTER'
[Link to CUSTOMIZABLE-REACT-QUERY](https://customi-doc-refine.pankod.com)