### PR TITLE
handle custom routes on CRUD componenets and buttons

### DIFF
--- a/documentation/docs/ui-frameworks/antd/components/buttons/clone.md
+++ b/documentation/docs/ui-frameworks/antd/components/buttons/clone.md
@@ -78,7 +78,7 @@ Clicking the button will trigger the `clone` method of [`useNavigation`](/core/h
 **`<CloneButton>`** component reads the id information from the route by default.
 :::
 
-### `resourceName`
+### `resourceNameOrRouteName`
 
 It is used to redirect the app to the `/clone` endpoint of the given resource name. By default, the app redirects to a URL with `/clone` defined by the name property of the resource object.
 
@@ -86,7 +86,7 @@ It is used to redirect the app to the `/clone` endpoint of the given resource na
 import { CloneButton } from "@pankod/refine-antd";
 
 export const MyCloneComponent = () => {
-    return <CloneButton resourceName="categories" recordItemId="2" />;
+    return <CloneButton resourceNameOrRouteName="categories" recordItemId="2" />;
 };
 ```
 
@@ -123,7 +123,8 @@ export const MyListComponent = () => {
 | Property                    | Description                                      | Type                                                                                                                                 | Default                                                            |
 | --------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
 | props                       | Ant Design button props                          | [`ButtonProps`](https://ant.design/components/button/#API) & `{ resourceName?: string; recordItemId?: BaseKey; hideText?: boolean; }` |                                                                    |
-| resourceName                | Determines which resource to use for redirection | `string`                                                                                                                             | Resource name that it reads from route                             |
+| resourceNameOrRouteName                                                                                   | Determines which resource to use for redirection | `string`                                                                                                      | Resource name that it reads from route                           |
+| <div className="required-block"><div>resourceName</div> <div className=" required">deprecated</div></div> | Determines which resource to use for redirection | `string`                                                                                                      | Resource name that it reads from route                           |
 | recordItemId                | Adds `id` to the end of the URL                  | [`BaseKey`](/core/interfaces.md#basekey)                                                                                                                             | Record id that it reads from route                                 |
 | hideText                    | Allows to hide button text                       | `boolean`                                                                                                                            | `false`                                                            |
 | ignoreAccessControlProvider | Skip access control                              | `boolean`                                                                                                                            | `false`                                                            |

--- a/documentation/docs/ui-frameworks/antd/components/buttons/create.md
+++ b/documentation/docs/ui-frameworks/antd/components/buttons/create.md
@@ -51,7 +51,7 @@ Will look like this:
 
 ## Properties
 
-### `resourceName`
+### `resourceNameOrRouteName`
 
 It is used to redirect the app to the `/create` endpoint of the given resource name. By default, the app redirects to a URL with `/create` defined by the name property of resource object.
 
@@ -59,7 +59,7 @@ It is used to redirect the app to the `/create` endpoint of the given resource n
 import { CreateButton } from "@pankod/refine-antd";
 
 export const MyCreateComponent = () => {
-    return <CreateButton resourceName="posts" />;
+    return <CreateButton resourceNameOrRouteName="posts" />;
 };
 ```
 
@@ -96,7 +96,8 @@ export const MyListComponent = () => {
 | Property                    | Description                                      | Type                                                                                                          | Default                                                         |
 | --------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
 | props                       | Ant Design button props                          | [`ButtonProps`](https://ant.design/components/button/#API) & `{ resourceName?: string; hideText?: boolean; }` |                                                                 |
-| resourceName                | Determines which resource to use for redirection | `string`                                                                                                      | Resource name that it reads from route                          |
+| resourceNameOrRouteName                                                                                   | Determines which resource to use for redirection | `string`                                                                                                      | Resource name that it reads from route                           |
+| <div className="required-block"><div>resourceName</div> <div className=" required">deprecated</div></div> | Determines which resource to use for redirection | `string`                                                                                                      | Resource name that it reads from route                           |
 | hideText                    | Allows to hide button text                       | `boolean`                                                                                                     | `false`                                                         |
 | ignoreAccessControlProvider | Skip access control                              | `boolean`                                                                                                     | `false`                                                         |
 | children                    | Sets the button text                             | `ReactNode`                                                                                                   | `"Create"`                                                      |

--- a/documentation/docs/ui-frameworks/antd/components/buttons/delete.md
+++ b/documentation/docs/ui-frameworks/antd/components/buttons/delete.md
@@ -92,13 +92,13 @@ Clicking the button will trigger the [`useDelete`](/core/hooks/data/useDelete.md
 
 ### `resourceName`
 
-`resourceName` allows us to manage which resource's record is going to be deleted.
+`resourceNameOrRouteName` allows us to manage which resource's record is going to be deleted.
 
 ```tsx 
 import { DeleteButton } from "@pankod/refine-antd";
 
 export const MyDeleteComponent = () => {
-    return <DeleteButton resourceName="categories" recordItemId="2" />;
+    return <DeleteButton resourceNameOrRouteName="categories" recordItemId="2" />;
 };
 ```
 
@@ -230,7 +230,8 @@ export const MyDeleteComponent = () => {
 | Property                    | Description                                                                                  | Type                                                                                                                        | Default                                                                              |
 | --------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | props                       | Ant Design button properties                                                                 | [`ButtonProps`](https://ant.design/components/button/#API) & [`DeleteButtonProps`](/core/interfaces.md#delete-button-props) |                                                                                      |
-| resourceName                | Determines which resource to use for deletion                                                | `string`                                                                                                                    | Resource name that it reads from route                                               |
+| resourceNameOrRouteName                                                                                   | Determines which resource to use for redirection | `string`                                                                                                      | Resource name that it reads from route                           |
+| <div className="required-block"><div>resourceName</div> <div className=" required">deprecated</div></div> | Determines which resource to use for redirection | `string`                                                                                                      | Resource name that it reads from route                           |
 | recordItemId                | Determines which id to use for deletion                                                      | [`BaseKey`](/core/interfaces.md#basekey)                                                                                                                  | Record id that it reads from route                                                   |
 | onSuccess                   | Called when [mutation](https://react-query.tanstack.com/reference/useMutation) is successful | `(value: DeleteOneResponse) => void`                                                                                        |                                                                                      |
 | mutationMode                | Determines when mutations are executed.                                                      | `"pessimistic"` \| `"optimistic"` \| `"undoable"`                                                                           |                                                                                      |

--- a/documentation/docs/ui-frameworks/antd/components/buttons/edit.md
+++ b/documentation/docs/ui-frameworks/antd/components/buttons/edit.md
@@ -77,15 +77,15 @@ Clicking the button will trigger the `edit` method of [`useNavigation`](/core/ho
 `<EditButton>` component reads the id information from the route by default.
 :::
 
-### `resourceName`
+### `resourceNameOrRouteName`
 
-Redirection endpoint(`resourceName/edit`) is defined by `resourceName` property. By default, `<EditButton>` uses `name` property of the resource object as an endpoint to redirect after clicking.
+Redirection endpoint(`resourceNameOrRouteName/edit`) is defined by `resourceNameOrRouteName` property. By default, `<EditButton>` uses `name` property of the resource object as an endpoint to redirect after clicking.
 
 ```tsx 
 import { EditButton } from "@pankod/refine-antd";
 
 export const MyEditComponent = () => {
-    return <EditButton resourceName="categories" recordItemId="2" />;
+    return <EditButton resourceNameOrRouteName="categories" recordItemId="2" />;
 };
 ```
 
@@ -119,13 +119,14 @@ export const MyListComponent = () => {
 
 ### Properties
 
-| Property                    | Description                                      | Type                                                                                                                                 | Default                                                          |
-| --------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| props                       | Ant Design button properties                     | [`ButtonProps`](https://ant.design/components/button/#API) & `{ resourceName?: string; recordItemId?: BaseKey; hideText?: boolean; }` |                                                                  |
-| resourceName                | Determines which resource to use for redirection | `string`                                                                                                                             | Resource name that it reads from route                           |
-| recordItemId                | Adds `id` to the end of the URL                  | [`BaseKey`](/core/interfaces.md#basekey)                                                                                                                             | Record id that it reads from route                               |
-| hideText                    | Allows to hide button text                       | `boolean`                                                                                                                            | `false`                                                          |
-| ignoreAccessControlProvider | Skip access control                              | `boolean`                                                                                                                            | `false`                                                          |
-| children                    | Sets the button text                             | `ReactNode`                                                                                                                          | `"Edit"`                                                         |
-| icon                        | Sets the icon component of button                | `ReactNode`                                                                                                                          | [`<EditOutlined />`](https://ant.design/components/icon/)        |
-| onClick                     | Sets the handler to handle click event           | `(event) => void`                                                                                                                    | Triggers navigation for redirection to the edit page of resource |
+| Property                                                                                                  | Description                                      | Type                                                                                                                                  | Default                                                          |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| props                                                                                                     | Ant Design button properties                     | [`ButtonProps`](https://ant.design/components/button/#API) & `{ resourceName?: string; recordItemId?: BaseKey; hideText?: boolean; }` |                                                                  |
+| resourceNameOrRouteName                                                                                   | Determines which resource to use for redirection | `string`                                                                                                                              | Resource name that it reads from route                           |
+| <div className="required-block"><div>resourceName</div> <div className=" required">deprecated</div></div> | Determines which resource to use for redirection | `string`                                                                                                                              | Resource name that it reads from route                           |
+| recordItemId                                                                                              | Adds `id` to the end of the URL                  | [`BaseKey`](/core/interfaces.md#basekey)                                                                                              | Record id that it reads from route                               |
+| hideText                                                                                                  | Allows to hide button text                       | `boolean`                                                                                                                             | `false`                                                          |
+| ignoreAccessControlProvider                                                                               | Skip access control                              | `boolean`                                                                                                                             | `false`                                                          |
+| children                                                                                                  | Sets the button text                             | `ReactNode`                                                                                                                           | `"Edit"`                                                         |
+| icon                                                                                                      | Sets the icon component of button                | `ReactNode`                                                                                                                           | [`<EditOutlined />`](https://ant.design/components/icon/)        |
+| onClick                                                                                                   | Sets the handler to handle click event           | `(event) => void`                                                                                                                     | Triggers navigation for redirection to the edit page of resource |

--- a/documentation/docs/ui-frameworks/antd/components/buttons/list.md
+++ b/documentation/docs/ui-frameworks/antd/components/buttons/list.md
@@ -61,15 +61,15 @@ The button text is defined automatically by **refine** based on _resource_ objec
 
 ## Properties
 
-### `resourceName`
+### `resourceNameOrRouteName`
 
-Redirection endpoint(`resourceName/list`) is defined by `resourceName` property. By default, `<ListButton>` uses `name` property of the resource object as the endpoint to redirect after clicking.
+Redirection endpoint(`resourceNameOrRouteName/list`) is defined by `resourceNameOrRouteName` property. By default, `<ListButton>` uses `name` property of the resource object as the endpoint to redirect after clicking.
 
 ```tsx 
 import { ListButton } from "@pankod/refine-antd";
 
 export const MyListComponent = () => {
-    return <ListButton resourceName="categories" />;
+    return <ListButton resourceNameOrRouteName="categories" />;
 };
 ```
 
@@ -103,12 +103,13 @@ export const MyListComponent = () => {
 
 ### Properties
 
-| Property                    | Description                                      | Type                                                                                                          | Default                                                          |
-| --------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| props                       | Ant Design button properties                     | [`ButtonProps`](https://ant.design/components/button/#API) & `{ resourceName?: string; hideText?: boolean; }` |                                                                  |
-| resourceName                | Determines which resource to use for redirection | `string`                                                                                                      | Resource name that it reads from route                           |
-| hideText                    | Allows to hide button text                       | `boolean`                                                                                                     | `false`                                                          |
-| ignoreAccessControlProvider | Skip access control                              | `boolean`                                                                                                     | `false`                                                          |
-| children                    | Sets the button text                             | `ReactNode`                                                                                                   | Humanized resource name that it reads from route                 |
-| icon                        | Sets the icon component of button                | `ReactNode`                                                                                                   | [`<BarsOutlined />`](https://ant.design/components/icon/)        |
-| onClick                     | Sets the handler to handle click event           | `(event) => void`                                                                                             | Triggers navigation for redirection to the list page of resource |
+| Property                                                                                                  | Description                                      | Type                                                                                                          | Default                                                          |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| props                                                                                                     | Ant Design button properties                     | [`ButtonProps`](https://ant.design/components/button/#API) & `{ resourceName?: string; hideText?: boolean; }` |                                                                  |
+| resourceNameOrRouteName                                                                                   | Determines which resource to use for redirection | `string`                                                                                                      | Resource name that it reads from route                           |
+| <div className="required-block"><div>resourceName</div> <div className=" required">deprecated</div></div> | Determines which resource to use for redirection | `string`                                                                                                      | Resource name that it reads from route                           |
+| hideText                                                                                                  | Allows to hide button text                       | `boolean`                                                                                                     | `false`                                                          |
+| ignoreAccessControlProvider                                                                               | Skip access control                              | `boolean`                                                                                                     | `false`                                                          |
+| children                                                                                                  | Sets the button text                             | `ReactNode`                                                                                                   | Humanized resource name that it reads from route                 |
+| icon                                                                                                      | Sets the icon component of button                | `ReactNode`                                                                                                   | [`<BarsOutlined />`](https://ant.design/components/icon/)        |
+| onClick                                                                                                   | Sets the handler to handle click event           | `(event) => void`                                                                                             | Triggers navigation for redirection to the list page of resource |

--- a/documentation/docs/ui-frameworks/antd/components/buttons/refresh.md
+++ b/documentation/docs/ui-frameworks/antd/components/buttons/refresh.md
@@ -77,15 +77,15 @@ Clicking the button will trigger the [`useOne`](/core/hooks/data/useOne.md) meth
 `<RefreshButton>` component reads the id information from the route by default.
 :::
 
-### `resourceName`
+### `resourceNameOrRouteName`
 
-`resourceName` allows us to manage which resource is going to be refreshed.
+`resourceNameOrRouteName` allows us to manage which resource is going to be refreshed.
 
 ```tsx 
 import { RefreshButton } from "@pankod/refine-antd";
 
 export const MyRefreshComponent = () => {
-    return <RefreshButton resourceName="categories" recordItemId="2" />;
+    return <RefreshButton resourceNameOrRouteName="categories" recordItemId="2" />;
 };
 ```
 
@@ -111,13 +111,14 @@ export const MyRefreshComponent = () => {
 
 ### Properties
 
-| Property     | Description                                  | Type                                                                                                                                 | Default                                                                        |
-| ------------ | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
-| props        | Ant Design button props                      | [`ButtonProps`](https://ant.design/components/button/#API) & `{ resourceName?: string; recordItemId?: BaseKey; hideText?: boolean; }` |                                                                                |
-| resourceName | Determines which resource to use for refresh | `string`                                                                                                                             | Resource name that it reads from route                                         |
-| recordItemId | Determines which id to use for refresh       | [`BaseKey`](/core/interfaces.md#basekey)                                                                                                                             | Record id that it reads from route                                             |
-| hideText     | Allows to hide button text                   | `boolean`                                                                                                                            | `false`                                                                        |
-| children     | Sets the button text                         | `ReactNode`                                                                                                                          | `"Refresh"`                                                                    |
-| icon         | Sets the icon component of button            | `ReactNode`                                                                                                                          | [`<RedoOutlined />`](https://ant.design/components/icon/)                      |
-| onClick      | Sets the handler to handle the click event   | `(event) => void`                                                                                                                    | trigger the [`useOne`](/core/hooks/data/useOne.md) method for refresh |
-| metaData     | Metadata query for `dataProvider`            | [`MetaDataQuery`](/core/interfaces.md#metadataquery)                                                                     | {}                                                                             |
+| Property                                                                                                  | Description                                      | Type                                                                                                                                  | Default                                                               |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| props                                                                                                     | Ant Design button props                          | [`ButtonProps`](https://ant.design/components/button/#API) & `{ resourceName?: string; recordItemId?: BaseKey; hideText?: boolean; }` |                                                                       |
+| resourceNameOrRouteName                                                                                   | Determines which resource to use for redirection | `string`                                                                                                                              | Resource name that it reads from route                                |
+| <div className="required-block"><div>resourceName</div> <div className=" required">deprecated</div></div> | Determines which resource to use for redirection | `string`                                                                                                                              | Resource name that it reads from route                                |
+| recordItemId                                                                                              | Determines which id to use for refresh           | [`BaseKey`](/core/interfaces.md#basekey)                                                                                              | Record id that it reads from route                                    |
+| hideText                                                                                                  | Allows to hide button text                       | `boolean`                                                                                                                             | `false`                                                               |
+| children                                                                                                  | Sets the button text                             | `ReactNode`                                                                                                                           | `"Refresh"`                                                           |
+| icon                                                                                                      | Sets the icon component of button                | `ReactNode`                                                                                                                           | [`<RedoOutlined />`](https://ant.design/components/icon/)             |
+| onClick                                                                                                   | Sets the handler to handle the click event       | `(event) => void`                                                                                                                     | trigger the [`useOne`](/core/hooks/data/useOne.md) method for refresh |
+| metaData                                                                                                  | Metadata query for `dataProvider`                | [`MetaDataQuery`](/core/interfaces.md#metadataquery)                                                                                  | {}                                                                    |

--- a/documentation/docs/ui-frameworks/antd/components/buttons/show.md
+++ b/documentation/docs/ui-frameworks/antd/components/buttons/show.md
@@ -76,15 +76,15 @@ Clicking the button will trigger the `show` method of [`useNavigation`](/core/ho
 `<ShowButton>` component reads the id information from the route by default.
 :::
 
-### `resourceName`
+### `resourceNameOrRouteName`
 
-Redirection endpoint(`resourceName/show`) is defined by `resourceName` property. By default, `<ShowButton>` uses `name` property of the resource object as an endpoint to redirect after clicking.
+Redirection endpoint(`resourceNameOrRouteName/show`) is defined by `resourceNameOrRouteName` property. By default, `<ShowButton>` uses `name` property of the resource object as an endpoint to redirect after clicking.
 
 ```tsx 
 import { ShowButton } from "@pankod/refine-antd";
 
 export const MyShowComponent = () => {
-    return <ShowButton resourceName="categories" recordItemId="2" />;
+    return <ShowButton resourceNameOrRouteName="categories" recordItemId="2" />;
 };
 ```
 
@@ -118,13 +118,14 @@ export const MyListComponent = () => {
 
 ### Properties
 
-| Property                    | Description                                      | Type                                                                                                                                 | Default                                                          |
-| --------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| props                       | Ant Design button properties                     | [`ButtonProps`](https://ant.design/components/button/#API) & `{ resourceName?: string; recordItemId?: BaseKey; hideText?: boolean; }` |                                                                  |
-| resourceName                | Determines which resource to use for redirection | `string`                                                                                                                             | Resource name that it reads from route                           |
-| recordItemId                | Adds `id` to the end of the URL                  | [`BaseKey`](/core/interfaces.md#basekey)                                                                                                                             | Record id that it reads from route                               |
-| hideText                    | Allows to hide button text                       | `boolean`                                                                                                                            | `false`                                                          |
-| ignoreAccessControlProvider | Skip access control                              | `boolean`                                                                                                                            | `false`                                                          |
-| children                    | Sets the button text                             | `ReactNode`                                                                                                                          | `"Show"`                                                         |
-| icon                        | Sets the icon component of button                | `ReactNode`                                                                                                                          | [`<EyeOutlined />`](https://ant.design/components/icon/)         |
-| onClick                     | Sets the handler to handle click event           | `(event) => void`                                                                                                                    | Triggers navigation for redirection to the show page of resource |
+| Property                                                                                                  | Description                                      | Type                                                                                                                                  | Default                                                          |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| props                                                                                                     | Ant Design button properties                     | [`ButtonProps`](https://ant.design/components/button/#API) & `{ resourceName?: string; recordItemId?: BaseKey; hideText?: boolean; }` |                                                                  |
+| resourceNameOrRouteName                                                                                   | Determines which resource to use for redirection | `string`                                                                                                                              | Resource name that it reads from route                           |
+| <div className="required-block"><div>resourceName</div> <div className=" required">deprecated</div></div> | Determines which resource to use for redirection | `string`                                                                                                                              | Resource name that it reads from route                           |
+| recordItemId                                                                                              | Adds `id` to the end of the URL                  | [`BaseKey`](/core/interfaces.md#basekey)                                                                                              | Record id that it reads from route                               |
+| hideText                                                                                                  | Allows to hide button text                       | `boolean`                                                                                                                             | `false`                                                          |
+| ignoreAccessControlProvider                                                                               | Skip access control                              | `boolean`                                                                                                                             | `false`                                                          |
+| children                                                                                                  | Sets the button text                             | `ReactNode`                                                                                                                           | `"Show"`                                                         |
+| icon                                                                                                      | Sets the icon component of button                | `ReactNode`                                                                                                                           | [`<EyeOutlined />`](https://ant.design/components/icon/)         |
+| onClick                                                                                                   | Sets the handler to handle click event           | `(event) => void`                                                                                                                     | Triggers navigation for redirection to the show page of resource |

--- a/examples/base/src/App.tsx
+++ b/examples/base/src/App.tsx
@@ -26,6 +26,25 @@ const App: React.FC = () => {
                     show: PostShow,
                     canDelete: true,
                 },
+                {
+                    name: "posts",
+                    list: PostList,
+                    create: PostCreate,
+                    edit: PostEdit,
+                    show: PostShow,
+                    canDelete: true,
+                    options: {
+                        route: "posts-hede",
+                    },
+                },
+                {
+                    name: "categories",
+                    list: PostList,
+                    create: PostCreate,
+                    edit: PostEdit,
+                    show: PostShow,
+                    canDelete: true,
+                },
             ]}
             notificationProvider={notificationProvider}
             Layout={Layout}

--- a/examples/base/src/App.tsx
+++ b/examples/base/src/App.tsx
@@ -26,25 +26,6 @@ const App: React.FC = () => {
                     show: PostShow,
                     canDelete: true,
                 },
-                {
-                    name: "posts",
-                    list: PostList,
-                    create: PostCreate,
-                    edit: PostEdit,
-                    show: PostShow,
-                    canDelete: true,
-                    options: {
-                        route: "posts-hede",
-                    },
-                },
-                {
-                    name: "categories",
-                    list: PostList,
-                    create: PostCreate,
-                    edit: PostEdit,
-                    show: PostShow,
-                    canDelete: true,
-                },
             ]}
             notificationProvider={notificationProvider}
             Layout={Layout}

--- a/packages/antd/src/components/buttons/clone/index.spec.tsx
+++ b/packages/antd/src/components/buttons/clone/index.spec.tsx
@@ -208,4 +208,31 @@ describe("Clone Button", () => {
 
         expect(mHistory.push).toBeCalledWith("/categories/clone/1");
     });
+
+    it("should redirect with custom route called function successfully if click the button", () => {
+        const { getByText } = render(
+            <Route path="/:resource">
+                <CloneButton
+                    resourceNameOrRouteName="custom-route-posts"
+                    recordItemId="1"
+                />
+            </Route>,
+            {
+                wrapper: TestWrapper({
+                    resources: [
+                        {
+                            name: "posts",
+                            options: { route: "custom-route-posts" },
+                        },
+                        { name: "posts" },
+                    ],
+                    routerInitialEntries: ["/posts"],
+                }),
+            },
+        );
+
+        fireEvent.click(getByText("Clone"));
+
+        expect(mHistory.push).toBeCalledWith("/custom-route-posts/clone/1");
+    });
 });

--- a/packages/antd/src/components/buttons/clone/index.tsx
+++ b/packages/antd/src/components/buttons/clone/index.tsx
@@ -12,7 +12,11 @@ import {
 } from "@pankod/refine-core";
 
 export type CloneButtonProps = ButtonProps & {
+    /**
+     * @deprecated resourceName deprecated. Use resourceNameOrRouteName instead # https://github.com/pankod/refine/issues/1618
+     */
     resourceName?: string;
+    resourceNameOrRouteName?: string;
     recordItemId?: BaseKey;
     hideText?: boolean;
     ignoreAccessControlProvider?: boolean;
@@ -27,6 +31,7 @@ export type CloneButtonProps = ButtonProps & {
  */
 export const CloneButton: React.FC<CloneButtonProps> = ({
     resourceName: propResourceName,
+    resourceNameOrRouteName: propResourceNameOrRouteName,
     recordItemId,
     hideText = false,
     ignoreAccessControlProvider = false,
@@ -45,7 +50,9 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
     const { resource: routeResourceName, id: idFromRoute } =
         useParams<ResourceRouterParams>();
 
-    const resource = resourceWithRoute(routeResourceName);
+    const resource = resourceWithRoute(
+        propResourceNameOrRouteName ?? routeResourceName,
+    );
 
     const resourceName = propResourceName ?? resource.name;
 
@@ -73,7 +80,9 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
     return (
         <Button
             onClick={(e): void =>
-                onClick ? onClick(e) : clone(resourceName, id!)
+                onClick
+                    ? onClick(e)
+                    : clone(propResourceName ?? resource.route, id!)
             }
             icon={<PlusSquareOutlined />}
             disabled={data?.can === false}

--- a/packages/antd/src/components/buttons/create/index.spec.tsx
+++ b/packages/antd/src/components/buttons/create/index.spec.tsx
@@ -174,7 +174,10 @@ describe("Create Button", () => {
             {
                 wrapper: TestWrapper({
                     resources: [
-                        { name: "posts", route: "custom-route-posts" },
+                        {
+                            name: "posts",
+                            options: { route: "custom-route-posts" },
+                        },
                         { name: "posts" },
                     ],
                     routerInitialEntries: ["/posts"],

--- a/packages/antd/src/components/buttons/create/index.spec.tsx
+++ b/packages/antd/src/components/buttons/create/index.spec.tsx
@@ -165,4 +165,25 @@ describe("Create Button", () => {
 
         expect(mHistory.push).toBeCalledWith("/posts/create");
     });
+
+    it("should redirect with custom route called function successfully if click the button", () => {
+        const { getByText } = render(
+            <Route path="/:resource">
+                <CreateButton resourceNameOrRouteName="custom-route-posts" />
+            </Route>,
+            {
+                wrapper: TestWrapper({
+                    resources: [
+                        { name: "posts", route: "custom-route-posts" },
+                        { name: "posts" },
+                    ],
+                    routerInitialEntries: ["/posts"],
+                }),
+            },
+        );
+
+        fireEvent.click(getByText("Create"));
+
+        expect(mHistory.push).toBeCalledWith("/custom-route-posts/create");
+    });
 });

--- a/packages/antd/src/components/buttons/create/index.tsx
+++ b/packages/antd/src/components/buttons/create/index.tsx
@@ -11,7 +11,11 @@ import {
 } from "@pankod/refine-core";
 
 export type CreateButtonProps = ButtonProps & {
+    /**
+     * @deprecated resourceName deprecated. Use resourceNameOrRouteName instead # https://github.com/pankod/refine/issues/1618
+     */
     resourceName?: string;
+    resourceNameOrRouteName?: string;
     hideText?: boolean;
     ignoreAccessControlProvider?: boolean;
 };
@@ -25,6 +29,7 @@ export type CreateButtonProps = ButtonProps & {
  */
 export const CreateButton: React.FC<CreateButtonProps> = ({
     resourceName: propResourceName,
+    resourceNameOrRouteName: propResourceNameOrRouteName,
     hideText = false,
     ignoreAccessControlProvider = false,
     children,
@@ -41,7 +46,9 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
 
     const { resource: routeResourceName } = useParams<ResourceRouterParams>();
 
-    const resource = resourceWithRoute(routeResourceName);
+    const resource = resourceWithRoute(
+        propResourceNameOrRouteName ?? routeResourceName,
+    );
 
     const resourceName = propResourceName ?? resource.name;
 
@@ -66,7 +73,9 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
     return (
         <Button
             onClick={(e): void =>
-                onClick ? onClick(e) : create(resourceName, "push")
+                onClick
+                    ? onClick(e)
+                    : create(propResourceName ?? resource.route, "push")
             }
             icon={<PlusSquareOutlined />}
             disabled={data?.can === false}

--- a/packages/antd/src/components/buttons/delete/index.spec.tsx
+++ b/packages/antd/src/components/buttons/delete/index.spec.tsx
@@ -234,6 +234,46 @@ describe("Delete Button", () => {
             expect(deleteOneMock).toBeCalledTimes(1);
             expect(onSuccessMock).toBeCalledTimes(1);
         });
+
+        it("should confirm Popconfirm successfuly with onSuccess", async () => {
+            const deleteOneMock = jest.fn();
+            const onSuccessMock = jest.fn();
+
+            const { getByText, getAllByText, debug } = render(
+                <Route path="/:resource/:action/:id">
+                    <DeleteButton
+                        onSuccess={onSuccessMock}
+                        confirmOkText="confirmOkText"
+                        confirmCancelText="confirmCancelText"
+                        confirmTitle="confirmTitle"
+                    />
+                </Route>,
+                {
+                    wrapper: TestWrapper({
+                        dataProvider: {
+                            ...MockJSONServer,
+                            deleteOne: deleteOneMock,
+                        },
+                        routerInitialEntries: ["/posts/edit/1"],
+                    }),
+                },
+            );
+
+            await act(async () => {
+                fireEvent.click(getByText("Delete"));
+            });
+
+            getByText("confirmTitle");
+            getByText("confirmOkText");
+            getByText("confirmCancelText");
+
+            await act(async () => {
+                fireEvent.click(getByText("confirmOkText"));
+            });
+
+            expect(deleteOneMock).toBeCalledTimes(1);
+            expect(onSuccessMock).toBeCalledTimes(1);
+        });
     });
 
     it("should render with custom mutationMode", () => {
@@ -256,6 +296,22 @@ describe("Delete Button", () => {
         const { getByText } = render(
             <Route path="/:resource">
                 <DeleteButton resourceName="categories" />
+            </Route>,
+            {
+                wrapper: TestWrapper({
+                    resources: [{ name: "posts" }, { name: "categories" }],
+                    routerInitialEntries: ["/posts"],
+                }),
+            },
+        );
+
+        fireEvent.click(getByText("Delete"));
+    });
+
+    it("should render with resourceNameOrRouteName", () => {
+        const { getByText } = render(
+            <Route path="/:resource">
+                <DeleteButton resourceNameOrRouteName="categories" />
             </Route>,
             {
                 wrapper: TestWrapper({

--- a/packages/antd/src/components/buttons/delete/index.tsx
+++ b/packages/antd/src/components/buttons/delete/index.tsx
@@ -17,7 +17,11 @@ import {
 } from "@pankod/refine-core";
 
 export type DeleteButtonProps = ButtonProps & {
+    /**
+     * @deprecated resourceName deprecated. Use resourceNameOrRouteName instead # https://github.com/pankod/refine/issues/1618
+     */
     resourceName?: string;
+    resourceNameOrRouteName?: string;
     recordItemId?: BaseKey;
     onSuccess?: (value: DeleteOneResponse) => void;
     mutationMode?: MutationMode;
@@ -38,6 +42,7 @@ export type DeleteButtonProps = ButtonProps & {
  */
 export const DeleteButton: React.FC<DeleteButtonProps> = ({
     resourceName: propResourceName,
+    resourceNameOrRouteName: propResourceNameOrRouteName,
     recordItemId,
     onSuccess,
     mutationMode: mutationModeProp,
@@ -66,16 +71,17 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     const { resource: routeResourceName, id: idFromRoute } =
         useParams<ResourceRouterParams>();
 
-    const resourceName = propResourceName ?? routeResourceName;
-
-    const resource = resourceWithRoute(resourceName);
+    const resource = resourceWithRoute(
+        propResourceNameOrRouteName ?? routeResourceName,
+    );
+    const resourceName = propResourceName ?? resource.name;
 
     const { mutate, isLoading, variables } = useDelete();
 
     const id = recordItemId ?? idFromRoute;
 
     const { data } = useCan({
-        resource: resource.name,
+        resource: resourceName,
         action: "delete",
         params: { id },
         queryOptions: {
@@ -99,7 +105,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
                 mutate(
                     {
                         id: id!,
-                        resource: resource.name,
+                        resource: resourceName,
                         mutationMode,
                         successNotification,
                         errorNotification,

--- a/packages/antd/src/components/buttons/edit/index.spec.tsx
+++ b/packages/antd/src/components/buttons/edit/index.spec.tsx
@@ -15,6 +15,10 @@ jest.mock("react-router-dom", () => ({
 describe("Edit Button", () => {
     const edit = jest.fn();
 
+    beforeEach(() => {
+        mHistory.push.mockReset();
+    });
+
     it("should render button successfuly", () => {
         const { container, getByText } = render(
             <EditButton onClick={() => edit()} />,
@@ -160,5 +164,32 @@ describe("Edit Button", () => {
         fireEvent.click(getByText("Edit"));
 
         expect(mHistory.push).toBeCalledWith("/categories/edit/1");
+    });
+
+    it("should redirect with custom route called function successfully if click the button", () => {
+        const { getByText } = render(
+            <Route path="/:resource">
+                <EditButton
+                    resourceNameOrRouteName="custom-route-posts"
+                    recordItemId={1}
+                />
+            </Route>,
+            {
+                wrapper: TestWrapper({
+                    resources: [
+                        {
+                            name: "posts",
+                            options: { route: "custom-route-posts" },
+                        },
+                        { name: "posts" },
+                    ],
+                    routerInitialEntries: ["/posts"],
+                }),
+            },
+        );
+
+        fireEvent.click(getByText("Edit"));
+
+        expect(mHistory.push).toBeCalledWith("/custom-route-posts/edit/1");
     });
 });

--- a/packages/antd/src/components/buttons/edit/index.tsx
+++ b/packages/antd/src/components/buttons/edit/index.tsx
@@ -12,7 +12,11 @@ import {
 } from "@pankod/refine-core";
 
 export type EditButtonProps = ButtonProps & {
+    /**
+     * @deprecated resourceName deprecated. Use resourceNameOrRouteName instead # https://github.com/pankod/refine/issues/1618
+     */
     resourceName?: string;
+    resourceNameOrRouteName?: string;
     recordItemId?: BaseKey;
     hideText?: boolean;
     ignoreAccessControlProvider?: boolean;
@@ -27,6 +31,7 @@ export type EditButtonProps = ButtonProps & {
  */
 export const EditButton: React.FC<EditButtonProps> = ({
     resourceName: propResourceName,
+    resourceNameOrRouteName: propResourceNameOrRouteName,
     recordItemId,
     hideText = false,
     ignoreAccessControlProvider = false,
@@ -43,8 +48,9 @@ export const EditButton: React.FC<EditButtonProps> = ({
     const { resource: routeResourceName, id: idFromRoute } =
         useParams<ResourceRouterParams>();
 
-    const resource = resourceWithRoute(routeResourceName);
-
+    const resource = resourceWithRoute(
+        propResourceNameOrRouteName ?? routeResourceName,
+    );
     const resourceName = propResourceName ?? resource.name;
 
     const { edit } = useNavigation();
@@ -73,7 +79,9 @@ export const EditButton: React.FC<EditButtonProps> = ({
     return (
         <Button
             onClick={(e): void =>
-                onClick ? onClick(e) : edit(resourceName, id!)
+                onClick
+                    ? onClick(e)
+                    : edit(propResourceName ?? resource.route, id!)
             }
             icon={<EditOutlined />}
             disabled={data?.can === false}

--- a/packages/antd/src/components/buttons/list/index.spec.tsx
+++ b/packages/antd/src/components/buttons/list/index.spec.tsx
@@ -1,8 +1,17 @@
 import React from "react";
-import { Route } from "react-router-dom";
+import ReactRouterDom, { Route } from "react-router-dom";
 
 import { fireEvent, render, TestWrapper, waitFor } from "@test";
 import { ListButton } from "./";
+
+const mHistory = {
+    push: jest.fn(),
+};
+
+jest.mock("react-router-dom", () => ({
+    ...(jest.requireActual("react-router-dom") as typeof ReactRouterDom),
+    useHistory: jest.fn(() => mHistory),
+}));
 
 describe("List Button", () => {
     const list = jest.fn();
@@ -142,5 +151,29 @@ describe("List Button", () => {
         fireEvent.click(getByText("Posts"));
 
         expect(list).toHaveBeenCalledTimes(1);
+    });
+
+    it("should redirect with custom route called function successfully if click the button", () => {
+        const { getByText } = render(
+            <Route path="/:resource">
+                <ListButton resourceNameOrRouteName="custom-route-posts" />
+            </Route>,
+            {
+                wrapper: TestWrapper({
+                    resources: [
+                        {
+                            name: "posts",
+                            options: { route: "custom-route-posts" },
+                        },
+                        { name: "posts" },
+                    ],
+                    routerInitialEntries: ["/posts"],
+                }),
+            },
+        );
+
+        fireEvent.click(getByText("Posts"));
+
+        expect(mHistory.push).toBeCalledWith("/custom-route-posts");
     });
 });

--- a/packages/antd/src/components/buttons/list/index.tsx
+++ b/packages/antd/src/components/buttons/list/index.tsx
@@ -12,7 +12,11 @@ import {
 } from "@pankod/refine-core";
 
 export type ListButtonProps = ButtonProps & {
+    /**
+     * @deprecated resourceName deprecated. Use resourceNameOrRouteName instead # https://github.com/pankod/refine/issues/1618
+     */
     resourceName?: string;
+    resourceNameOrRouteName?: string;
     hideText?: boolean;
     ignoreAccessControlProvider?: boolean;
 };
@@ -26,6 +30,7 @@ export type ListButtonProps = ButtonProps & {
  */
 export const ListButton: React.FC<ListButtonProps> = ({
     resourceName: propResourceName,
+    resourceNameOrRouteName: propResourceNameOrRouteName,
     hideText = false,
     ignoreAccessControlProvider = false,
     children,
@@ -41,10 +46,13 @@ export const ListButton: React.FC<ListButtonProps> = ({
 
     const { resource: routeResourceName } = useParams<ResourceRouterParams>();
 
-    const resource = resourceWithRoute(routeResourceName);
+    const resource = resourceWithRoute(
+        propResourceNameOrRouteName ?? routeResourceName,
+    );
 
     const resourceName = propResourceName ?? resource.name;
 
+    console.log("resourceName", propResourceName, resource, resourceName);
     const { data } = useCan({
         resource: resourceName,
         action: "list",
@@ -66,7 +74,9 @@ export const ListButton: React.FC<ListButtonProps> = ({
     return (
         <Button
             onClick={(e): void =>
-                onClick ? onClick(e) : list(resourceName, "push")
+                onClick
+                    ? onClick(e)
+                    : list(propResourceName ?? resource.route, "push")
             }
             icon={<BarsOutlined />}
             disabled={data?.can === false}

--- a/packages/antd/src/components/buttons/refresh/index.tsx
+++ b/packages/antd/src/components/buttons/refresh/index.tsx
@@ -12,7 +12,11 @@ import {
 } from "@pankod/refine-core";
 
 export type RefreshButtonProps = ButtonProps & {
+    /**
+     * @deprecated resourceName deprecated. Use resourceNameOrRouteName instead # https://github.com/pankod/refine/issues/1618
+     */
     resourceName?: string;
+    resourceNameOrRouteName?: string;
     recordItemId?: BaseKey;
     hideText?: boolean;
     metaData?: MetaDataQuery;
@@ -27,6 +31,7 @@ export type RefreshButtonProps = ButtonProps & {
  */
 export const RefreshButton: React.FC<RefreshButtonProps> = ({
     resourceName: propResourceName,
+    resourceNameOrRouteName: propResourceNameOrRouteName,
     recordItemId,
     hideText = false,
     metaData,
@@ -43,14 +48,16 @@ export const RefreshButton: React.FC<RefreshButtonProps> = ({
     const { resource: routeResourceName, id: idFromRoute } =
         useParams<ResourceRouterParams>();
 
-    const resourceName = propResourceName ?? routeResourceName;
+    const resource = resourceWithRoute(
+        propResourceNameOrRouteName ?? routeResourceName,
+    );
 
-    const resource = resourceWithRoute(resourceName);
+    const resourceName = propResourceName ?? resource.name;
 
     const id = recordItemId ?? idFromRoute;
 
     const { refetch, isFetching } = useOne({
-        resource: resource.name,
+        resource: resourceName,
         id,
         queryOptions: {
             enabled: false,

--- a/packages/antd/src/components/buttons/show/index.spec.tsx
+++ b/packages/antd/src/components/buttons/show/index.spec.tsx
@@ -199,4 +199,31 @@ describe("Show Button", () => {
 
         expect(mHistory.push).toBeCalledWith("/categories/show/1");
     });
+
+    it("should redirect with custom route called function successfully if click the button", () => {
+        const { getByText } = render(
+            <Route path="/:resource">
+                <ShowButton
+                    resourceNameOrRouteName="custom-route-posts"
+                    recordItemId="1"
+                />
+            </Route>,
+            {
+                wrapper: TestWrapper({
+                    resources: [
+                        {
+                            name: "posts",
+                            options: { route: "custom-route-posts" },
+                        },
+                        { name: "posts" },
+                    ],
+                    routerInitialEntries: ["/posts"],
+                }),
+            },
+        );
+
+        fireEvent.click(getByText("Show"));
+
+        expect(mHistory.push).toBeCalledWith("/custom-route-posts/show/1");
+    });
 });

--- a/packages/antd/src/components/buttons/show/index.tsx
+++ b/packages/antd/src/components/buttons/show/index.tsx
@@ -13,7 +13,11 @@ import {
 } from "@pankod/refine-core";
 
 export type ShowButtonProps = ButtonProps & {
+    /**
+     * @deprecated resourceName deprecated. Use resourceNameOrRouteName instead # https://github.com/pankod/refine/issues/1618
+     */
     resourceName?: string;
+    resourceNameOrRouteName?: string;
     recordItemId?: BaseKey;
     hideText?: boolean;
     ignoreAccessControlProvider?: boolean;
@@ -28,6 +32,7 @@ export type ShowButtonProps = ButtonProps & {
  */
 export const ShowButton: React.FC<ShowButtonProps> = ({
     resourceName: propResourceName,
+    resourceNameOrRouteName: propResourceNameOrRouteName,
     recordItemId,
     hideText = false,
     ignoreAccessControlProvider = false,
@@ -45,7 +50,9 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
     const { resource: routeResourceName, id: idFromRoute } =
         useParams<ResourceRouterParams>();
 
-    const resource = resourceWithRoute(routeResourceName);
+    const resource = resourceWithRoute(
+        propResourceNameOrRouteName ?? routeResourceName,
+    );
 
     const resourceName = propResourceName ?? resource.name;
 
@@ -73,7 +80,9 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
     return (
         <Button
             onClick={(e): void =>
-                rest?.onClick ? rest.onClick(e) : show(resourceName, id!)
+                rest?.onClick
+                    ? rest.onClick(e)
+                    : show(propResourceName ?? resource.route, id!)
             }
             icon={<EyeOutlined />}
             disabled={data?.can === false}

--- a/packages/antd/src/components/crud/edit/index.tsx
+++ b/packages/antd/src/components/crud/edit/index.tsx
@@ -101,11 +101,11 @@ export const Edit: React.FC<EditProps> = ({
                     {!recordItemId && (
                         <ListButton
                             data-testid="edit-list-button"
-                            resourceName={resource.name}
+                            resourceNameOrRouteName={resource.route}
                         />
                     )}
                     <RefreshButton
-                        resourceName={resource.name}
+                        resourceNameOrRouteName={resource.route}
                         recordItemId={id}
                     />
                 </Space>

--- a/packages/antd/src/components/crud/list/index.tsx
+++ b/packages/antd/src/components/crud/list/index.tsx
@@ -47,7 +47,7 @@ export const List: React.FC<ListProps> = ({
     const defaultExtra = isCreateButtonVisible && (
         <CreateButton
             size="middle"
-            resourceName={resource.name}
+            resourceNameOrRouteName={resource.route}
             data-testid="list-create-button"
             {...createButtonProps}
         />

--- a/packages/antd/src/components/crud/show/index.tsx
+++ b/packages/antd/src/components/crud/show/index.tsx
@@ -85,20 +85,20 @@ export const Show: React.FC<ShowProps> = ({
                     {!recordItemId && (
                         <ListButton
                             data-testid="show-list-button"
-                            resourceName={resource.name}
+                            resourceNameOrRouteName={resource.route}
                         />
                     )}
                     {isEditButtonVisible && (
                         <EditButton
                             disabled={isLoading}
                             data-testid="show-edit-button"
-                            resourceName={resource.name}
+                            resourceNameOrRouteName={resource.route}
                             recordItemId={id}
                         />
                     )}
                     {isDeleteButtonVisible && (
                         <DeleteButton
-                            resourceName={resource.name}
+                            resourceNameOrRouteName={resource.route}
                             data-testid="show-delete-button"
                             recordItemId={id}
                             onSuccess={() =>
@@ -107,7 +107,7 @@ export const Show: React.FC<ShowProps> = ({
                         />
                     )}
                     <RefreshButton
-                        resourceName={resource.name}
+                        resourceNameOrRouteName={resource.route}
                         recordItemId={id}
                     />
                 </Space>

--- a/packages/core/src/hooks/resource/useResourceWithRoute/index.ts
+++ b/packages/core/src/hooks/resource/useResourceWithRoute/index.ts
@@ -2,7 +2,9 @@ import { useContext, useCallback } from "react";
 import { ResourceContext } from "@contexts/resource";
 import { IResourceItem } from "../../../interfaces";
 
-export const useResourceWithRoute = (): ((route: string) => IResourceItem) => {
+export type UseResourceWithRouteReturnType = (route: string) => IResourceItem;
+
+export const useResourceWithRoute = (): UseResourceWithRouteReturnType => {
     const { resources } = useContext(ResourceContext);
 
     const resourceWithRoute = useCallback(


### PR DESCRIPTION
Hey, I'm client! Test me! 'MASTER'
[Link to FIX-ROUTES-HANDLE-CRUD-AND-BUTTONS](https://fix-rou-client.refine.pankod.com)

Please provide enough information so that others can review your pull request:

Buttons such as create, edit, show that were added automatically when using the custom route in resource definitions were going to the wrong route.  We have to add the unit tests.

**Closing issues**

- #1618 

Test documentation! 'MASTER'
[Link to FIX-ROUTES-HANDLE-CRUD-AND-BUTTONS](https://fix-rou-doc-refine.pankod.com)