### PR TITLE
Add hash router support for react-router-v6

### DIFF
--- a/packages/react-router-v6/src/index.ts
+++ b/packages/react-router-v6/src/index.ts
@@ -12,6 +12,7 @@ import {
 import {
     BrowserRouterComponent,
     MemoryRouterComponent,
+    HashRouterComponent,
 } from "./routerComponent";
 import { Prompt } from "./prompt";
 
@@ -60,4 +61,4 @@ const RouterProvider: IReactRouterProvider = {
 };
 export default RouterProvider;
 
-export { MemoryRouterComponent };
+export { MemoryRouterComponent, HashRouterComponent };

--- a/packages/react-router-v6/src/routerComponent.tsx
+++ b/packages/react-router-v6/src/routerComponent.tsx
@@ -5,6 +5,8 @@ import {
     BrowserRouterProps,
     MemoryRouter,
     MemoryRouterProps,
+    HashRouter,
+    HashRouterProps,
 } from "react-router-dom";
 
 import { RouteProvider } from "./routeProvider";
@@ -30,5 +32,17 @@ export const MemoryRouterComponent: React.FC<MemoryRouterProps> = ({
             <RouteProvider />
             {children}
         </MemoryRouter>
+    );
+};
+
+export const HashRouterComponent: React.FC<HashRouterProps> = ({
+    children,
+    ...props
+}) => {
+    return (
+        <HashRouter {...props}>
+            <RouteProvider />
+            {children}
+        </HashRouter>
     );
 };


### PR DESCRIPTION
Test me! 'MASTER'
[Link to REACT-ROUTER-V6-HASH-ROUTER-SUPPORT](https://react-r-refine.pankod.com)

Added hash router support for react-router v6