### PR TITLE
create useModalForm hook for headless usage with react-hook-form 

### DIFF
--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@pankod/refine-core": "^3.14.1",
-    "react-hook-form": "^7.22.1"
+    "react-hook-form": "^7.30.0"
   },
   "gitHead": "829f5a516f98c06f666d6be3e6e6099c75c07719",
   "publishConfig": {

--- a/packages/react-hook-form/src/index.ts
+++ b/packages/react-hook-form/src/index.ts
@@ -4,6 +4,11 @@ export {
     UseStepsFormProps,
     UseStepsFormReturnType,
 } from "./useStepsForm";
+export {
+    useModalForm,
+    UseModalFormProps,
+    UseModalFormReturnType,
+} from "./useModalForm";
 
 export type {
     BatchFieldArrayUpdate,

--- a/packages/react-hook-form/src/useForm/index.ts
+++ b/packages/react-hook-form/src/useForm/index.ts
@@ -56,9 +56,6 @@ export const useForm = <
         warnWhenUnsavedChangesProp ?? warnWhenUnsavedChangesRefine;
 
     const useFormCoreResult = useFormCore<TData, TError, TVariables>({
-        onMutationSuccess: () => {
-            reset();
-        },
         ...refineCoreProps,
     });
 
@@ -82,6 +79,10 @@ export const useForm = <
         );
 
         reset(fields as any);
+
+        return () => {
+            reset();
+        };
     }, [queryResult?.data]);
 
     useEffect(() => {

--- a/packages/react-hook-form/src/useModalForm/index.spec.ts
+++ b/packages/react-hook-form/src/useModalForm/index.spec.ts
@@ -1,0 +1,184 @@
+import { renderHook } from "@testing-library/react-hooks";
+
+import { TestWrapper } from "../../test";
+
+import { useModalForm } from "./";
+
+describe("useModalForm Hook", () => {
+    it("should return correct initial value of 'visible'", () => {
+        const { result } = renderHook(() => useModalForm(), {
+            wrapper: TestWrapper({}),
+        });
+
+        expect(result.current.modal.visible).toBe(false);
+    });
+
+    it("'visible' initial value should be set with 'defaultVisible'", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    modalOptions: {
+                        defaultVisible: true,
+                    },
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        expect(result.current.modal.visible).toBe(true);
+    });
+
+    it("'visible' value should be false when 'close' is called", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    modalOptions: {
+                        defaultVisible: true,
+                    },
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        result.current.modal.close();
+
+        expect(result.current.modal.visible).toBe(false);
+    });
+
+    it("'visible' value should be true when 'show' is called", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    modalOptions: {
+                        defaultVisible: false,
+                    },
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        result.current.modal.show();
+
+        expect(result.current.modal.visible).toBe(true);
+    });
+
+    it("'id' should be updated when 'show' is called with 'id'", async () => {
+        const { result } = renderHook(() => useModalForm(), {
+            wrapper: TestWrapper({}),
+        });
+
+        const id = "5";
+
+        result.current.modal.show(id);
+
+        expect(result.current.refineCore.id).toBe(id);
+    });
+
+    it("'title' should be set with 'action' and 'resource'", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    refineCoreProps: {
+                        resource: "test",
+                        action: "edit",
+                    },
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        expect(result.current.modal.title).toBe("Edit test");
+    });
+
+    it("when 'autoSubmitClose' is true, 'close' should be called when 'submit' is called", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    modalOptions: {
+                        autoSubmitClose: true,
+                    },
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        result.current.modal.close();
+        result.current.modal.submit({});
+
+        expect(result.current.modal.visible).toBe(false);
+    });
+
+    it("when 'autoSubmitClose' is false, 'close' should not be called when 'submit' is called", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    modalOptions: {
+                        autoSubmitClose: false,
+                    },
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        result.current.modal.show();
+        result.current.modal.submit({});
+
+        expect(result.current.modal.visible).toBe(true);
+    });
+
+    it("autoResetForm is true, 'reset' should be called when 'submit' is called", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    modalOptions: {
+                        autoResetForm: true,
+                    },
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        const reset = jest.fn();
+
+        result.current.reset = reset;
+
+        result.current.modal.show();
+        result.current.register("test");
+        result.current.setValue("test", "test");
+        result.current.modal.submit({ test: "test" });
+
+        expect(result.current.getValues()).toStrictEqual({});
+    });
+
+    it("autoResetForm is false, 'reset' should not be called when 'submit' is called", async () => {
+        const { result } = renderHook(
+            () =>
+                useModalForm({
+                    modalOptions: {
+                        autoResetForm: false,
+                    },
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        const reset = jest.fn();
+
+        result.current.reset = reset;
+
+        result.current.modal.show();
+        result.current.register("test");
+        result.current.setValue("test", "test");
+        result.current.modal.submit({ test: "test" });
+
+        expect(result.current.getValues()).toStrictEqual({ test: "test" });
+    });
+});

--- a/packages/react-hook-form/src/useModalForm/index.spec.ts
+++ b/packages/react-hook-form/src/useModalForm/index.spec.ts
@@ -17,6 +17,9 @@ describe("useModalForm Hook", () => {
         const { result } = renderHook(
             () =>
                 useModalForm({
+                    refineCoreProps: {
+                        resource: "posts",
+                    },
                     modalOptions: {
                         defaultVisible: true,
                     },
@@ -98,6 +101,9 @@ describe("useModalForm Hook", () => {
         const { result } = renderHook(
             () =>
                 useModalForm({
+                    refineCoreProps: {
+                        resource: "posts",
+                    },
                     modalOptions: {
                         autoSubmitClose: true,
                     },
@@ -117,6 +123,9 @@ describe("useModalForm Hook", () => {
         const { result } = renderHook(
             () =>
                 useModalForm({
+                    refineCoreProps: {
+                        resource: "posts",
+                    },
                     modalOptions: {
                         autoSubmitClose: false,
                     },
@@ -133,9 +142,13 @@ describe("useModalForm Hook", () => {
     });
 
     it("autoResetForm is true, 'reset' should be called when 'submit' is called", async () => {
-        const { result } = renderHook(
+        const { result, waitFor } = renderHook(
             () =>
                 useModalForm({
+                    refineCoreProps: {
+                        resource: "posts",
+                        action: "create",
+                    },
                     modalOptions: {
                         autoResetForm: true,
                     },
@@ -145,14 +158,12 @@ describe("useModalForm Hook", () => {
             },
         );
 
-        const reset = jest.fn();
-
-        result.current.reset = reset;
-
         result.current.modal.show();
         result.current.register("test");
         result.current.setValue("test", "test");
         result.current.modal.submit({ test: "test" });
+
+        await waitFor(() => result.current.refineCore.mutationResult.isSuccess);
 
         expect(result.current.getValues()).toStrictEqual({});
     });
@@ -161,6 +172,9 @@ describe("useModalForm Hook", () => {
         const { result } = renderHook(
             () =>
                 useModalForm({
+                    refineCoreProps: {
+                        resource: "posts",
+                    },
                     modalOptions: {
                         autoResetForm: false,
                     },
@@ -169,10 +183,6 @@ describe("useModalForm Hook", () => {
                 wrapper: TestWrapper({}),
             },
         );
-
-        const reset = jest.fn();
-
-        result.current.reset = reset;
 
         result.current.modal.show();
         result.current.register("test");

--- a/packages/react-hook-form/src/useModalForm/index.ts
+++ b/packages/react-hook-form/src/useModalForm/index.ts
@@ -1,0 +1,156 @@
+import { useCallback } from "react";
+import {
+    BaseKey,
+    BaseRecord,
+    HttpError,
+    useModal,
+    useResource,
+    userFriendlyResourceName,
+    useTranslate,
+    useWarnAboutChange,
+} from "@pankod/refine-core";
+import { FieldValues } from "react-hook-form";
+
+import { useForm, UseFormProps, UseFormReturnType } from "../useForm";
+
+export type UseModalFormReturnType<
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+    TVariables extends FieldValues = FieldValues,
+    TContext extends object = {},
+> = UseFormReturnType<TData, TError, TVariables, TContext> & {
+    modal: {
+        submitButtonProps: {
+            disabled: boolean;
+            onClick: (values: TVariables) => void;
+            loading: boolean;
+        };
+        submit: (values: TVariables) => void;
+        close: () => void;
+        show: (id?: BaseKey) => void;
+        visible: boolean;
+        title: string;
+    };
+};
+
+export type UseModalFormProps<
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+    TVariables extends FieldValues = FieldValues,
+    TContext extends object = {},
+> = UseFormProps<TData, TError, TVariables, TContext> & {
+    modalOptions?: {
+        defaultVisible?: boolean;
+        autoSubmitClose?: boolean;
+        autoResetForm?: boolean;
+    };
+};
+
+export const useModalForm = <
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+    TVariables extends FieldValues = FieldValues,
+    TContext extends object = {},
+>({
+    modalOptions,
+    refineCoreProps,
+    ...rest
+}: UseModalFormProps<
+    TData,
+    TError,
+    TVariables,
+    TContext
+> = {}): UseModalFormReturnType<TData, TError, TVariables, TContext> => {
+    const translate = useTranslate();
+
+    const { resource: resourceProp, action: actionProp } =
+        refineCoreProps ?? {};
+    const {
+        defaultVisible = false,
+        autoSubmitClose = true,
+        autoResetForm = true,
+    } = modalOptions ?? {};
+
+    const useHookFormResult = useForm({
+        refineCoreProps,
+        ...rest,
+    });
+
+    const {
+        reset,
+        refineCore: { onFinish, formLoading, setId },
+    } = useHookFormResult;
+
+    const { visible, show, close } = useModal({
+        defaultVisible,
+    });
+
+    const submit = async (values: TVariables) => {
+        await onFinish(values);
+
+        if (autoSubmitClose) {
+            close();
+        }
+
+        if (autoResetForm) {
+            reset();
+        }
+    };
+
+    const { resourceName } = useResource({
+        resourceNameOrRouteName: resourceProp,
+    });
+
+    const { warnWhen, setWarnWhen } = useWarnAboutChange();
+    const handleClose = useCallback(() => {
+        if (warnWhen) {
+            const warnWhenConfirm = window.confirm(
+                translate(
+                    "warnWhenUnsavedChanges",
+                    "Are you sure you want to leave? You have unsaved changes.",
+                ),
+            );
+
+            if (warnWhenConfirm) {
+                setWarnWhen(false);
+            } else {
+                return;
+            }
+        }
+
+        setId?.(undefined);
+        close();
+    }, [warnWhen]);
+
+    const handleShow = useCallback((id?: BaseKey) => {
+        setId?.(id);
+
+        show();
+    }, []);
+
+    const submitButtonProps = {
+        disabled: formLoading,
+        onClick: submit,
+        loading: formLoading,
+    };
+
+    const title = translate(
+        `${resourceName}.titles.${actionProp}`,
+        `${userFriendlyResourceName(
+            `${actionProp} ${resourceName}`,
+            "singular",
+        )}`,
+    );
+
+    return {
+        modal: {
+            submitButtonProps,
+            submit,
+            close: handleClose,
+            show: handleShow,
+            visible,
+            title,
+        },
+        ...useHookFormResult,
+    };
+};


### PR DESCRIPTION
Hey, I'm client! Test me! 'MASTER'
[Link to HEADLESS-USE-MODAL-FORM](https://headles-client.refine.pankod.com)

Test me! 'MASTER'
[Link to HEADLESS-USE-MODAL-FORM](https://headles-refine.pankod.com)

