### PR TITLE
[Bug] handle error state on useExport hook

### DIFF
--- a/documentation/docs/core/hooks/import-export/useExport.md
+++ b/documentation/docs/core/hooks/import-export/useExport.md
@@ -204,6 +204,7 @@ You can pass more options to further customize the exporting process.
 | exportOptions    | Used for exporting options                                                                                                 | [`Options`][export-to-csv#api] \| `undefined`                                    |           |
 | metaData         | Metadata query for `dataProvider`                                                                                          | [`MetaDataQuery`](/core/interfaces.md#metadataquery)                             | {}        |
 | dataProviderName | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.                         | `string`                                                                         | `default` |
+| onError          | Callback to handle error events of this hook                                                                               | `(error: any) => void`                                                           |  |
 
 ### `useExport` Return Values
 

--- a/packages/core/src/hooks/export/index.spec.ts
+++ b/packages/core/src/hooks/export/index.spec.ts
@@ -130,4 +130,36 @@ describe("useExport Hook", () => {
             })),
         );
     });
+
+    it("should handle getList throwing error", async () => {
+        const onError = jest.fn();
+        const { result } = renderHook(
+            () =>
+                useExport({
+                    onError,
+                }),
+            {
+                wrapper: TestWrapper({
+                    dataProvider: {
+                        default: {
+                            ...MockJSONServer.default,
+                            getList: () => {
+                                throw new Error("Error");
+                            },
+                        } as any,
+                    },
+                    resources: [{ name: "posts" }],
+                }),
+            },
+        );
+
+        await act(async () => {
+            await result.current.triggerExport();
+        });
+
+        expect(result.current.isLoading).toEqual(false);
+        expect(onError).toBeCalledWith(Error("Error"));
+
+        expect(generateCsvMock).not.toBeCalled();
+    });
 });


### PR DESCRIPTION
Test me! 'MASTER'
[Link to HANDLE-ERROR-USE-EXPORT](https://handle--refine.pankod.com)

Please provide enough information so that others can review your pull request:

If there was an error in `getList` while using the useExport hook, the user would not be aware of it and the loading state would stay `true` forever

**Closing issues**

- #1716 