### PR TITLE
upgrade refine-nextjs-router - next.js@12

### DIFF
--- a/examples/fineFoods/client/package.json
+++ b/examples/fineFoods/client/package.json
@@ -15,7 +15,7 @@
         "@pankod/refine-simple-rest": "^2.0.12",
         "gsap": "^3.8.0",
         "js-confetti": "^0.9.0",
-        "next": "^11.1.2",
+        "next": "^12.0.3",
         "next-compose-plugins": "^2.2.1",
         "next-plugin-antd-less": "^1.4.3",
         "nookies": "^2.5.2",

--- a/examples/i18n/nextjs/package.json
+++ b/examples/i18n/nextjs/package.json
@@ -12,7 +12,7 @@
         "@pankod/refine": "^2.0.7",
         "@pankod/refine-nextjs-router": "^2.0.7",
         "@pankod/refine-simple-rest": "^2.0.7",
-        "next": "^11.1.2",
+        "next": "^12.0.3",
         "next-compose-plugins": "^2.2.1",
         "next-i18next": "^8.9.0",
         "nookies": "^2.5.2",

--- a/examples/refine-next/package.json
+++ b/examples/refine-next/package.json
@@ -12,7 +12,7 @@
         "@pankod/refine": "^2.0.7",
         "@pankod/refine-nextjs-router": "^2.0.7",
         "@pankod/refine-simple-rest": "^2.0.7",
-        "next": "^11.1.2",
+        "next": "^12.0.3",
         "next-compose-plugins": "^2.2.1",
         "nookies": "^2.5.2",
         "react": "^17.0.2",

--- a/examples/refine-next/tsconfig.json
+++ b/examples/refine-next/tsconfig.json
@@ -1,28 +1,51 @@
 {
-    "compilerOptions": {
-        "target": "es5",
-        "lib": ["dom", "dom.iterable", "esnext"],
-        "allowJs": true,
-        "skipLibCheck": true,
-        "strict": true,
-        "forceConsistentCasingInFileNames": true,
-        "noEmit": true,
-        "esModuleInterop": true,
-        "module": "esnext",
-        "moduleResolution": "node",
-        "resolveJsonModule": true,
-        "isolatedModules": true,
-        "jsx": "preserve",
-        "baseUrl": ".",
-        "paths": {
-            "@components/*": ["src/components/*"],
-            "@components": ["src/components"],
-            "@styles/*": ["src/styles/*"],
-            "@styles": ["src/styles"],
-            "@public/*": ["public/*"],
-            "@public": ["public"]
-        }
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": [
+        "src/components/*"
+      ],
+      "@components": [
+        "src/components"
+      ],
+      "@styles/*": [
+        "src/styles/*"
+      ],
+      "@styles": [
+        "src/styles"
+      ],
+      "@public/*": [
+        "public/*"
+      ],
+      "@public": [
+        "public"
+      ]
     },
-    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-    "exclude": ["node_modules"]
+    "incremental": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/packages/nextjs-router/package.json
+++ b/packages/nextjs-router/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@pankod/refine": "^2.0.12",
     "@types/qs": "^6.9.7",
-    "next": "^11.1.2",
+    "next": "^12.0.3",
     "qs": "^6.10.1"
   },
   "gitHead": "829f5a516f98c06f666d6be3e6e6099c75c07719",


### PR DESCRIPTION
Test me! 'ALPHA'
[Link to UPGRADE-NEXTJS-12](https://upgrade-refine.pankod.com)

Please provide enough information so that others can review your pull request:

Added support for next.js@12

Explain the **details** for making this change. What existing problem does the pull request solve?

Unable to use next.js 12 with refine. now refine-nextjs-router depends on next@12


**Closing issues**

#1233 