### PR TITLE
[Bug] Fix syncWithLocation reset issue on useTable hook

### DIFF
--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -107,37 +107,21 @@ export const useTable = <
 
     const resource = resourceWithRoute(resourceFromProp ?? routeResourceName);
 
-    const [sorter, setSorter] = useState<CrudSorting>(permanentSorter);
-
-    const [filters, setFilters] = useState<CrudFilters>(permanentFilter);
+    const [sorter, setSorter] = useState<CrudSorting>(
+        setInitialSorters(permanentSorter, initialSorter ?? []),
+    );
+    const [filters, setFilters] = useState<CrudFilters>(
+        setInitialFilters(permanentFilter, initialFilter ?? []),
+    );
     const [current, setCurrent] = useState<number>(initialCurrent);
     const [pageSize, setPageSize] = useState<number>(initialPageSize);
 
     useEffect(() => {
-        if (syncWithLocation) {
-            const {
-                parsedCurrent,
-                parsedPageSize,
-                parsedSorter,
-                parsedFilters,
-            } = parseTableParams(search);
-
-            setCurrent(parsedCurrent || initialCurrent);
-            setPageSize(parsedPageSize || initialPageSize);
-
-            setSorter(
-                setInitialSorters(
-                    permanentSorter,
-                    parsedSorter.length ? parsedSorter : [],
-                ),
-            );
-
-            setFilters(
-                setInitialFilters(
-                    permanentFilter,
-                    parsedFilters.length ? parsedFilters : [],
-                ),
-            );
+        if (syncWithLocation && search === "") {
+            setCurrent(initialCurrent);
+            setPageSize(initialPageSize);
+            setSorter(setInitialSorters(permanentSorter, initialSorter ?? []));
+            setFilters(setInitialFilters(permanentFilter, initialFilter ?? []));
         }
     }, [syncWithLocation, search]);
 

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -100,6 +100,21 @@ export const useTable = <
     const { search, pathname } = useLocation();
     const liveMode = useLiveMode(liveModeFromProp);
 
+    let defaultCurrent = initialCurrent;
+    let defaultPageSize = initialPageSize;
+    let defaultSorter = initialSorter;
+    let defaultFilter = initialFilter;
+
+    if (syncWithLocation) {
+        const { parsedCurrent, parsedPageSize, parsedSorter, parsedFilters } =
+            parseTableParams(search);
+
+        defaultCurrent = parsedCurrent || defaultCurrent;
+        defaultPageSize = parsedPageSize || defaultPageSize;
+        defaultSorter = parsedSorter.length ? parsedSorter : defaultSorter;
+        defaultFilter = parsedFilters.length ? parsedFilters : defaultFilter;
+    }
+
     const { resource: routeResourceName } = useParams<ResourceRouterParams>();
 
     const { push } = useNavigation();
@@ -108,20 +123,20 @@ export const useTable = <
     const resource = resourceWithRoute(resourceFromProp ?? routeResourceName);
 
     const [sorter, setSorter] = useState<CrudSorting>(
-        setInitialSorters(permanentSorter, initialSorter ?? []),
+        setInitialSorters(permanentSorter, defaultSorter ?? []),
     );
     const [filters, setFilters] = useState<CrudFilters>(
-        setInitialFilters(permanentFilter, initialFilter ?? []),
+        setInitialFilters(permanentFilter, defaultFilter ?? []),
     );
-    const [current, setCurrent] = useState<number>(initialCurrent);
-    const [pageSize, setPageSize] = useState<number>(initialPageSize);
+    const [current, setCurrent] = useState<number>(defaultCurrent);
+    const [pageSize, setPageSize] = useState<number>(defaultPageSize);
 
     useEffect(() => {
         if (syncWithLocation && search === "") {
-            setCurrent(initialCurrent);
-            setPageSize(initialPageSize);
-            setSorter(setInitialSorters(permanentSorter, initialSorter ?? []));
-            setFilters(setInitialFilters(permanentFilter, initialFilter ?? []));
+            setCurrent(defaultCurrent);
+            setPageSize(defaultPageSize);
+            setSorter(setInitialSorters(permanentSorter, defaultSorter ?? []));
+            setFilters(setInitialFilters(permanentFilter, defaultFilter ?? []));
         }
     }, [syncWithLocation, search]);
 

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -100,21 +100,6 @@ export const useTable = <
     const { search, pathname } = useLocation();
     const liveMode = useLiveMode(liveModeFromProp);
 
-    let defaultCurrent = initialCurrent;
-    let defaultPageSize = initialPageSize;
-    let defaultSorter = initialSorter;
-    let defaultFilter = initialFilter;
-
-    if (syncWithLocation) {
-        const { parsedCurrent, parsedPageSize, parsedSorter, parsedFilters } =
-            parseTableParams(search);
-
-        defaultCurrent = parsedCurrent || defaultCurrent;
-        defaultPageSize = parsedPageSize || defaultPageSize;
-        defaultSorter = parsedSorter.length ? parsedSorter : defaultSorter;
-        defaultFilter = parsedFilters.length ? parsedFilters : defaultFilter;
-    }
-
     const { resource: routeResourceName } = useParams<ResourceRouterParams>();
 
     const { push } = useNavigation();
@@ -122,15 +107,39 @@ export const useTable = <
 
     const resource = resourceWithRoute(resourceFromProp ?? routeResourceName);
 
-    const [sorter, setSorter] = useState<CrudSorting>(
-        setInitialSorters(permanentSorter, defaultSorter ?? []),
-    );
+    const [sorter, setSorter] = useState<CrudSorting>(permanentSorter);
 
-    const [filters, setFilters] = useState<CrudFilters>(
-        setInitialFilters(permanentFilter, defaultFilter ?? []),
-    );
-    const [current, setCurrent] = useState<number>(defaultCurrent);
-    const [pageSize, setPageSize] = useState<number>(defaultPageSize);
+    const [filters, setFilters] = useState<CrudFilters>(permanentFilter);
+    const [current, setCurrent] = useState<number>(initialCurrent);
+    const [pageSize, setPageSize] = useState<number>(initialPageSize);
+
+    useEffect(() => {
+        if (syncWithLocation) {
+            const {
+                parsedCurrent,
+                parsedPageSize,
+                parsedSorter,
+                parsedFilters,
+            } = parseTableParams(search);
+
+            setCurrent(parsedCurrent || initialCurrent);
+            setPageSize(parsedPageSize || initialPageSize);
+
+            setSorter(
+                setInitialSorters(
+                    permanentSorter,
+                    parsedSorter.length ? parsedSorter : [],
+                ),
+            );
+
+            setFilters(
+                setInitialFilters(
+                    permanentFilter,
+                    parsedFilters.length ? parsedFilters : [],
+                ),
+            );
+        }
+    }, [syncWithLocation, search]);
 
     useEffect(() => {
         if (syncWithLocation) {


### PR DESCRIPTION
Test me! 'MASTER'
[Link to USE-TABLE-SYNC-WITH-LOCATION-BUG](https://use-tab-refine.pankod.com)

Hey, I'm client! Test me! 'MASTER'
[Link to USE-TABLE-SYNC-WITH-LOCATION-BUG](https://use-tab-client.refine.pankod.com)

Test me! 'MASTER'
[Link to USE-TABLE-SYNC-WITH-LOCATION-BUG](https://use-tab-refine.pankod.com)

Please provide enough information so that others can review your pull request:

In the `useTable` hook `sycnWithLocation` was not watching the URL changes. As a result, the values followed by the URL, such as pagination, were not reset to initial values when the same resource was selected from the Sider. The `useTable` hook now watches the URL and the filters can be reset.

**Closing issues**

- #1810 