### PR TITLE
fix wrong set id after mutation on useForm

### DIFF
--- a/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
+++ b/packages/antd/src/hooks/form/useDrawerForm/useDrawerForm.ts
@@ -9,6 +9,7 @@ import {
     HttpError,
     LiveModeProps,
     BaseRecord,
+    BaseKey,
 } from "@pankod/refine-core";
 
 import { useForm, UseFormProps, UseFormReturnType } from "../useForm";
@@ -35,7 +36,7 @@ export type UseDrawerFormReturnType<
     formProps: FormProps<TVariables> & {
         form: FormInstance<TVariables>;
     };
-    show: (id?: string) => void;
+    show: (id?: BaseKey) => void;
     close: () => void;
     drawerProps: DrawerProps;
     saveButtonProps: ButtonProps;
@@ -138,7 +139,7 @@ export const useDrawerForm = <
         setId?.(undefined);
     }, [warnWhen]);
 
-    const handleShow = useCallback((id?: string) => {
+    const handleShow = useCallback((id?: BaseKey) => {
         setId?.(id);
 
         setVisible(true);

--- a/packages/core/src/hooks/form/useForm.ts
+++ b/packages/core/src/hooks/form/useForm.ts
@@ -129,7 +129,6 @@ export const useForm = <
     // id state is needed to determine selected record in a context for example useModal
     const [id, setId] = React.useState<BaseKey | undefined>(defaultId);
 
-    console.log("id", id);
     const resourceName = resourceFromProps ?? resourceFromRoute;
     const action = actionFromProps ?? actionFromRoute ?? "create";
 

--- a/packages/core/src/hooks/form/useForm.ts
+++ b/packages/core/src/hooks/form/useForm.ts
@@ -24,6 +24,7 @@ import {
     MetaDataQuery,
     UpdateResponse,
     MutationMode,
+    BaseKey,
 } from "../../interfaces";
 import { UseUpdateReturnType } from "../data/useUpdate";
 import { UseCreateReturnType } from "../data/useCreate";
@@ -68,8 +69,8 @@ export type UseFormReturnType<
     TError extends HttpError = HttpError,
     TVariables = {},
 > = {
-    id?: string;
-    setId: Dispatch<SetStateAction<string | undefined>>;
+    id?: BaseKey;
+    setId: Dispatch<SetStateAction<BaseKey | undefined>>;
 
     queryResult?: QueryObserverResult<GetOneResponse<TData>>;
     mutationResult:
@@ -121,13 +122,14 @@ export const useForm = <
         id: idFromParams,
     } = useParams<ResourceRouterParams>();
 
-    // id state is needed to determine selected record in a context for example useModal
-    const [id, setId] = React.useState<string | undefined>(
+    const defaultId =
         !resourceFromProps || resourceFromProps === resourceFromRoute
             ? idFromParams
-            : undefined,
-    );
+            : undefined;
+    // id state is needed to determine selected record in a context for example useModal
+    const [id, setId] = React.useState<BaseKey | undefined>(defaultId);
 
+    console.log("id", id);
     const resourceName = resourceFromProps ?? resourceFromRoute;
     const action = actionFromProps ?? actionFromRoute ?? "create";
 
@@ -235,7 +237,7 @@ export const useForm = <
 
                         if (mutationMode === "pessimistic") {
                             // If it is in modal mode set it to undefined. Otherwise set it to current id from route.
-                            setId(idFromParams);
+                            setId(defaultId);
                             handleSubmitWithRedirect({
                                 redirect,
                                 resource,
@@ -254,7 +256,7 @@ export const useForm = <
 
         if (!(mutationMode === "pessimistic")) {
             // If it is in modal mode set it to undefined. Otherwise set it to current id from route.
-            setId(idFromParams);
+            setId(defaultId);
             handleSubmitWithRedirect({
                 redirect,
                 resource,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:
useForm was losing `id` value after successful mutation.

**Closing issues**

- #1646 