### PR TITLE
[Improvement] Move getDefaultFilter and getDefaultSorter to core package

### DIFF
--- a/documentation/docs/core/interfaces.md
+++ b/documentation/docs/core/interfaces.md
@@ -72,6 +72,14 @@ title: Interface References
 | `"asc"`      | Ascending order  |
 | `"desc"`     | Descending order |
 
+## SortOrder
+```ts
+"desc" |
+    "asc" |
+    "null";
+
+```
+
 ## Pagination
 
 | Key      | Type     |

--- a/documentation/docs/ui-frameworks/antd/components/filter-dropdown.md
+++ b/documentation/docs/ui-frameworks/antd/components/filter-dropdown.md
@@ -105,13 +105,13 @@ Determines the value passed to children. `mapValue` takes `selectedKeys` as an a
 For example when using `useSelect` for `<Select>` component. In this case values must be mapped to `number`s using `mapValue`.
 
 ```tsx 
+import { getDefaultFilter } from "@pankod/refine-core";
 import {
     useTable,
     Table,
     FilterDropdown,
     Select,
     useSelect,
-    getDefaultFilter,
 } from "@pankod/refine-antd";
 
 const { tableProps, filters } = useTable<IPost>({

--- a/documentation/docs/ui-frameworks/antd/hooks/table/useTable.md
+++ b/documentation/docs/ui-frameworks/antd/hooks/table/useTable.md
@@ -305,14 +305,14 @@ const { tableProps, sorter, filters } = useTable<IPost>({
 If you give default filter values, `defaultFilteredValue` property needs to be properly given to the relevant `<Table.Column>` components so that those filter fields come with default values when the page is opened.
 
 ```tsx title="/src/pages/posts/list.tsx"
+// highlight-next-line
+import { getDefaultFilter } from "@pankod/refine-core";
 import {
     List,
     Table,
     Radio,
     FilterDropdown,
     TagField,
-    // highlight-next-line
-    getDefaultFilter,
     useTable,
     getDefaultSortOrder,
 } from "@pankod/refine-antd";

