### PR TITLE
Docs: Fix appwrite docs

### DIFF
--- a/documentation/versioned_docs/version-2.xx.xx/guides-and-concepts/data-provider/appwrite.md
+++ b/documentation/versioned_docs/version-2.xx.xx/guides-and-concepts/data-provider/appwrite.md
@@ -616,8 +616,8 @@ If you want to restrict permissions and only allow specific users, you need to s
 ```tsx
 const { formProps, saveButtonProps } = useForm<IPost>({
     metaData: {
-        writeAccess: ["User ID, Team ID, or Role"],
-        readAccess: ["User ID, Team ID, or Role"] 
+        writePermissions: ["User ID, Team ID, or Role"],
+        readPermissions: ["User ID, Team ID, or Role"] 
     }
 });
 ```


### PR DESCRIPTION
In the appwrite implementation, it uses `writePermissions` and `readPermissions` instead of `writeAccess` and `readAccess`:

https://github.com/pankod/refine/blob/master/packages/appwrite/src/index.ts#L141