### PR TITLE
encode & decode id params

### DIFF
--- a/packages/core/src/components/buttons/clone/index.tsx
+++ b/packages/core/src/components/buttons/clone/index.tsx
@@ -48,7 +48,7 @@ export const CloneButton: FC<CloneButtonProps> = ({
 
     const resourceName = propResourceName ?? resource.name;
 
-    const id = recordItemId ?? idFromRoute;
+    const id = recordItemId ?? decodeURIComponent(idFromRoute);
 
     const onButtonClick = () => {
         clone(resourceName, id);

--- a/packages/core/src/components/buttons/delete/index.tsx
+++ b/packages/core/src/components/buttons/delete/index.tsx
@@ -66,7 +66,7 @@ export const DeleteButton: FC<DeleteButtonProps> = ({
 
     const { mutate, isLoading, variables } = useDelete();
 
-    const id = recordItemId ?? idFromRoute;
+    const id = recordItemId ?? decodeURIComponent(idFromRoute);
 
     const { data } = useCan({
         resource: resource.name,

--- a/packages/core/src/components/buttons/edit/index.tsx
+++ b/packages/core/src/components/buttons/edit/index.tsx
@@ -48,7 +48,7 @@ export const EditButton: FC<EditButtonProps> = ({
 
     const { edit } = useNavigation();
 
-    const id = recordItemId ?? idFromRoute;
+    const id = recordItemId ?? decodeURIComponent(idFromRoute);
 
     const { data } = useCan({
         resource: resourceName,

--- a/packages/core/src/components/buttons/refresh/index.tsx
+++ b/packages/core/src/components/buttons/refresh/index.tsx
@@ -45,7 +45,7 @@ export const RefreshButton: FC<RefreshButtonProps> = ({
 
     const { refetch, isFetching } = useOne({
         resource: resource.name,
-        id: `${recordItemId ?? idFromRoute}`,
+        id: `${recordItemId ?? decodeURIComponent(idFromRoute)}`,
         queryOptions: {
             enabled: false,
         },

--- a/packages/core/src/components/buttons/show/index.tsx
+++ b/packages/core/src/components/buttons/show/index.tsx
@@ -48,7 +48,7 @@ export const ShowButton: FC<ShowButtonProps> = ({
 
     const resourceName = propResourceName ?? resource.name;
 
-    const id = recordItemId ?? idFromRoute;
+    const id = recordItemId ?? decodeURIComponent(idFromRoute);
 
     const { data } = useCan({
         resource: resourceName,

--- a/packages/core/src/components/crud/edit/index.tsx
+++ b/packages/core/src/components/crud/edit/index.tsx
@@ -102,7 +102,9 @@ export const Edit: React.FC<EditProps> = ({
                     )}
                     <RefreshButton
                         resourceName={resource.name}
-                        recordItemId={recordItemId ?? idFromRoute}
+                        recordItemId={
+                            recordItemId ?? encodeURIComponent(idFromRoute)
+                        }
                     />
                 </Space>
             }

--- a/packages/core/src/components/crud/show/index.tsx
+++ b/packages/core/src/components/crud/show/index.tsx
@@ -63,6 +63,8 @@ export const Show: React.FC<ShowProps> = ({
     const isDeleteButtonVisible = canDelete ?? resource.canDelete;
     const isEditButtonVisible = canEdit ?? resource.canEdit;
 
+    const id = recordItemId ?? encodeURIComponent(idFromRoute);
+
     return (
         <PageHeader
             ghost={false}
@@ -90,14 +92,14 @@ export const Show: React.FC<ShowProps> = ({
                             disabled={isLoading}
                             data-testid="show-edit-button"
                             resourceName={resource.name}
-                            recordItemId={recordItemId ?? idFromRoute}
+                            recordItemId={id}
                         />
                     )}
                     {isDeleteButtonVisible && (
                         <DeleteButton
                             resourceName={resource.name}
                             data-testid="show-delete-button"
-                            recordItemId={recordItemId ?? idFromRoute}
+                            recordItemId={id}
                             onSuccess={() =>
                                 list(resource.route ?? resource.name)
                             }
@@ -105,7 +107,7 @@ export const Show: React.FC<ShowProps> = ({
                     )}
                     <RefreshButton
                         resourceName={resource.name}
-                        recordItemId={recordItemId ?? idFromRoute}
+                        recordItemId={id}
                     />
                 </Space>
             }

--- a/packages/core/src/hooks/form/useCloneForm/useCloneForm.ts
+++ b/packages/core/src/hooks/form/useCloneForm/useCloneForm.ts
@@ -66,7 +66,7 @@ export const useCloneForm = <
     const { id: idFromRoute, action: actionFromRoute } =
         useParams<ResourceRouterParams>();
 
-    const id = props.cloneId ?? idFromRoute;
+    const id = props.cloneId ?? decodeURIComponent(idFromRoute);
 
     const action = props.action ?? actionFromRoute;
     // Check if clone process comes from useParams or modal

--- a/packages/core/src/hooks/form/useEditForm/useEditForm.ts
+++ b/packages/core/src/hooks/form/useEditForm/useEditForm.ts
@@ -110,7 +110,10 @@ export const useEditForm = <
 
     const { id: idFromRoute, action: actionFromRoute } =
         useParams<ResourceRouterParams>();
-    const [editId, setEditId] = React.useState<string | undefined>(idFromRoute);
+
+    const [editId, setEditId] = React.useState<string | undefined>(
+        idFromRoute !== undefined ? decodeURIComponent(idFromRoute) : undefined,
+    );
 
     const action = actionFromParams ?? actionFromRoute;
 

--- a/packages/core/src/hooks/navigation/index.spec.tsx
+++ b/packages/core/src/hooks/navigation/index.spec.tsx
@@ -40,36 +40,66 @@ describe("useNavigation Hook", () => {
         result.current.edit("posts", "1", "push");
 
         expect(mHistory.push).toBeCalledWith("/posts/edit/1");
+
+        mHistory.push.mockReset();
+        result.current.edit("posts", "foo/1", "push");
+
+        expect(mHistory.push).toBeCalledWith("/posts/edit/foo%2F1");
     });
 
     it("navigation edit with replace", async () => {
         result.current.edit("posts", "1", "replace");
 
         expect(mHistory.replace).toBeCalledWith("/posts/edit/1");
+
+        mHistory.replace.mockReset();
+        result.current.edit("posts", "foo/1", "replace");
+
+        expect(mHistory.replace).toBeCalledWith("/posts/edit/foo%2F1");
     });
 
     it("navigation clone with push", async () => {
         result.current.clone("posts", "1", "push");
 
         expect(mHistory.push).toBeCalledWith("/posts/clone/1");
+
+        mHistory.push.mockReset();
+        result.current.clone("posts", "foo/1", "push");
+
+        expect(mHistory.push).toBeCalledWith("/posts/clone/foo%2F1");
     });
 
     it("navigation clone with replace", async () => {
         result.current.clone("posts", "1", "replace");
 
         expect(mHistory.replace).toBeCalledWith("/posts/clone/1");
+
+        mHistory.replace.mockReset();
+        result.current.clone("posts", "foo/1", "replace");
+
+        expect(mHistory.replace).toBeCalledWith("/posts/clone/foo%2F1");
     });
 
     it("navigation show with push", async () => {
         result.current.show("posts", "1", "push");
 
         expect(mHistory.push).toBeCalledWith("/posts/show/1");
+
+        mHistory.push.mockReset();
+        result.current.show("posts", "foo/1", "push");
+
+        expect(mHistory.push).toBeCalledWith("/posts/show/foo%2F1");
     });
 
     it("navigation show with replace", async () => {
         result.current.show("posts", "1", "replace");
 
         expect(mHistory.replace).toBeCalledWith("/posts/show/1");
+
+        mHistory.replace.mockReset();
+        result.current.show("posts", "foo/1", "replace");
+
+        expect(mHistory.replace).toBeCalledWith("/posts/show/foo%2F1");
     });
 
     it("navigation list with push", async () => {

--- a/packages/core/src/hooks/navigation/index.ts
+++ b/packages/core/src/hooks/navigation/index.ts
@@ -25,9 +25,11 @@ export const useNavigation = () => {
     const edit = (resource: string, id: string, type: HistoryType = "push") => {
         const resourceName = resourceWithRoute(resource);
 
+        const encodedId = encodeURIComponent(id);
+
         type === "push"
-            ? history.push(`/${resourceName.route}/edit/${id}`)
-            : history.replace(`/${resourceName.route}/edit/${id}`);
+            ? history.push(`/${resourceName.route}/edit/${encodedId}`)
+            : history.replace(`/${resourceName.route}/edit/${encodedId}`);
     };
 
     const clone = (
@@ -37,17 +39,21 @@ export const useNavigation = () => {
     ) => {
         const resourceName = resourceWithRoute(resource);
 
+        const encodedId = encodeURIComponent(id);
+
         type === "push"
-            ? history.push(`/${resourceName.route}/clone/${id}`)
-            : history.replace(`/${resourceName.route}/clone/${id}`);
+            ? history.push(`/${resourceName.route}/clone/${encodedId}`)
+            : history.replace(`/${resourceName.route}/clone/${encodedId}`);
     };
 
     const show = (resource: string, id: string, type: HistoryType = "push") => {
         const resourceName = resourceWithRoute(resource);
 
+        const encodedId = encodeURIComponent(id);
+
         type === "push"
-            ? history.push(`/${resourceName.route}/show/${id}`)
-            : history.replace(`/${resourceName.route}/show/${id}`);
+            ? history.push(`/${resourceName.route}/show/${encodedId}`)
+            : history.replace(`/${resourceName.route}/show/${encodedId}`);
     };
 
     const list = (resource: string, type: HistoryType = "push") => {

--- a/packages/core/src/hooks/show/useShow.ts
+++ b/packages/core/src/hooks/show/useShow.ts
@@ -48,9 +48,10 @@ export const useShow = <TData extends BaseRecord = BaseRecord>({
         useParams<ResourceRouterParams>();
 
     const [showId, setShowId] = useState<string | undefined>(
-        id ?? idFromRoute !== undefined
-            ? decodeURIComponent(idFromRoute)
-            : undefined,
+        id ??
+            (idFromRoute !== undefined
+                ? decodeURIComponent(idFromRoute)
+                : undefined),
     );
 
     const resourceWithRoute = useResourceWithRoute();

--- a/packages/core/src/hooks/show/useShow.ts
+++ b/packages/core/src/hooks/show/useShow.ts
@@ -47,7 +47,11 @@ export const useShow = <TData extends BaseRecord = BaseRecord>({
     const { resource: routeResourceName, id: idFromRoute } =
         useParams<ResourceRouterParams>();
 
-    const [showId, setShowId] = useState<string | undefined>(id ?? idFromRoute);
+    const [showId, setShowId] = useState<string | undefined>(
+        id ?? idFromRoute !== undefined
+            ? decodeURIComponent(idFromRoute)
+            : undefined,
+    );
 
     const resourceWithRoute = useResourceWithRoute();
 

--- a/packages/nextjs-router/src/nextRouteComponent.tsx
+++ b/packages/nextjs-router/src/nextRouteComponent.tsx
@@ -27,8 +27,10 @@ export const NextRouteComponent: React.FC<NextRouteComponentProps> = ({
     const {
         resource: routeResourceName,
         action,
-        id,
+        id: idFromRoute,
     } = useParams<ResourceRouterParams>();
+
+    const id = decodeURIComponent(idFromRoute);
 
     const { pathname } = useLocation();
     const { DashboardPage, catchAll, LoginPage } = useRefineContext();

--- a/packages/react-location/src/resourceComponent.tsx
+++ b/packages/react-location/src/resourceComponent.tsx
@@ -18,8 +18,10 @@ export const ResourceComponentWrapper: React.FC = () => {
     const {
         resource: routeResourceName,
         action,
-        id,
+        id: idFromRoute,
     } = useParams<ResourceRouterParams>();
+
+    const id = decodeURIComponent(idFromRoute);
 
     const resource = resources.find((res) => res.route === routeResourceName);
 

--- a/packages/react-router/src/routeProvider.tsx
+++ b/packages/react-router/src/routeProvider.tsx
@@ -77,7 +77,9 @@ const RouteProviderBase: React.FC = () => {
                     <CanAccess
                         resource={name}
                         action="create"
-                        params={{ id: props.match.params.id }}
+                        params={{
+                            id: decodeURIComponent(props.match.params.id),
+                        }}
                         fallback={catchAll ?? <ErrorComponent />}
                     >
                         <CreateComponent
@@ -100,7 +102,9 @@ const RouteProviderBase: React.FC = () => {
                     <CanAccess
                         resource={name}
                         action="edit"
-                        params={{ id: props.match.params.id }}
+                        params={{
+                            id: decodeURIComponent(props.match.params.id),
+                        }}
                         fallback={catchAll ?? <ErrorComponent />}
                     >
                         <EditComponent
@@ -123,7 +127,9 @@ const RouteProviderBase: React.FC = () => {
                     <CanAccess
                         resource={name}
                         action="show"
-                        params={{ id: props.match.params.id }}
+                        params={{
+                            id: decodeURIComponent(props.match.params.id),
+                        }}
                         fallback={catchAll ?? <ErrorComponent />}
                     >
                         <ShowComponent


### PR DESCRIPTION
Test me! 'MASTER'
[Link to ENCODE-DECODE-ID-PARAM](https://encode--refine.pankod.com)

Hey, I'm client! Test me! 'MASTER'
[Link to ENCODE-DECODE-ID-PARAM](https://encode--client.refine.pankod.com)

Please provide enough information so that others can review your pull request:

Now id parameters are used by encoding and decoding.

Explain the **details** for making this change. What existing problem does the pull request solve?

So lets say my record.style_code returns a value like ABC/2 then it'll redirect to /products/ABC/2 instead of something like /products/ABC%2F2

**Closing issues**

- #1467 

