### PR TITLE
Fix useForm initialValues issue

### DIFF
--- a/packages/antd/src/hooks/form/useForm.ts
+++ b/packages/antd/src/hooks/form/useForm.ts
@@ -113,10 +113,7 @@ export const useForm = <
         warnWhenUnsavedChangesProp ?? warnWhenUnsavedChangesRefine;
 
     React.useEffect(() => {
-        form.setFieldsValue(queryResult?.data?.data as any);
-        return () => {
-            form.resetFields();
-        };
+        form.resetFields();
     }, [queryResult?.data?.data, id]);
 
     const onKeyUp = (event: React.KeyboardEvent<HTMLFormElement>) => {
@@ -146,6 +143,7 @@ export const useForm = <
             onFinish,
             onKeyUp,
             onValuesChange,
+            initialValues: queryResult?.data?.data,
         },
         saveButtonProps,
         ...useFormCoreResult,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Ant Design Form's `setFieldsValue` method was making all fields `touched`. it's better to use `initialValues` instead


**Closing issues**

