### PR TITLE
fix useTable loading state

### DIFF
--- a/packages/core/src/hooks/table/useTable/useTable.ts
+++ b/packages/core/src/hooks/table/useTable/useTable.ts
@@ -240,8 +240,7 @@ export const useTable = <
         tableProps: {
             ...tablePropsSunflower,
             dataSource: data?.data,
-            loading: liveMode ? isLoading : isFetching,
-            // loading: isFetching,
+            loading: liveMode === "auto" ? isLoading : isFetching,
             onChange,
             pagination: {
                 ...tablePropsSunflower.pagination,


### PR DESCRIPTION
Hey, I'm client! Test me! 'MASTER'
[Link to FIX-USE-TABLE-LOADING-STATE](https://fix-use-client.refine.pankod.com)

The `useTable` should show a loading animation based on the `isFetching` state of react-query. `isLoading` should only be considered when `liveMode` is `auto`.

**Closing issues**

closes #1316 