### PR TITLE
fix useMenu selected key issue

### DIFF
--- a/packages/core/src/hooks/resource/useMenu/index.tsx
+++ b/packages/core/src/hooks/resource/useMenu/index.tsx
@@ -29,14 +29,14 @@ export const useMenu: () => useMenuReturnType = () => {
 
     const { hasDashboard } = useContext<IRefineContext>(RefineContext);
 
-    let selectedResource = resources.find((el) =>
-        location?.pathname?.startsWith(`/${el.route}`),
+    let selectedResource = resources.find(
+        (el) => location?.pathname === `/${el.route}`,
     );
 
     // for no ssr
     if (!selectedResource) {
-        selectedResource = resources.find((el) =>
-            params?.resource?.startsWith(el.route as string),
+        selectedResource = resources.find(
+            (el) => params?.resource === (el.route as string),
         );
     }
 
@@ -46,7 +46,7 @@ export const useMenu: () => useMenuReturnType = () => {
     } else if (location.pathname === "/") {
         selectedKey = "/";
     } else {
-        selectedKey = "notfound";
+        selectedKey = location?.pathname;
     }
 
     const menuItems: IMenuItem[] = React.useMemo(


### PR DESCRIPTION
Test me! 'MASTER'
[Link to FIX-USE-MENU-SELECTED-KEY](https://fix-use-refine.pankod.com)

Please provide enough information so that others can review your pull request:

The `useMenu` hook was returning the wrong `selectedKey` if I defined multiple resources with the same resource name.

Explain the **details** for making this change. What existing problem does the pull request solve?

Checking as strict instead of checking with startsWith

**Closing issues**

- #1432 
- #1283 