### PR TITLE
Updated docs regarding setting Authorization Credentials

### DIFF
--- a/documentation/docs/core/providers/auth-provider.md
+++ b/documentation/docs/core/providers/auth-provider.md
@@ -527,7 +527,7 @@ If the resolved data has a `name` property, a name text appears; if it has an `a
 
 After user logs in, their credentials can be sent along with the API request by configuring the [`dataProvider`](/core/providers/data-provider.md). A custom `httpClient` can be passed to [`dataProvider`](/core/providers/data-provider.md) to include configurations like cookies and request headers.
 
-We'll show how to add a token acquired from the `login` method to the **Authorization** header of the **HTTP** requests.
+We'll show how to add a token acquired from the `login` method to the **Authorization** header of the **HTTP** requests. We will leverage the default headers configuration of Axios. See the [Config Default](https://axios-http.com/docs/config_defaults) of Axios docs for more information on how this works.
 
 ```tsx title="App.tsx"
 ...
@@ -551,8 +551,8 @@ const App = () => {
 
                 if (user) {
                     localStorage.setItem("auth", JSON.stringify(user));
-
-                    axiosInstance.defaults.headers = {
+                    // This sets the authorization headers on Axios instance
+                    axiosInstance.defaults.headers.common = {
                         Authorization: `Bearer ${user.token}`,
                     };
 
@@ -578,6 +578,81 @@ const App = () => {
 :::note
 We recommend using **axios** as the **HTTP** client with the **@pankod/refine-simple-rest** [`dataProvider`](/core/providers/data-provider.md). Other **HTTP** clients can also be preferred.
 :::
+
+Since default headers are per Axios instance it is important that you create a single Axios instance that will be re-used throughout your Refine project. There are a few methods to accomplish this, as shown one could create a variable that you import in other parts of your project and use as necessary. Another option would be to use a `Singleton` model which may work better depending on your code structure.
+
+Another option for setting the authorization for Axios is to use `axios.interceptors.request.use()`. This *intercepts* any request made and performs some function on that request. In theory, this function could do anything, for instance checking browser local storage for a key/token and inserting it somewhere in the request before sending the request. See the [interceptor](https://axios-http.com/docs/interceptors) docs for more information. 
+
+Here is an example of how one could use the interceptors to include authorization information in requests. This example uses Bearer tokens and assumes they've been saved in browser local storage:
+
+
+```tsx title="App.tsx"
+...
+// highlight-next-line
+import axios from "axios";
+// highlight-start
+const axiosInstance = axios.create();
+
+axiosInstance.interceptors.request.use(
+    // Here we can perform any function we'd like on the request
+    (request: AxiosRequestConfig) => {
+        // Retrieve the token from local storage
+        const token = JSON.parse(localStorage.getItem("auth"));
+        // Check if the header property exists
+        if (request.headers) {
+            // Set the Authorization header if it exists
+            request.headers[
+                "Authorization"
+            ] = `Bearer ${token}`;
+        } else {
+            // Create the headers property if it does not exist
+            request.headers = {
+                Authorization: `Bearer ${token}`,
+            };
+        }
+    },
+);
+
+// highlight-end
+
+const mockUsers = [
+    { username: "admin", token: "123" },
+    { username: "editor", token: "321" }
+];
+
+const App = () => {
+    const authProvider: AuthProvider = {
+// highlight-start
+        login: ({ username, password }) => {
+                // Suppose we actually send a request to the back end here.
+                const user = mockUsers.find((item) => item.username === username);
+
+                if (user) {
+                    localStorage.setItem("auth", JSON.stringify(user));
+                    return Promise.resolve();
+                }
+                return Promise.reject();
+            },
+// highlight-end
+            ...
+        };
+
+    return (
+        <Refine
+// highlight-next-line
+            authProvider={authProvider}
+            routerProvider={routerProvider}
+            dataProvider={dataProvider(API_URL, axiosInstance)}
+        />
+    );
+}
+```
+
+:::note
+Interceptors are also a great way for refreshing tokens when they expire. 
+:::
+
+
 
 ## Hooks and Components
 


### PR DESCRIPTION
First version of updated docs for the `Authorization Credentials` section of `core/providers/auth-provider`. 

I added some language about the importance of a singular Axios instance and another method for setting credentials. 

I also fixed a typo in the original example. Switching from `axiosInstance.defaults.headers` -> ` axiosInstance.defaults.headers.common`.

One possible issue is that the example interceptor code is synchronous and Axios has some special docs about this. I was unable to get their example working though. See [here](https://github.com/axios/axios#interceptors) for more information.

I also  think it could be useful to provide an example for something that is _not_ Bearer style authorization. I'm not sure what the next most common authorization format would be -- but if a suggestion is given I could write some example docs for that type as well. 

I know this PR will need some work, just want to get an Alpha version going to start the conversation and see how we can make this page better (: 


Closes #1683 