### PR TITLE
remove unused dashboard property of LayoutWrapper component

### DIFF
--- a/documentation/docs/core/components/layout-wrapper.md
+++ b/documentation/docs/core/components/layout-wrapper.md
@@ -71,7 +71,6 @@ In this example, we hide the left sider only for this page. The rest should look
 
 | Property      | Description                                           | Type       | Default |
 | ------------- | ----------------------------------------------------- | ---------- | ------- |
-| dashboard     |                                                       | `boolean`  | \*      |
 | Layout        | Outer component that renders other components         | `React.FC` | \*      |
 | Sider         | [Custom sider to use][refine#sider]                   | `React.FC` | \*      |
 | Header        | [Custom header to use][refine#header]                 | `React.FC` | \*      |

--- a/examples/dataProvider/nhost/package.json
+++ b/examples/dataProvider/nhost/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@nhost/nhost-js": "^0.3.9",
-    "@nhost/react-apollo": "^2.1.4",
     "@nhost/react-auth": "^2.0.7",
     "@pankod/refine-antd": "^3.5.0",
     "@pankod/refine-core": "^3.5.0",

--- a/examples/dataProvider/nhost/src/App.tsx
+++ b/examples/dataProvider/nhost/src/App.tsx
@@ -8,7 +8,6 @@ import {
 import routerProvider from "@pankod/refine-react-router";
 import dataProvider from "@pankod/refine-nhost";
 import { NhostAuthProvider } from "@nhost/react-auth";
-import { NhostApolloProvider } from "@nhost/react-apollo";
 
 import "@pankod/refine-antd/dist/styles.min.css";
 
@@ -80,32 +79,30 @@ const authProvider: AuthProvider = {
 const App: React.FC = () => {
     return (
         <NhostAuthProvider nhost={nhost}>
-            <NhostApolloProvider nhost={nhost}>
-                <Refine
-                    routerProvider={routerProvider}
-                    dataProvider={dataProvider(nhost)}
-                    authProvider={authProvider}
-                    resources={[
-                        {
-                            name: "posts",
-                            list: PostList,
-                            create: PostCreate,
-                            edit: PostEdit,
-                            show: PostShow,
-                        },
-                        {
-                            name: "categories",
-                            list: CategoriesList,
-                            create: CategoriesCreate,
-                            edit: CategoriesEdit,
-                        },
-                    ]}
-                    notificationProvider={notificationProvider}
-                    Layout={Layout}
-                    LoginPage={LoginPage}
-                    catchAll={<ErrorComponent />}
-                />
-            </NhostApolloProvider>
+            <Refine
+                routerProvider={routerProvider}
+                dataProvider={dataProvider(nhost)}
+                authProvider={authProvider}
+                resources={[
+                    {
+                        name: "posts",
+                        list: PostList,
+                        create: PostCreate,
+                        edit: PostEdit,
+                        show: PostShow,
+                    },
+                    {
+                        name: "categories",
+                        list: CategoriesList,
+                        create: CategoriesCreate,
+                        edit: CategoriesEdit,
+                    },
+                ]}
+                notificationProvider={notificationProvider}
+                Layout={Layout}
+                LoginPage={LoginPage}
+                catchAll={<ErrorComponent />}
+            />
         </NhostAuthProvider>
     );
 };

--- a/packages/antd/src/components/layout/index.tsx
+++ b/packages/antd/src/components/layout/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Layout as AntLayout, Grid } from "antd";
-import { LayoutProps, useRefineContext } from "@pankod/refine-core";
+import { LayoutProps } from "@pankod/refine-core";
 
 import { Sider as DefaultSider } from "./sider";
 import { Header as DefaultHeader } from "./header";

--- a/packages/core/src/components/layoutWrapper/index.tsx
+++ b/packages/core/src/components/layoutWrapper/index.tsx
@@ -9,7 +9,6 @@ import {
 import { LayoutProps, TitleProps } from "../../interfaces";
 
 export interface LayoutWrapperProps {
-    dashboard?: boolean;
     Layout?: React.FC<LayoutProps>;
     Sider?: React.FC;
     Header?: React.FC;
@@ -27,7 +26,6 @@ export interface LayoutWrapperProps {
  */
 export const LayoutWrapper: React.FC<LayoutWrapperProps> = ({
     children,
-    dashboard,
     Layout: LayoutFromProps,
     Sider: SiderFromProps,
     Header: HeaderFromProps,
@@ -47,7 +45,6 @@ export const LayoutWrapper: React.FC<LayoutWrapperProps> = ({
             Footer={FooterFromProps ?? Footer}
             Title={TitleFromProps ?? Title}
             OffLayoutArea={OffLayoutAreaFromProps ?? OffLayoutArea}
-            dashboard={dashboard}
         >
             {children}
             <UnsavedPrompt />


### PR DESCRIPTION
Hey, I'm client! Test me! 'MASTER'
[Link to REMOVE-UNUSED-DASHBOARD-PROP](https://remove--client.refine.pankod.com)

Test me! 'MASTER'
[Link to REMOVE-UNUSED-DASHBOARD-PROP](https://remove--refine.pankod.com)

We've removed unnecessary `dashboard` property of `<LayoutWrapper />` component