### PR TITLE
Add fallback for defaultValueQueryOptions on useSelect hook

### DIFF
--- a/documentation/docs/core/hooks/useSelect.md
+++ b/documentation/docs/core/hooks/useSelect.md
@@ -204,6 +204,8 @@ const { options } = useSelect({
 
 ### `defaultValueQueryOptions`
 
+When the `defaultValue` property is given, the `useMany` data hook is called for the selected records. With this property, you can change the options of this query. If not given, the values given in queryOptions will be used.
+
 ```tsx
 const { options } = useSelect({
     resource: "categories",

--- a/documentation/docs/ui-frameworks/antd/hooks/field/useSelect.md
+++ b/documentation/docs/ui-frameworks/antd/hooks/field/useSelect.md
@@ -222,6 +222,8 @@ const { selectProps } = useSelect({
 
 ### `defaultValueQueryOptions`
 
+When the `defaultValue` property is given, the `useMany` data hook is called for the selected records. With this property, you can change the options of this query. If not given, the values given in queryOptions will be used.
+
 ```tsx
 const { selectProps } = useSelect({
     resource: "categories",

--- a/packages/core/src/hooks/useSelect/index.spec.ts
+++ b/packages/core/src/hooks/useSelect/index.spec.ts
@@ -297,6 +297,47 @@ describe("useSelect Hook", () => {
         expect(mockFunc).toBeCalled();
     });
 
+    it("should invoke queryOptions methods for defaultValue and default query successfully", async () => {
+        const mockFunc = jest.fn();
+
+        const { result, waitFor } = renderHook(
+            () =>
+                useSelect({
+                    resource: "posts",
+                    queryOptions: {
+                        onSuccess: () => {
+                            mockFunc();
+                        },
+                    },
+                    defaultValue: [1],
+                }),
+            {
+                wrapper: TestWrapper({
+                    dataProvider: MockJSONServer,
+                    resources: [{ name: "posts" }],
+                }),
+            },
+        );
+
+        await waitFor(() => {
+            return !result.current.queryResult?.isLoading;
+        });
+
+        const { options } = result.current;
+
+        expect(options).toHaveLength(2);
+        expect(options).toEqual([
+            {
+                label: "Necessitatibus necessitatibus id et cupiditate provident est qui amet.",
+                value: "1",
+            },
+            { label: "Recusandae consectetur aut atque est.", value: "2" },
+        ]);
+
+        // for init call and defaultValue
+        expect(mockFunc).toBeCalledTimes(2);
+    });
+
     it("should invoke queryOptions methods for default value successfully", async () => {
         const mockFunc = jest.fn();
 

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -61,7 +61,7 @@ export const useSelect = <
         debounce: debounceValue = 300,
         successNotification,
         errorNotification,
-        defaultValueQueryOptions,
+        defaultValueQueryOptions: defaultValueQueryOptionsFromProps,
         queryOptions,
         fetchSize,
         liveMode,
@@ -85,6 +85,9 @@ export const useSelect = <
             })),
         );
     };
+
+    const defaultValueQueryOptions =
+        defaultValueQueryOptionsFromProps ?? (queryOptions as any);
 
     const defaultValueQueryResult = useMany<TData, TError>({
         resource,


### PR DESCRIPTION
Test me! 'MASTER'
[Link to FEATURE-USE-SELECT-DEFAULT-VALUE](https://feature-refine.pankod.com)

Please provide enough information so that others can review your pull request:

In the useSelect hook, When the `defaultValue` property is given, the `useMany` data hook is called for the selected records. With this property, you can change the options of this query. If not given, the values given in queryOptions will be used.

**Closing issues**

- #1673