### PR TITLE
fix buttons resourceName prop issue

### DIFF
--- a/packages/core/src/components/buttons/clone/index.tsx
+++ b/packages/core/src/components/buttons/clone/index.tsx
@@ -51,7 +51,7 @@ export const CloneButton: FC<CloneButtonProps> = ({
     const id = recordItemId ?? idFromRoute;
 
     const onButtonClick = () => {
-        clone(routeResourceName, id);
+        clone(resourceName, id);
     };
 
     const { data } = useCan({

--- a/packages/core/src/components/buttons/create/index.tsx
+++ b/packages/core/src/components/buttons/create/index.tsx
@@ -45,7 +45,7 @@ export const CreateButton: FC<CreateButtonProps> = ({
 
     const resourceName = propResourceName ?? resource.name;
 
-    const onButtonClick = () => create(routeResourceName, "push");
+    const onButtonClick = () => create(resourceName, "push");
 
     const { data } = useCan({
         resource: resourceName,

--- a/packages/core/src/components/buttons/edit/index.tsx
+++ b/packages/core/src/components/buttons/edit/index.tsx
@@ -72,7 +72,7 @@ export const EditButton: FC<EditButtonProps> = ({
     return (
         <Button
             onClick={(): void => {
-                edit(routeResourceName, id);
+                edit(resourceName, id);
             }}
             icon={<EditOutlined />}
             disabled={data?.can === false}

--- a/packages/core/src/components/buttons/list/index.tsx
+++ b/packages/core/src/components/buttons/list/index.tsx
@@ -65,7 +65,7 @@ export const ListButton: FC<ListButtonProps> = ({
 
     return (
         <Button
-            onClick={(): void => list(routeResourceName, "push")}
+            onClick={(): void => list(resourceName, "push")}
             icon={<BarsOutlined />}
             disabled={data?.can === false}
             title={createButtonDisabledTitle()}

--- a/packages/core/src/components/buttons/show/index.tsx
+++ b/packages/core/src/components/buttons/show/index.tsx
@@ -71,7 +71,7 @@ export const ShowButton: FC<ShowButtonProps> = ({
 
     return (
         <Button
-            onClick={(): void => show(routeResourceName, id)}
+            onClick={(): void => show(resourceName, id)}
             icon={<EyeOutlined />}
             disabled={data?.can === false}
             title={createButtonDisabledTitle()}

--- a/packages/core/src/hooks/resource/useResourceWithRoute/index.ts
+++ b/packages/core/src/hooks/resource/useResourceWithRoute/index.ts
@@ -10,7 +10,13 @@ export const useResourceWithRoute = (): ((route: string) => IResourceItem) => {
             const resource = resources.find((p) => p.route === route);
 
             if (!resource) {
-                return { name: route } as IResourceItem;
+                const resourceWithName = resources.find(
+                    (p) => p.name === route,
+                );
+                return (
+                    resourceWithName ??
+                    ({ name: route, route: route } as IResourceItem)
+                );
             }
             return resource;
         },


### PR DESCRIPTION
Hey, I'm client! Test me! 'MASTER'
[Link to FIX-BUTTONS-RESOURCE-NAME-PROP](https://fix-but-client.refine.pankod.com)

Button's `resourceName` prop was ignored. Navigation was broken when using a custom path in resources. I  updated the `useNavigation` hook for that too.

**Closing issues**

- #1387 
- #1400 
