### PR TITLE
Fix useShow id handle

### DIFF
--- a/packages/core/src/hooks/show/useShow.spec.tsx
+++ b/packages/core/src/hooks/show/useShow.spec.tsx
@@ -68,6 +68,35 @@ describe("useShow Hook", () => {
         expect(result.current.showId).toEqual("1");
     });
 
+    it("correctly return id undefined when resource different from route", async () => {
+        const { result } = renderHook(
+            () =>
+                useShow({
+                    resource: "categories",
+                }),
+            {
+                wrapper: WrapperWithRoute,
+            },
+        );
+
+        expect(result.current.showId).toEqual(undefined);
+    });
+
+    it("correctly return id when resource different from route", async () => {
+        const { result } = renderHook(
+            () =>
+                useShow({
+                    resource: "categories",
+                    id: "2",
+                }),
+            {
+                wrapper: WrapperWithRoute,
+            },
+        );
+
+        expect(result.current.showId).toEqual("2");
+    });
+
     it("correctly return id value which was set with setShowId after it was set", async () => {
         const { result } = renderHook(() => useShow(), {
             wrapper: WrapperWithRoute,

--- a/packages/core/src/hooks/show/useShow.ts
+++ b/packages/core/src/hooks/show/useShow.ts
@@ -49,9 +49,12 @@ export const useShow = <TData extends BaseRecord = BaseRecord>({
     const { resource: routeResourceName, id: idFromRoute } =
         useParams<ResourceRouterParams>();
 
-    const [showId, setShowId] = useState<BaseKey | undefined>(
-        id ?? idFromRoute,
-    );
+    const defaultId =
+        !resourceFromProp || resourceFromProp === routeResourceName
+            ? id ?? idFromRoute
+            : id;
+
+    const [showId, setShowId] = useState<BaseKey | undefined>(defaultId);
 
     const resourceWithRoute = useResourceWithRoute();
 


### PR DESCRIPTION
Test me! 'MASTER'
[Link to USE-SHOW-HOOK-HANDLE-ID](https://use-sho-refine.pankod.com)

Please provide enough information so that others can review your pull request:

`useShow` hook was getting wrong "id" during initialize when route and resource are different


**Closing issues**

- #1701