### PR TITLE
Airtable data or filter

### DIFF
--- a/documentation/docs/core/interfaces.md
+++ b/documentation/docs/core/interfaces.md
@@ -53,7 +53,8 @@ title: Interface References
 | `"ncontainss"` | Doesn't contain, case sensitive |
 | `"between"`    | Between                         |
 | `"nbetween"`   | Doesn't between                 |
-| `"null"`       | Is null or not null             |
+| `"null"`       | Is null                         |
+| `"nnull"`      | Is not null                     |
 
 ## CrudSorting
 

--- a/packages/airtable/src/index.ts
+++ b/packages/airtable/src/index.ts
@@ -72,10 +72,11 @@ const generateLogicalFilter = (filter: LogicalFilter): Formula => {
     }
 
     if (operator === "null") {
-        if (typeof value !== "boolean")
-            throw new Error("Value must be a boolean for the null operator");
+        return ["=", { field }, ["BLANK"]];
+    }
 
-        return [value ? "=" : "!=", { field }, ["BLANK"]];
+    if (operator === "nnull") {
+        return ["!=", { field }, ["BLANK"]];
     }
 
     throw Error(

--- a/packages/airtable/test/getList/index.spec.ts
+++ b/packages/airtable/test/getList/index.spec.ts
@@ -317,4 +317,47 @@ describe("getList", () => {
         // {field} must not be null (blank)
         expect(response.data[0]["query"]).toBe("AND({title}!=BLANK())");
     });
+
+    it.each(["between", "nbetween"] as const)(
+        "fails for %s filter",
+        async (operator) => {
+            const filter = {
+                operator,
+                field: "age",
+                value: [10, 15],
+            } as const;
+
+            await expect(() => {
+                return dataProvider(
+                    "keywoytODSr6xAqfg",
+                    "appKYl1H4k9g73sBT",
+                ).getList({
+                    resource: "posts",
+                    filters: [filter],
+                });
+            }).rejects.toThrow(
+                `Operator ${operator} is not supported for the Airtable data provider`,
+            );
+        },
+    );
+
+    it.each(["in", "nin"] as const)("fails for %s filter", async (operator) => {
+        const filter = {
+            operator,
+            field: "posts",
+            value: ["uuid-1", "uuid-2"],
+        } as const;
+
+        await expect(() => {
+            return dataProvider(
+                "keywoytODSr6xAqfg",
+                "appKYl1H4k9g73sBT",
+            ).getList({
+                resource: "posts",
+                filters: [filter],
+            });
+        }).rejects.toThrow(
+            `Operator ${operator} is not supported for the Airtable data provider`,
+        );
+    });
 });

--- a/packages/airtable/test/getList/index.spec.ts
+++ b/packages/airtable/test/getList/index.spec.ts
@@ -282,7 +282,7 @@ describe("getList", () => {
         const filter = {
             operator: "null",
             field: "title",
-            value: true,
+            value: undefined,
         } as const;
 
         const response = await dataProvider(
@@ -300,9 +300,9 @@ describe("getList", () => {
 
     it("correct falsy null filter", async () => {
         const filter = {
-            operator: "null",
+            operator: "nnull",
             field: "title",
-            value: false,
+            value: undefined,
         } as const;
 
         const response = await dataProvider(


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:
Adds support for OR filter (https://github.com/pankod/refine/issues/1417) in the airtable data provider. Also fix the changed `null`/`nnull` handling and ammend its documentation in https://refine.dev/docs/core/interfaceReferences/#crudfilters

Explain the **details** for making this change. What existing problem does the pull request solve?
Complements https://github.com/pankod/refine/issues/1417

**Test plan (required)**
Tests available at `packages/airtable/test/getList/index.spec.ts`