### PR TITLE
Fix react-router-v6 not matched route warning

### DIFF
--- a/packages/react-router-v6/src/routeProvider.tsx
+++ b/packages/react-router-v6/src/routeProvider.tsx
@@ -147,7 +147,7 @@ export const RouteProvider = () => {
     if (isLoading) {
         return (
             <Routes>
-                <Route />
+                <Route path="*" element={null} />
             </Routes>
         );
     }


### PR DESCRIPTION
Test me! 'MASTER'
[Link to FIX-REACT-ROUTER-V6-NO-ROUTE-WARNING](https://fix-rea-refine.pankod.com)

Please provide enough information so that others can review your pull request:

It was because we returned an "empty route" during the authentication process.

**Closing issues**

- #1638 