### PR TITLE
Fix strapi-graphql useUpdate mutation

### DIFF
--- a/examples/dataProvider/strapi-graphql/src/App.tsx
+++ b/examples/dataProvider/strapi-graphql/src/App.tsx
@@ -115,6 +115,7 @@ const App: React.FC = () => {
                     create: PostCreate,
                     edit: PostEdit,
                     show: PostShow,
+                    canDelete: true,
                 },
             ]}
         />

--- a/examples/dataProvider/strapi-graphql/src/pages/posts/edit.tsx
+++ b/examples/dataProvider/strapi-graphql/src/pages/posts/edit.tsx
@@ -27,7 +27,6 @@ export const PostEdit: React.FC<IResourceComponentsProps> = () => {
         IPost
     >({
         metaData: {
-            operation: "post",
             fields: [
                 "id",
                 "title",

--- a/packages/strapi-graphql/src/index.ts
+++ b/packages/strapi-graphql/src/index.ts
@@ -181,7 +181,7 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
                 fields: [
                     {
                         operation: singularResource,
-                        fields: ["id"],
+                        fields: metaData?.fields ?? ["id"],
                         variables: {},
                     },
                 ],
@@ -212,7 +212,7 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
                         fields: [
                             {
                                 operation: singularResource,
-                                fields: ["id"],
+                                fields: metaData?.fields ?? ["id"],
                                 variables: {},
                             },
                         ],

--- a/packages/strapi-graphql/src/index.ts
+++ b/packages/strapi-graphql/src/index.ts
@@ -178,7 +178,7 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
                         type: `${camelUpdateName}Input`,
                     },
                 },
-                fields: metaData?.fields ?? [
+                fields: [
                     {
                         operation: singularResource,
                         fields: ["id"],
@@ -209,7 +209,7 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
                                 type: `${camelUpdateName}Input`,
                             },
                         },
-                        fields: metaData?.fields ?? [
+                        fields: [
                             {
                                 operation: singularResource,
                                 fields: ["id"],

--- a/packages/strapi-graphql/test/gqlClient.ts
+++ b/packages/strapi-graphql/test/gqlClient.ts
@@ -6,7 +6,7 @@ const client = new GraphQLClient(API_URL);
 
 client.setHeader(
     "Authorization",
-    "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjMxNzk1ODUyLCJleHAiOjE2MzQzODc4NTJ9.d7-y7lmdWv_duYJ7kEvupXnu6k9N7zWmX4UDBrTaT2I",
+    "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjQwODU2NzUzLCJleHAiOjE2NDM0NDg3NTN9.8vzOs3CbB--_O7DnmzCVeSimCWZKw6rXYrA4bNGQC7E",
 );
 
 export default client;

--- a/packages/strapi-graphql/test/update/index.mock.ts
+++ b/packages/strapi-graphql/test/update/index.mock.ts
@@ -5,7 +5,7 @@ nock("https://api.strapi.refine.dev:443", { encodedQueryParams: true })
         query: "mutation ($input: updatePostInput) {\n  updatePost (input: $input) {\n    post  { id, title, content, category { id } }\n  }\n}",
         variables: {
             input: {
-                where: { id: "21" },
+                where: { id: "150" },
                 data: {
                     title: "updated-foo",
                     content: "updated-bar",
@@ -20,7 +20,7 @@ nock("https://api.strapi.refine.dev:443", { encodedQueryParams: true })
             data: {
                 updatePost: {
                     post: {
-                        id: "21",
+                        id: "150",
                         title: "updated-foo",
                         content: "updated-bar",
                         category: { id: "2" },
@@ -32,11 +32,11 @@ nock("https://api.strapi.refine.dev:443", { encodedQueryParams: true })
             "Server",
             "nginx/1.17.10",
             "Date",
-            "Fri, 17 Sep 2021 08:18:44 GMT",
+            "Thu, 30 Dec 2021 11:49:05 GMT",
             "Content-Type",
             "application/json",
             "Content-Length",
-            "113",
+            "114",
             "Connection",
             "close",
             "Vary",
@@ -48,7 +48,7 @@ nock("https://api.strapi.refine.dev:443", { encodedQueryParams: true })
             "X-Powered-By",
             "Strapi <strapi.io>",
             "X-Response-Time",
-            "157ms",
+            "74ms",
         ],
     );
 

--- a/packages/strapi-graphql/test/update/index.spec.ts
+++ b/packages/strapi-graphql/test/update/index.spec.ts
@@ -6,25 +6,14 @@ describe("create", () => {
     it("correct response with metaData", async () => {
         const { data } = await dataProvider(client).update({
             resource: "posts",
-            id: "21",
+            id: "150",
             variables: {
                 title: "updated-foo",
                 content: "updated-bar",
                 category: "2",
             },
             metaData: {
-                fields: [
-                    {
-                        operation: "post",
-                        fields: [
-                            "id",
-                            "title",
-                            "content",
-                            { category: ["id"] },
-                        ],
-                        variables: {},
-                    },
-                ],
+                fields: ["id", "title", "content", { category: ["id"] }],
             },
         });
 

--- a/packages/strapi-graphql/test/updateMany/index.spec.ts
+++ b/packages/strapi-graphql/test/updateMany/index.spec.ts
@@ -14,18 +14,7 @@ describe("updateMany", () => {
             },
 
             metaData: {
-                fields: [
-                    {
-                        operation: "post",
-                        fields: [
-                            "id",
-                            "title",
-                            "content",
-                            { category: ["id"] },
-                        ],
-                        variables: {},
-                    },
-                ],
+                fields: ["id", "title", "content", { category: ["id"] }],
             },
         });
 


### PR DESCRIPTION
Hey, I'm client! Test me! 'MASTER'
[Link to FIX-STRAPI-GRAPHQL-UPDATE-MUTATION](https://fix-str-client.refine.pankod.com)

Test me! 'MASTER'
[Link to FIX-STRAPI-GRAPHQL-UPDATE-MUTATION](https://fix-str-refine.pankod.com)

Strapi only returns the `id` field when updating. `useEditForm` was throwing an error as it was sent all fields to the `useUpdate` mutation.

**Closing issues**

- #1396 