### PR TITLE
Add filter support to the airtable data provider

### DIFF
--- a/packages/airtable/package.json
+++ b/packages/airtable/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@pankod/refine": "^2.4.9",
+    "@qualifyze/airtable-formulator": "^1.0.1",
     "airtable": "^0.11.1",
     "asyncairtable": "^2.1.0",
     "query-string": "^7.0.1"

--- a/packages/airtable/src/index.ts
+++ b/packages/airtable/src/index.ts
@@ -1,5 +1,10 @@
 import { DataProvider } from "@pankod/refine";
-import { CrudSorting } from "@pankod/refine/dist/interfaces";
+import {
+    CrudFilters,
+    CrudOperators,
+    CrudSorting,
+} from "@pankod/refine/dist/interfaces";
+import { compile, Formula } from "@qualifyze/airtable-formulator";
 import Airtable from "airtable";
 import { AirtableBase } from "airtable/lib/airtable_base";
 
@@ -8,6 +13,71 @@ const generateSort = (sort?: CrudSorting) => {
         field: item.field,
         direction: item.order,
     }));
+};
+
+const simpleOperators: Partial<Record<CrudOperators, string>> = {
+    eq: "=",
+    ne: "!=",
+    lt: "<",
+    lte: "<=",
+    gt: ">",
+    gte: ">=",
+};
+
+const generateFilter = (filters?: CrudFilters): string | undefined => {
+    if (filters) {
+        const parsedFilter = filters.map(
+            ({ field, operator, value }): Formula => {
+                if (Object.keys(simpleOperators).includes(operator)) {
+                    const mappedOperator =
+                        simpleOperators[
+                            operator as keyof typeof simpleOperators
+                        ];
+
+                    return [mappedOperator as string, { field }, value];
+                }
+
+                if (["contains", "ncontains"].includes(operator)) {
+                    const mappedOperator = {
+                        contains: "!=",
+                        ncontains: "=",
+                    }[operator as "contains" | "ncontains"];
+
+                    return [mappedOperator, ["FIND", value, { field }], 0];
+                }
+
+                if (["containss", "ncontainss"].includes(operator)) {
+                    const mappedOperator = {
+                        containss: "!=",
+                        ncontainss: "=",
+                    }[operator as "containss" | "ncontainss"];
+
+                    const find = [
+                        "FIND",
+                        ["LOWER", value],
+                        ["LOWER", { field }],
+                    ] as Formula;
+
+                    return [mappedOperator, find, 0];
+                }
+
+                if (operator === "null") {
+                    if (typeof value !== "boolean")
+                        throw new Error(
+                            "Value must be a boolean for the null operator",
+                        );
+
+                    return [value ? "=" : "!=", { field }, ["BLANK"]];
+                }
+
+                throw Error(`Operator ${operator} is not supported`);
+            },
+        );
+
+        return compile(["AND", ...parsedFilter]);
+    }
+
+    return undefined;
 };
 
 const AirtableDataProvider = (
@@ -19,15 +89,17 @@ const AirtableDataProvider = (
         airtableClient || new Airtable({ apiKey: apiKey }).base(baseId);
 
     return {
-        getList: async ({ resource, pagination, sort }) => {
+        getList: async ({ resource, pagination, sort, filters }) => {
             const current = pagination?.current || 1;
             const pageSize = pagination?.pageSize || 10;
 
             const generetedSort = generateSort(sort) || [];
+            const queryFilters = generateFilter(filters);
 
             const { all } = base(resource).select({
                 pageSize: 100,
                 sort: generetedSort,
+                ...(queryFilters ? { filterByFormula: queryFilters } : {}),
             });
 
             const data = await all();

--- a/packages/airtable/src/index.ts
+++ b/packages/airtable/src/index.ts
@@ -37,20 +37,20 @@ const generateFilter = (filters?: CrudFilters): string | undefined => {
                     return [mappedOperator as string, { field }, value];
                 }
 
-                if (["contains", "ncontains"].includes(operator)) {
-                    const mappedOperator = {
-                        contains: "!=",
-                        ncontains: "=",
-                    }[operator as "contains" | "ncontains"];
-
-                    return [mappedOperator, ["FIND", value, { field }], 0];
-                }
-
                 if (["containss", "ncontainss"].includes(operator)) {
                     const mappedOperator = {
                         containss: "!=",
                         ncontainss: "=",
                     }[operator as "containss" | "ncontainss"];
+
+                    return [mappedOperator, ["FIND", value, { field }], 0];
+                }
+
+                if (["contains", "ncontains"].includes(operator)) {
+                    const mappedOperator = {
+                        contains: "!=",
+                        ncontains: "=",
+                    }[operator as "contains" | "ncontains"];
 
                     const find = [
                         "FIND",

--- a/packages/airtable/test/getList/index.mock.ts
+++ b/packages/airtable/test/getList/index.mock.ts
@@ -1,4 +1,65 @@
 import nock from "nock";
+import url from "url";
+
+const commonHeaders = [
+    "access-control-allow-headers",
+    "authorization,content-length,content-type,user-agent,x-airtable-application-id,x-airtable-user-agent,x-api-version,x-requested-with",
+    "access-control-allow-methods",
+    "DELETE,GET,OPTIONS,PATCH,POST,PUT",
+    "access-control-allow-origin",
+    "*",
+    "airtable-uncompressed-content-length",
+    "380",
+    "Content-Type",
+    "application/json; charset=utf-8",
+    "Date",
+    "Thu, 24 Jun 2021 12:24:32 GMT",
+    "Server",
+    "Tengine",
+    "Set-Cookie",
+    "brw=brwHislGvzT3Ws3Yf; path=/; expires=Fri, 24 Jun 2022 12:24:32 GMT; domain=.airtable.com; samesite=none; secure",
+    "Strict-Transport-Security",
+    "max-age=31536000; includeSubDomains; preload",
+    "Vary",
+    "Accept-Encoding",
+    "X-Content-Type-Options",
+    "nosniff",
+    "X-Frame-Options",
+    "DENY",
+    "Content-Length",
+    "233",
+    "Connection",
+    "Close",
+];
+
+nock("https://api.airtable.com:443", { encodedQueryParams: true })
+    .persist()
+    .get("/v0/appKYl1H4k9g73sBT/posts")
+    .query((query) => {
+        if (query.pageSize !== "100") return false;
+        if (query.filterByFormula === undefined) return false;
+
+        return true;
+    })
+    .reply(
+        200,
+        function () {
+            const parsed = new url.URL(this.req.path, "http://example.com");
+            const query = parsed.searchParams.get("filterByFormula");
+
+            return JSON.stringify({
+                offset: 0,
+                records: [
+                    {
+                        fields: {
+                            query,
+                        },
+                    },
+                ],
+            });
+        },
+        commonHeaders,
+    );
 
 nock("https://api.airtable.com:443", { encodedQueryParams: true })
     .get("/v0/appKYl1H4k9g73sBT/posts")

--- a/packages/airtable/test/getList/index.spec.ts
+++ b/packages/airtable/test/getList/index.spec.ts
@@ -196,7 +196,7 @@ describe("getList", () => {
 
     it("correct contains filter", async () => {
         const filter = {
-            operator: "contains",
+            operator: "containss",
             field: "title",
             value: "Hello",
         } as const;
@@ -216,7 +216,7 @@ describe("getList", () => {
 
     it("correct not contains filter", async () => {
         const filter = {
-            operator: "ncontains",
+            operator: "ncontainss",
             field: "title",
             value: "Hello",
         } as const;
@@ -236,9 +236,9 @@ describe("getList", () => {
 
     it("correct case-insensitive contains filter", async () => {
         const filter = {
-            operator: "containss",
+            operator: "contains",
             field: "title",
-            value: "hello",
+            value: "Hello",
         } as const;
 
         const response = await dataProvider(
@@ -252,15 +252,15 @@ describe("getList", () => {
         expect(response.total).toBe(1);
         // must find lower-cased string in lower-cased {field} - lower-casing both values makes it case-insensitive
         expect(response.data[0]["query"]).toBe(
-            'AND(FIND(LOWER("hello"),LOWER({title}))!=0)',
+            'AND(FIND(LOWER("Hello"),LOWER({title}))!=0)',
         );
     });
 
     it("correct case-insensitive not contains filter", async () => {
         const filter = {
-            operator: "ncontainss",
+            operator: "ncontains",
             field: "title",
-            value: "hello",
+            value: "Hello",
         } as const;
 
         const response = await dataProvider(
@@ -274,7 +274,7 @@ describe("getList", () => {
         expect(response.total).toBe(1);
         // must not find lower-cased string in lower-cased {field} - lower-casing both values makes it case-insensitive
         expect(response.data[0]["query"]).toBe(
-            'AND(FIND(LOWER("hello"),LOWER({title}))=0)',
+            'AND(FIND(LOWER("Hello"),LOWER({title}))=0)',
         );
     });
 

--- a/packages/airtable/test/getList/index.spec.ts
+++ b/packages/airtable/test/getList/index.spec.ts
@@ -33,4 +33,288 @@ describe("getList", () => {
         expect(response.data[0]["title"]).toBe("Hello World!");
         expect(response.total).toBe(2);
     });
+
+    it("correct equals filter for strings", async () => {
+        const filter = {
+            operator: "eq",
+            field: "title",
+            value: "Hello World!",
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // {field} must equal exactly string
+        expect(response.data[0]["query"]).toBe('AND({title}="Hello World!")');
+    });
+
+    it("correct equals filter for numbers", async () => {
+        const filter = {
+            operator: "eq",
+            field: "age",
+            value: 100,
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // {field} must equal exactly number
+        expect(response.data[0]["query"]).toBe("AND({age}=100)");
+    });
+
+    it("correct not equals filter for strings", async () => {
+        const filter = {
+            operator: "ne",
+            field: "title",
+            value: "Hello World!",
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // {field} must not equal exactly string
+        expect(response.data[0]["query"]).toBe('AND({title}!="Hello World!")');
+    });
+
+    it("correct not equals filter for numbers", async () => {
+        const filter = {
+            operator: "ne",
+            field: "age",
+            value: 100,
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // {field} must not equal exactly number
+        expect(response.data[0]["query"]).toBe("AND({age}!=100)");
+    });
+
+    it("correct less than filter", async () => {
+        const filter = {
+            operator: "lt",
+            field: "age",
+            value: 10,
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // {field} must be less than value (as number)
+        expect(response.data[0]["query"]).toBe("AND({age}<10)");
+    });
+
+    it("correct less than or equal filter", async () => {
+        const filter = {
+            operator: "lte",
+            field: "age",
+            value: 10,
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // {field} must be less than or equal value (as number)
+        expect(response.data[0]["query"]).toBe("AND({age}<=10)");
+    });
+
+    it("correct greater than filter", async () => {
+        const filter = {
+            operator: "gt",
+            field: "age",
+            value: 10,
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // {field} must be greater than value (as number)
+        expect(response.data[0]["query"]).toBe("AND({age}>10)");
+    });
+
+    it("correct greater than or equal filter", async () => {
+        const filter = {
+            operator: "gte",
+            field: "age",
+            value: 10,
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // {field} must be greater than or equal value (as number)
+        expect(response.data[0]["query"]).toBe("AND({age}>=10)");
+    });
+
+    it("correct contains filter", async () => {
+        const filter = {
+            operator: "contains",
+            field: "title",
+            value: "Hello",
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // must find string in {field} - FIND returns non-zero value
+        expect(response.data[0]["query"]).toBe('AND(FIND("Hello",{title})!=0)');
+    });
+
+    it("correct not contains filter", async () => {
+        const filter = {
+            operator: "ncontains",
+            field: "title",
+            value: "Hello",
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // must not find string in {field} - FIND returns zero
+        expect(response.data[0]["query"]).toBe('AND(FIND("Hello",{title})=0)');
+    });
+
+    it("correct case-insensitive contains filter", async () => {
+        const filter = {
+            operator: "containss",
+            field: "title",
+            value: "hello",
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // must find lower-cased string in lower-cased {field} - lower-casing both values makes it case-insensitive
+        expect(response.data[0]["query"]).toBe(
+            'AND(FIND(LOWER("hello"),LOWER({title}))!=0)',
+        );
+    });
+
+    it("correct case-insensitive not contains filter", async () => {
+        const filter = {
+            operator: "ncontainss",
+            field: "title",
+            value: "hello",
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // must not find lower-cased string in lower-cased {field} - lower-casing both values makes it case-insensitive
+        expect(response.data[0]["query"]).toBe(
+            'AND(FIND(LOWER("hello"),LOWER({title}))=0)',
+        );
+    });
+
+    it("correct truthy null filter", async () => {
+        const filter = {
+            operator: "null",
+            field: "title",
+            value: true,
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // {field} must be null (blank)
+        expect(response.data[0]["query"]).toBe("AND({title}=BLANK())");
+    });
+
+    it("correct falsy null filter", async () => {
+        const filter = {
+            operator: "null",
+            field: "title",
+            value: false,
+        } as const;
+
+        const response = await dataProvider(
+            "keywoytODSr6xAqfg",
+            "appKYl1H4k9g73sBT",
+        ).getList({
+            resource: "posts",
+            filters: [filter],
+        });
+
+        expect(response.total).toBe(1);
+        // {field} must not be null (blank)
+        expect(response.data[0]["query"]).toBe("AND({title}!=BLANK())");
+    });
 });


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:
Adds support for filters in Airtable by using Airtable's `filterByFormula` feature.

**Note**: I was not sure how the `null` filter works from the [documentation](https://refine.dev/docs/api-references/interfaceReferences/#crudfilters) (I assumed value is `false` for `field is not null` and `true` for `field is null`). 

Explain the **details** for making this change. What existing problem does the pull request solve?
This provides feature parity with other data providers by making simple filtering in a table possible. 

Some things that could still be added: 
- Support for array lookups (Airtable filters don't understand arrays so this requires matching on the string Airtable generates (comma separated list)

**Test plan (required)**
Tried on the Airtable example app. Tests are part of the PR - they check whether the filter is correctly translated into a syntax Airtable can understand.

Resolves #1317 