### PR TITLE
fix custom routes wrapped layout wrapper

### DIFF
--- a/packages/react-router/src/routeProvider.tsx
+++ b/packages/react-router/src/routeProvider.tsx
@@ -176,7 +176,7 @@ const RouteProviderBase: React.FC = () => {
     const renderAuthorized = () => (
         <Switch>
             {[...(customRoutes || [])].map((route, i) => (
-                <RouteWithSubRoutes key={i} {...route} />
+                <Route key={`custom-route-${i}`} {...route} />
             ))}
             <Route>
                 <Switch>
@@ -205,14 +205,18 @@ const RouteProviderBase: React.FC = () => {
                         <RouteWithSubRoutes key={i} {...route} />
                     ))}
                     <Route path="/:resource?/:action?">
-                        <LayoutWrapper>
-                            {catchAll ?? <ErrorComponent />}
-                        </LayoutWrapper>
+                        {catchAll ?? (
+                            <LayoutWrapper>
+                                <ErrorComponent />
+                            </LayoutWrapper>
+                        )}
                     </Route>
                     <Route>
-                        <LayoutWrapper>
-                            {catchAll ?? <ErrorComponent />}
-                        </LayoutWrapper>
+                        {catchAll ?? (
+                            <LayoutWrapper>
+                                <ErrorComponent />
+                            </LayoutWrapper>
+                        )}
                     </Route>
                 </Switch>
             </Route>
@@ -229,7 +233,7 @@ const RouteProviderBase: React.FC = () => {
                 }
             />
             {[...(customRoutes || [])].map((route, i) => (
-                <RouteWithSubRoutes key={i} {...route} />
+                <Route key={`custom-route-${i}`} {...route} />
             ))}
 
             <Route


### PR DESCRIPTION
Hey, I'm client! Test me! 'MASTER'
[Link to FIX-LAYOUT-WRAPPER-FOR-CUSTOM-PAGASE](https://fix-lay-client.refine.pankod.com)

Please provide enough information so that others can review your pull request:

`customPages` were wrapped in `LayoutWrapper` by default. Now the user can specify himself whether to wrap it in LayoutWrapper or not.

**Closing issues**

closes #1279 