### PR TITLE
omit defaultFormValues prop on useModalForm

### DIFF
--- a/packages/core/types/sunflower.d.ts
+++ b/packages/core/types/sunflower.d.ts
@@ -1,7 +1,8 @@
 import { FormInstance, FormProps, ModalProps } from "../src/components/antd";
 import { UseFormConfig, UseModalFormConfig } from "sunflower-antd";
 
-export interface UseStepsFormConfig extends UseFormConfig {
+export interface UseStepsFormConfig
+    extends Omit<UseFormConfig, "defaultFormValues"> {
     defaultCurrent?: number;
     total?: number;
     isBackValidate?: boolean;
@@ -84,7 +85,7 @@ declare module "sunflower-antd" {
     };
 
     export declare const useModalForm: <TData, TVariables>(
-        config: UseModalFormConfig,
+        config: Omit<UseModalFormConfig, "defaultFormValues">,
     ) => {
         form: FormInstance<TVariables>;
         visible: boolean;


### PR DESCRIPTION
Test me! 'MASTER'
[Link to OMIT-DEFAULT-FORM-VALUES-USE-MODAL-FORM](https://omit-de-refine.pankod.com)

"defaultFormValues" from sunflower library is not used by refine but exported as type. It is now Omited. Form component's `initialValues` property can be used

**Closing issues**

#1263 