### PR TITLE
WIP: Add a new method to useTable for changing the filter operator dynamic…

### DIFF
--- a/packages/core/src/hooks/table/useTable/useTable.ts
+++ b/packages/core/src/hooks/table/useTable/useTable.ts
@@ -30,6 +30,7 @@ import {
     BaseRecord,
     CrudFilters,
     CrudSorting,
+    CrudOperators,
     GetListResponse,
     SuccessErrorNotification,
     HttpError,
@@ -60,6 +61,10 @@ export type useTableReturnType<
     tableQueryResult: QueryObserverResult<GetListResponse<TData>>;
     sorter?: CrudSorting;
     filters?: CrudFilters;
+    changeFilterOperator: (
+        field: keyof TData,
+        newOperator: CrudOperators,
+    ) => void;
 };
 
 /**
@@ -232,6 +237,21 @@ export const useTable = <
         }
     };
 
+    const changeFilterOperator = (
+        field: keyof TData,
+        newOperator: CrudOperators,
+    ) => {
+        setFilters((currentFilters) => {
+            return currentFilters.map((filter) => {
+                if (filter.field === field) {
+                    return { ...filter, operator: newOperator };
+                }
+
+                return filter;
+            });
+        });
+    };
+
     return {
         searchFormProps: {
             ...form,
@@ -253,5 +273,6 @@ export const useTable = <
         tableQueryResult: queryResult,
         sorter,
         filters,
+        changeFilterOperator,
     };
 };


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:
This is a prototype of what a simplistic solution to #1373 could look like

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **details** for making this change. What existing problem does the pull request solve?
This allows users to dynamically change the filter operator - for example a checkbox added inside of `<Table.Column filterDropdown={...} />` could invert the operator from equals (`eq`) to not equal (`ne`), or it could trigger partial matching `contains`/`ncontains` instead of `eq`.

**Test plan (required)**
1. Use the `changeFilterOperator` helper to modify an operator for an existing filter dynamically
2. Observe the operator changing and the data on the page updating

Related to #1373 