### PR TITLE
Fix react-router-v6 resource name match

### DIFF
--- a/packages/react-router-v6/src/routeProvider.tsx
+++ b/packages/react-router-v6/src/routeProvider.tsx
@@ -26,10 +26,7 @@ const ResourceComponent: React.FC = () => {
         id,
     } = useParams<ResourceRouterParams>();
 
-    const resource = resources.find(
-        (res) =>
-            res.name === routeResourceName || res.route === routeResourceName,
-    );
+    const resource = resources.find((res) => res.route === routeResourceName);
 
     if (resource) {
         const {


### PR DESCRIPTION
Hey, I'm client! Test me! 'MASTER'
[Link to FIX-REACT-ROUTER-V6-RESOURCE-MATCH](https://fix-rea-client.refine.pankod.com)

Please provide enough information so that others can review your pull request:

The router was looking by `name` and `route` when selecting the resource. Now we're just looking at the route.

<!-- Make sure tests pass. -->

**Closing issues**

- #1642 