### PR TITLE
Fix correction of example code for components catchAll

### DIFF
--- a/documentation/docs/core/components/refine-config.md
+++ b/documentation/docs/core/components/refine-config.md
@@ -325,7 +325,7 @@ const App: React.FC = () => {
         <Refine
             ...
             // highlight-next-line
-            catchAll={CustomErrorPage}
+            catchAll={CustomErrorPage()}
         />
     );
 };

--- a/documentation/docs/core/components/refine-config.md
+++ b/documentation/docs/core/components/refine-config.md
@@ -318,14 +318,14 @@ When the app is navigated to a non-existent route, **refine** shows a default er
 
 ```tsx title="App.tsx"
 // highlight-next-line
-const CustomErrorPage = () => <div>Page not found</div>;
+const CustomErrorPage = <div>Page not found</div>;
 
 const App: React.FC = () => {
     return (
         <Refine
             ...
             // highlight-next-line
-            catchAll={CustomErrorPage()}
+            catchAll={CustomErrorPage}
         />
     );
 };


### PR DESCRIPTION
Warning: Functions are not valid as a React child. This may happen if you return a Component instead of <Component /> from render. Or maybe you meant to call this function rather than return it.