### PR TITLE
update "eq" filter operator on strapi & strapi-graphql data providers

### DIFF
--- a/examples/dataProvider/strapi/package.json
+++ b/examples/dataProvider/strapi/package.json
@@ -6,21 +6,21 @@
     "@pankod/refine": "^2.0.7",
     "@pankod/refine-react-router": "^2.0.7",
     "@pankod/refine-strapi": "^2.0.7",
-    "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/react": "^11.1.0",
-    "@testing-library/user-event": "^12.1.10",
-    "@types/jest": "^26.0.15",
-    "@types/node": "^12.0.0",
-    "@types/react": "^17.0.0",
+    "@testing-library/jest-dom": "^5.12.0",
+    "@testing-library/react": "^11.2.6",
+    "@testing-library/user-event": "^12.8.3",
+    "@types/jest": "^26.0.24",
+    "@types/node": "^12.20.11",
+    "@types/react": "^17.0.4",
     "@types/react-dom": "^17.0.4",
     "axios": "^0.21.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
-    "react-scripts": "4.0.2",
-    "typescript": "^4.1.2",
-    "web-vitals": "^1.0.1"
+    "react-scripts": "4.0.3",
+    "typescript": "^4.4.3",
+    "web-vitals": "^1.1.1"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -41,7 +41,7 @@
     ]
   },
   "devDependencies": {
-    "@babel/core": "^7.12.16",
+    "@babel/core": "^7.13.14",
     "http-proxy-middleware": "^1.3.1"
   }
 }

--- a/packages/strapi-graphql/src/index.ts
+++ b/packages/strapi-graphql/src/index.ts
@@ -22,7 +22,11 @@ const generateFilter = (filters?: CrudFilters) => {
 
     if (filters) {
         filters.map(({ field, operator, value }) => {
-            queryFilters[`${field}_${operator}`] = value;
+            if (operator === "eq") {
+                queryFilters[`${field}`] = value;
+            } else {
+                queryFilters[`${field}_${operator}`] = value;
+            }
         });
     }
 

--- a/packages/strapi/src/dataProvider.ts
+++ b/packages/strapi/src/dataProvider.ts
@@ -42,7 +42,11 @@ const generateFilter = (filters?: CrudFilters) => {
     const queryFilters: { [key: string]: string } = {};
     if (filters) {
         filters.map(({ field, operator, value }) => {
-            queryFilters[`${field}_${operator}`] = value;
+            if (operator === "eq") {
+                queryFilters[`${field}`] = value;
+            } else {
+                queryFilters[`${field}_${operator}`] = value;
+            }
         });
     }
 


### PR DESCRIPTION
Strapi REST and GraphQL APIs don't need a suffix for the "eq" filter. With this change, we can now support Strapi Draft Content filters.

**Closing issues**

closes #1273 