### PR TITLE
version 3.xx.xx multi-tenancy strapi.md typo fix.

### DIFF
--- a/documentation/versioned_docs/version-3.xx.xx/guides-and-concepts/multi-tenancy/strapi.md
+++ b/documentation/versioned_docs/version-3.xx.xx/guides-and-concepts/multi-tenancy/strapi.md
@@ -268,48 +268,36 @@ type SelectProps = {
 };
 
 export const StoreSelect: React.FC<SelectProps> = ({ onSelect }) => {
-    import { useContext } from "react";
-    import { Select, useSelect } from "@pankod/refine";
+    //highlight-start
+    const [store, setStore] = useContext(StoreContext);
+    //highlight-end
 
-    import { StoreContext } from "context/store";
-    import { IStore } from "interfaces";
+    const { selectProps: storeSelectProps } = useSelect<IStore>({
+        resource: "stores",
+        optionLabel: "title",
+        optionValue: "id",
+    });
 
-    type SelectProps = {
-        onSelect: () => void;
+    //highlight-start
+    const handleChange = (selectedValue: string) => {
+        setStore(selectedValue);
     };
+    //highlight-end
 
-    export const StoreSelect: React.FC<SelectProps> = ({ onSelect }) => {
-        //highlight-start
-        const [store, setStore] = useContext(StoreContext);
-        //highlight-end
-
-        const { selectProps: storeSelectProps } = useSelect<IStore>({
-            resource: "stores",
-            optionLabel: "title",
-            optionValue: "id",
-        });
-
-        //highlight-start
-        const handleChange = (selectedValue: string) => {
-            setStore(selectedValue);
-        };
-        //highlight-end
-
-        return (
-            <Select
-                defaultValue={store}
-                style={{ width: 130 }}
-                onChange={handleChange}
-                onSelect={onSelect}
-            >
-                {storeSelectProps.options?.map(({ value, label }) => (
-                    <Select.Option key={value} value={value}>
-                        {label}
-                    </Select.Option>
-                ))}
-            </Select>
-        );
-    };
+    return (
+        <Select
+            defaultValue={store}
+            style={{ width: 130 }}
+            onChange={handleChange}
+            onSelect={onSelect}
+        >
+            {storeSelectProps.options?.map(({ value, label }) => (
+                <Select.Option key={value} value={value}>
+                    {label}
+                </Select.Option>
+            ))}
+        </Select>
+    );
 };
 ```
 


### PR DESCRIPTION
Example of a StrapiV4 readme had a typo. `StoreContext` was duplicated.