### PR TITLE
Remove unnecessary 'prevFilters' param on 'unionFilters' function

### DIFF
--- a/packages/core/src/definitions/table/index.spec.ts
+++ b/packages/core/src/definitions/table/index.spec.ts
@@ -147,21 +147,9 @@ describe("definitions/table", () => {
                         value: "crud",
                     },
                 ],
-                [
-                    {
-                        field: "baz",
-                        operator: "in",
-                        value: "prev",
-                    },
-                ],
             ),
         ).toMatchInlineSnapshot(`
             Array [
-              Object {
-                "field": "baz",
-                "operator": "in",
-                "value": "prev",
-              },
               Object {
                 "field": "bar",
                 "operator": "in",
@@ -198,26 +186,9 @@ describe("definitions/table", () => {
                         value: "crud",
                     },
                 ],
-                [
-                    {
-                        field: "bar",
-                        operator: "in",
-                        value: "prev",
-                    },
-                    {
-                        field: "baz",
-                        operator: "in",
-                        value: "prev",
-                    },
-                ],
             ),
         ).toMatchInlineSnapshot(`
             Array [
-              Object {
-                "field": "baz",
-                "operator": "in",
-                "value": "prev",
-              },
               Object {
                 "field": "bar",
                 "operator": "in",
@@ -246,13 +217,6 @@ describe("definitions/table", () => {
                         field: "bar",
                         operator: "in",
                         value: undefined,
-                    },
-                ],
-                [
-                    {
-                        field: "bar",
-                        operator: "in",
-                        value: "prev",
                     },
                     {
                         field: "baz",

--- a/packages/core/src/definitions/table/index.ts
+++ b/packages/core/src/definitions/table/index.ts
@@ -75,11 +75,8 @@ export const compareSorters = (left: CrudSort, right: CrudSort): boolean =>
 export const unionFilters = (
     permanentFilter: CrudFilters,
     newFilters: CrudFilters,
-    prevFilters: CrudFilters,
 ): CrudFilters =>
-    reverse(
-        unionWith(permanentFilter, newFilters, prevFilters, compareFilters),
-    ).filter(
+    reverse(unionWith(permanentFilter, newFilters, compareFilters)).filter(
         (crudFilter) =>
             crudFilter.value !== undefined && crudFilter.value !== null,
     );

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -154,7 +154,7 @@ export const useTable = <
                 current,
                 pageSize,
             },
-            filters: unionFilters(permanentFilter, [], filters),
+            filters: unionFilters(permanentFilter, filters),
             sort: unionSorters(permanentSorter, sorter),
         },
         queryOptions,
@@ -168,9 +168,7 @@ export const useTable = <
     });
 
     const setFiltersWithUnion = (newFilters: CrudFilters) => {
-        setFilters((prevFilters) =>
-            unionFilters(permanentFilter, newFilters, prevFilters),
-        );
+        setFilters(() => unionFilters(permanentFilter, newFilters));
     };
 
     const setSortWithUnion = (newSorter: CrudSorting) => {


### PR DESCRIPTION
Hey, I'm client! Test me! 'MASTER'
[Link to UPDATE-UNION-FILTERS-PARAMS](https://update--client.refine.pankod.com)

Test me! 'MASTER'
[Link to UPDATE-UNION-FILTERS-PARAMS](https://update--refine.pankod.com)

