### PR TITLE
Fix syncWithLocation not working when using custom resource

### DIFF
--- a/packages/antd/src/hooks/list/useSimpleList/useSimpleList.ts
+++ b/packages/antd/src/hooks/list/useSimpleList/useSimpleList.ts
@@ -92,20 +92,15 @@ export const useSimpleList = <
 
     const { push } = useNavigation();
 
-    const { search } = useLocation();
+    const { search, pathname } = useLocation();
 
     const { syncWithLocation: syncWithLocationContext } = useSyncWithLocation();
-    let syncWithLocation = syncWithLocationProp ?? syncWithLocationContext;
+    const syncWithLocation = syncWithLocationProp ?? syncWithLocationContext;
 
     const [form] = useForm<TSearchVariables>();
 
     const resourceWithRoute = useResourceWithRoute();
     const resource = resourceWithRoute(resourceFromProp ?? routeResourceName);
-
-    // disable syncWithLocation for custom resource tables
-    if (resourceFromProp) {
-        syncWithLocation = false;
-    }
 
     let defaultPageSize = 10;
     let defaultCurrent = 1;
@@ -148,7 +143,7 @@ export const useSimpleList = <
                 filters,
             });
 
-            return push(`/${resource.route}?${stringifyParams}`);
+            return push(`${pathname}?${stringifyParams}`);
         }
     }, [syncWithLocation, current, pageSize, sorter, filters]);
 

--- a/packages/core/src/definitions/table/index.ts
+++ b/packages/core/src/definitions/table/index.ts
@@ -32,11 +32,13 @@ export const parseTableParams = (url: string) => {
     Object.keys(filters).map((item) => {
         const [field, operator] = item.split("__");
         const value = filters[item];
-        parsedFilters.push({
-            field,
-            operator: operator as CrudOperators,
-            value,
-        });
+        if (operator) {
+            parsedFilters.push({
+                field,
+                operator: operator as CrudOperators,
+                value,
+            });
+        }
     });
 
     return {

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -94,7 +94,7 @@ export const useTable = <
     const syncWithLocation = syncWithLocationProp ?? syncWithLocationContext;
 
     const { useLocation, useParams } = useRouterContext();
-    const { search } = useLocation();
+    const { search, pathname } = useLocation();
     const liveMode = useLiveMode(liveModeFromProp);
 
     let defaultCurrent = initialCurrent;
@@ -141,7 +141,7 @@ export const useTable = <
             });
 
             // Careful! This triggers render
-            return push(`/${resource.route}?${stringifyParams}`);
+            return push(`${pathname}?${stringifyParams}`);
         }
     }, [syncWithLocation, current, pageSize, sorter, filters]);
 

--- a/packages/nextjs-router/src/routerProvider.ts
+++ b/packages/nextjs-router/src/routerProvider.ts
@@ -19,12 +19,12 @@ export const RouterProvider: IRouterProvider = {
     },
     useLocation: () => {
         const router = useRouter();
-        const { pathname, query } = router;
+        const { query, asPath } = router;
 
         const queryParams = qs.stringify(query);
 
         return {
-            pathname,
+            pathname: asPath.split("?")[0],
             search: queryParams && `?${queryParams}`,
         };
     },


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Using 'syncWithLocation' when using custom `resource` was causing the wrong redirection. The active 'pathname' is now used.

Explain the **details** for making this change. What existing problem does the pull request solve?
- #1539

**Closing issues**

- #1539