--- a/examples/base/src/pages/posts/list.tsx
+++ b/examples/base/src/pages/posts/list.tsx
@@ -1,4 +1,8 @@
-import { IResourceComponentsProps, useMany } from "@pankod/refine-core";
+import {
+    IResourceComponentsProps,
+    useMany,
+    getDefaultFilter,
+} from "@pankod/refine-core";
 
 import {
     List,
@@ -11,7 +15,6 @@ import {
     Select,
     Radio,
     TagField,
-    getDefaultFilter,
 } from "@pankod/refine-antd";
 
 import { useTable, useSelect } from "@pankod/refine-antd";

--- a/examples/dataProvider/hasura/src/pages/posts/list.tsx
+++ b/examples/dataProvider/hasura/src/pages/posts/list.tsx
@@ -1,4 +1,7 @@
-import { IResourceComponentsProps } from "@pankod/refine-core";
+import {
+    IResourceComponentsProps,
+    getDefaultFilter,
+} from "@pankod/refine-core";
 
 import {
     List,
@@ -12,7 +15,6 @@ import {
     FilterDropdown,
     Select,
     useSelect,
-    getDefaultFilter,
     DateField,
 } from "@pankod/refine-antd";
 

--- a/examples/dataProvider/multiple/src/pages/posts/list.tsx
+++ b/examples/dataProvider/multiple/src/pages/posts/list.tsx
@@ -1,4 +1,8 @@
-import { IResourceComponentsProps, useMany } from "@pankod/refine-core";
+import {
+    IResourceComponentsProps,
+    useMany,
+    getDefaultFilter,
+} from "@pankod/refine-core";
 
 import {
     List,
@@ -11,13 +15,11 @@ import {
     Select,
     Radio,
     TagField,
-    getDefaultFilter,
     Collapse,
     useTable,
     useSelect,
     useSimpleList,
     AntdList,
-    NumberField,
 } from "@pankod/refine-antd";
 
 import { IPost, ICategory, IProducts } from "interfaces";

--- a/examples/dataProvider/nhost/src/pages/posts/list.tsx
+++ b/examples/dataProvider/nhost/src/pages/posts/list.tsx
@@ -1,4 +1,7 @@
-import { IResourceComponentsProps } from "@pankod/refine-core";
+import {
+    IResourceComponentsProps,
+    getDefaultFilter,
+} from "@pankod/refine-core";
 
 import {
     List,
@@ -12,7 +15,6 @@ import {
     FilterDropdown,
     Select,
     useSelect,
-    getDefaultFilter,
     DateField,
     ImageField,
 } from "@pankod/refine-antd";

--- a/examples/dataProvider/strapi/src/pages/posts/list.tsx
+++ b/examples/dataProvider/strapi/src/pages/posts/list.tsx
@@ -1,4 +1,7 @@
-import { IResourceComponentsProps } from "@pankod/refine-core";
+import {
+    IResourceComponentsProps,
+    getDefaultFilter,
+} from "@pankod/refine-core";
 
 import {
     List,
@@ -7,7 +10,6 @@ import {
     getDefaultSortOrder,
     FilterDropdown,
     Select,
-    getDefaultFilter,
     useSelect,
     DateField,
     Space,

--- a/examples/fineFoods/admin/src/pages/orders/list.tsx
+++ b/examples/fineFoods/admin/src/pages/orders/list.tsx
@@ -5,6 +5,7 @@ import {
     useExport,
     useNavigation,
     HttpError,
+    getDefaultFilter,
 } from "@pankod/refine-core";
 
 import {
@@ -28,7 +29,6 @@ import {
     Row,
     Col,
     ExportButton,
-    getDefaultFilter,
 } from "@pankod/refine-antd";
 
 import dayjs from "dayjs";

--- a/examples/fineFoods/admin/src/pages/products/list.tsx
+++ b/examples/fineFoods/admin/src/pages/products/list.tsx
@@ -3,6 +3,7 @@ import {
     IResourceComponentsProps,
     CrudFilters,
     HttpError,
+    getDefaultFilter,
 } from "@pankod/refine-core";
 
 import {
@@ -16,7 +17,6 @@ import {
     Icons,
     Typography,
     useDrawerForm,
-    getDefaultFilter,
 } from "@pankod/refine-antd";
 
 const { Text } = Typography;

--- a/examples/multi-level-menu/src/pages/posts/list.tsx
+++ b/examples/multi-level-menu/src/pages/posts/list.tsx
@@ -1,4 +1,8 @@
-import { IResourceComponentsProps, useMany } from "@pankod/refine-core";
+import {
+    IResourceComponentsProps,
+    useMany,
+    getDefaultFilter,
+} from "@pankod/refine-core";
 
 import {
     List,
@@ -11,7 +15,6 @@ import {
     Select,
     Radio,
     TagField,
-    getDefaultFilter,
 } from "@pankod/refine-antd";
 
 import { useTable, useSelect } from "@pankod/refine-antd";

--- a/examples/table/useTable/src/pages/posts/list.tsx
+++ b/examples/table/useTable/src/pages/posts/list.tsx
@@ -1,11 +1,14 @@
-import { IResourceComponentsProps, useMany } from "@pankod/refine-core";
+import {
+    IResourceComponentsProps,
+    useMany,
+    getDefaultFilter,
+} from "@pankod/refine-core";
 
 import {
     List,
     Table,
     Radio,
     FilterDropdown,
-    getDefaultFilter,
     TagField,
     useTable,
     getDefaultSortOrder,

--- a/examples/vite/src/pages/posts/list.tsx
+++ b/examples/vite/src/pages/posts/list.tsx
@@ -1,4 +1,8 @@
-import { IResourceComponentsProps, useMany } from "@pankod/refine-core";
+import {
+    IResourceComponentsProps,
+    useMany,
+    getDefaultFilter,
+} from "@pankod/refine-core";
 
 import {
     List,
@@ -11,7 +15,6 @@ import {
     Select,
     Radio,
     TagField,
-    getDefaultFilter,
 } from "@pankod/refine-antd";
 
 import { useTable, useSelect } from "@pankod/refine-antd";

--- a/packages/antd/src/definitions/table/index.ts
+++ b/packages/antd/src/definitions/table/index.ts
@@ -3,7 +3,8 @@ import {
     CrudOperators,
     CrudSorting,
     CrudFilter,
-    LogicalFilter,
+    getDefaultFilter as getDefaultFilterCore,
+    getDefaultSortOrder as getDefaultSortOrderCore,
 } from "@pankod/refine-core";
 import { SortOrder, SorterResult } from "antd/lib/table/interface";
 
@@ -11,37 +12,24 @@ export const getDefaultSortOrder = (
     columnName: string,
     sorter?: CrudSorting,
 ): SortOrder | undefined => {
-    if (!sorter) {
-        return undefined;
-    }
+    const sort = getDefaultSortOrderCore(columnName, sorter);
 
-    const sortItem = sorter.find((item) => item.field === columnName);
-
-    if (sortItem) {
-        return `${sortItem.order}end` as SortOrder;
+    if (sort) {
+        return `${sort}end`;
     }
 
     return undefined;
 };
 
+/**
+ * @deprecated getDefaultFilter moved to `@pankod/refine-core`. Use from `@pankod/refine-core`
+ */
 export const getDefaultFilter = (
     columnName: string,
     filters?: CrudFilters,
     operatorType: CrudOperators = "eq",
 ): CrudFilter["value"] | undefined => {
-    const filter = filters?.find((filter) => {
-        if (filter.operator !== "or") {
-            const { operator, field } = filter;
-            return field === columnName && operator === operatorType;
-        }
-        return undefined;
-    });
-
-    if (filter) {
-        return filter.value || [];
-    }
-
-    return undefined;
+    return getDefaultFilterCore(columnName, filters, operatorType);
 };
 
 export const mapAntdSorterToCrudSorting = (

--- a/packages/core/src/contexts/data/IDataContext.ts
+++ b/packages/core/src/contexts/data/IDataContext.ts
@@ -42,6 +42,8 @@ export type CrudOperators =
     | "nnull"
     | "or";
 
+export type SortOrder = "desc" | "asc" | null;
+
 export type LogicalFilter = {
     field: string;
     operator: Exclude<CrudOperators, "or">;

--- a/packages/core/src/definitions/table/index.spec.ts
+++ b/packages/core/src/definitions/table/index.spec.ts
@@ -6,10 +6,61 @@ import {
     compareFilters,
     compareSorters,
     unionSorters,
+    getDefaultSortOrder,
+    getDefaultFilter,
 } from "./";
 import { CrudSorting, CrudFilters } from "../../interfaces";
 
 describe("definitions/table", () => {
+    it("getDefaultSortOrder", () => {
+        const sorter: CrudSorting = [
+            {
+                field: "title",
+                order: "asc",
+            },
+            {
+                field: "view",
+                order: "desc",
+            },
+        ];
+
+        expect(getDefaultSortOrder("title", sorter)).toEqual("asc");
+        expect(getDefaultSortOrder("view", sorter)).toEqual("desc");
+    });
+
+    it("getDefaultFilter", () => {
+        const filters: CrudFilters = [
+            {
+                field: "title",
+                operator: "contains",
+                value: "test",
+            },
+        ];
+        expect(getDefaultFilter("title", filters, "contains")).toEqual("test");
+    });
+
+    it("getDefaultFilter empty array", () => {
+        const filters: CrudFilters = [
+            {
+                field: "title",
+                operator: "contains",
+                value: undefined,
+            },
+        ];
+        expect(getDefaultFilter("title", filters, "contains")).toEqual([]);
+    });
+
+    it("getDefaultFilter default operator", () => {
+        const filters: CrudFilters = [
+            {
+                field: "title",
+                operator: "eq",
+                value: "test",
+            },
+        ];
+        expect(getDefaultFilter("title", filters)).toEqual("test");
+    });
+
     it("stringify table params correctly", async () => {
         const pagination = {
             current: 1,

--- a/packages/core/src/definitions/table/index.ts
+++ b/packages/core/src/definitions/table/index.ts
@@ -8,6 +8,8 @@ import {
     CrudSorting,
     CrudFilter,
     CrudSort,
+    CrudOperators,
+    SortOrder,
 } from "../../interfaces";
 
 export const parseTableParams = (url: string) => {
@@ -108,3 +110,40 @@ export const setInitialSorters = (
     ...differenceWith(defaultSorter, permanentSorter, compareSorters),
     ...permanentSorter,
 ];
+
+export const getDefaultSortOrder = (
+    columnName: string,
+    sorter?: CrudSorting,
+): SortOrder | undefined => {
+    if (!sorter) {
+        return undefined;
+    }
+
+    const sortItem = sorter.find((item) => item.field === columnName);
+
+    if (sortItem) {
+        return sortItem.order as SortOrder;
+    }
+
+    return undefined;
+};
+
+export const getDefaultFilter = (
+    columnName: string,
+    filters?: CrudFilters,
+    operatorType: CrudOperators = "eq",
+): CrudFilter["value"] | undefined => {
+    const filter = filters?.find((filter) => {
+        if (filter.operator !== "or") {
+            const { operator, field } = filter;
+            return field === columnName && operator === operatorType;
+        }
+        return undefined;
+    });
+
+    if (filter) {
+        return filter.value || [];
+    }
+
+    return undefined;
+};

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -25,6 +25,7 @@ export {
     CrudOperators,
     CrudSorting,
     CrudSort,
+    SortOrder,
     GetListResponse,
     GetOneResponse,
     GetManyResponse,
@@ -63,6 +64,8 @@ export {
     setInitialFilters,
     unionSorters,
     setInitialSorters,
+    getDefaultFilter,
+    getDefaultSortOrder,
 } from "./definitions/table";
 export {
     userFriendlyResourceName,


### PR DESCRIPTION
Test me! 'MASTER'
[Link to REFACTOR-GET-DEFAULT-FILTER-AND-SORTER](https://refacto-refine.pankod.com)

Please provide enough information so that others can review your pull request:

We also needed the getDefaultFilter and getDefaultSorter helper functions in the "@pankod/refine-mui" package. We moved these two functions from `@pankod/refine-antd` package to `@pankod/refine-core`. We also marked it as deprecated in the `@pankod/refine-antd` package but this does not cause a Breaking Change 🎉
