### PR TITLE
Fix useTable returning FormInstance as formProps

### DIFF
--- a/packages/core/src/hooks/table/useTable/useTable.ts
+++ b/packages/core/src/hooks/table/useTable/useTable.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { Grid } from "antd";
-import { useFormTable } from "sunflower-antd";
+import { useFormTable, useForm as useFormSF } from "sunflower-antd";
+
 import { TablePaginationConfig, TableProps } from "antd/lib/table";
 import { FormProps } from "antd/lib/form";
 import { QueryObserverResult, UseQueryOptions } from "react-query";
@@ -106,6 +107,9 @@ export const useTable = <
     const { syncWithLocation: syncWithLocationContext } = useSyncWithLocation();
 
     const [form] = useForm<TSearchVariables>();
+    const formSF = useFormSF<any, TSearchVariables>({
+        form: form,
+    });
 
     const syncWithLocation = syncWithLocationProp ?? syncWithLocationContext;
 
@@ -241,7 +245,7 @@ export const useTable = <
 
     return {
         searchFormProps: {
-            ...form,
+            ...formSF,
             onFinish,
         },
         tableProps: {


### PR DESCRIPTION
Test me! 'MASTER'
[Link to FIX-USETABLE-FORM-RETURN-TYPE](https://fix-use-refine.pankod.com)

Please provide enough information so that others can review your pull request:

`useTable` was returning `FormInstance` as formProps. Actually `FormProps` should have returned.

**Closing issues**

1. #1436 