### PR TITLE
Make OptionsProps generic

### DIFF
--- a/packages/core/src/contexts/resource/IResourceContext.ts
+++ b/packages/core/src/contexts/resource/IResourceContext.ts
@@ -3,11 +3,10 @@ import { ReactNode } from "react";
 export interface IResourceContext {
     resources: IResourceItem[];
 }
-export interface OptionsProps {
+type OptionsProps<TExtends = { [key: string]: any }> = TExtends & {
     label?: string;
     route?: string;
-    [key: string]: any;
-}
+};
 
 export interface ResourceProps extends IResourceComponents {
     name: string;
@@ -15,20 +14,23 @@ export interface ResourceProps extends IResourceComponents {
     icon?: ReactNode;
     options?: OptionsProps;
 }
-export interface IResourceComponentsProps<TCrudData = any> {
+export interface IResourceComponentsProps<
+    TCrudData = any,
+    TOptionsPropsExtends = { [key: string]: any },
+> {
     canCreate?: boolean;
     canEdit?: boolean;
     canDelete?: boolean;
     canShow?: boolean;
     name?: string;
     initialData?: TCrudData;
-    options?: OptionsProps;
+    options?: OptionsProps<TOptionsPropsExtends>;
 }
 export interface IResourceComponents {
-    list?: React.FunctionComponent<IResourceComponentsProps>;
-    create?: React.FunctionComponent<IResourceComponentsProps>;
-    edit?: React.FunctionComponent<IResourceComponentsProps>;
-    show?: React.FunctionComponent<IResourceComponentsProps>;
+    list?: React.FunctionComponent<IResourceComponentsProps<any, any>>;
+    create?: React.FunctionComponent<IResourceComponentsProps<any, any>>;
+    edit?: React.FunctionComponent<IResourceComponentsProps<any, any>>;
+    show?: React.FunctionComponent<IResourceComponentsProps<any, any>>;
 }
 
 export interface IResourceItem extends IResourceComponents {


### PR DESCRIPTION
This allows the user to add a type-definition to the `IResourceComponentsProps` for the `options` prop instead of defaulting to `any`.
Example usage:

```tsx
<Refine
    resources=[{
        name: "posts",
        options: {
            dataProviderName: "my-custom-dataprovider",
        }
    }]
    ...
/>
```
```ts
export const PostList: React.FC<IResourceComponentsProps<{ dataProviderName: string }>> = (props) => {
    const { tableProps, searchFormProps, filters, ...rest } = useTable<IPost>({
        dataProviderName: props.options?.dataProviderName
    });
    // ...
}
```

If no generic param is provided, it default to the previous `[key: string]: any` definition.