### PR TITLE
Change flag for controlling useTable's loading property to isFetched

### DIFF
--- a/packages/core/src/hooks/table/useTable/useTable.ts
+++ b/packages/core/src/hooks/table/useTable/useTable.ts
@@ -193,7 +193,7 @@ export const useTable = <
         liveParams,
         onLiveEvent,
     });
-    const { data, isFetching, isLoading } = queryResult;
+    const { data, isFetched, isLoading } = queryResult;
 
     const onChange = (
         pagination: TablePaginationConfig,
@@ -240,7 +240,7 @@ export const useTable = <
         tableProps: {
             ...tablePropsSunflower,
             dataSource: data?.data,
-            loading: liveMode === "auto" ? isLoading : isFetching,
+            loading: liveMode === "auto" ? isLoading : !isFetched,
             onChange,
             pagination: {
                 ...tablePropsSunflower.pagination,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:
Changes the `isFetching` flag to the inverted `isFetched` flag instead for setting the loading property. `loading` will thus be true when fetching new data, but set to false if the data is already cached (and react-query is merely re-fetching in the background to update the cache).

Explain the **details** for making this change. What existing problem does the pull request solve?
See above

**Test plan (required)**
1. Open App
2. Observe initial loading animation
3. Click on a new page (second page) - observe loading animation appear
4. Click on the previous page (first page) - no loading animation (cached result shown, react-query refetches in the background)
5. Click on another new page (third page)
6. Observe the loading animation appear again

<!-- Make sure tests pass. -->

Resolves #1321 