### PR TITLE
fix(useTable): useTable creating nested <a> tag in Pagination component

### DIFF
--- a/.changeset/fluffy-dolphins-tell.md
+++ b/.changeset/fluffy-dolphins-tell.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": patch
+---
+
+Fix #1858 `useTable` creating nested `<a>` tag in Pagination component

--- a/packages/antd/src/hooks/table/useTable/useTable.ts
+++ b/packages/antd/src/hooks/table/useTable/useTable.ts
@@ -1,4 +1,4 @@
-import { createElement } from "react";
+import React, { cloneElement, createElement } from "react";
 import { Grid, FormProps, Form, TablePaginationConfig, TableProps } from "antd";
 import { QueryObserverResult } from "react-query";
 import { useForm as useFormSF } from "sunflower-antd";
@@ -169,10 +169,29 @@ export const useTable = <
                         sorter,
                         filters,
                     });
-                    return createElement(PaginationLink, {
-                        to: link,
-                        element,
-                    });
+
+                    if (type === "page") {
+                        return createElement(PaginationLink, {
+                            to: link,
+                            element: page,
+                        });
+                    }
+                    if (type === "next" || type === "prev") {
+                        return createElement(PaginationLink, {
+                            to: link,
+                            element: element,
+                        });
+                    }
+
+                    if (type === "jump-next" || type === "jump-prev") {
+                        return createElement(PaginationLink, {
+                            to: link,
+                            element: (element as React.ReactElement)?.props
+                                ?.children,
+                        });
+                    }
+
+                    return element;
                 },
                 pageSize,
                 current,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Fix #1858 `useTable` creating nested `<a>` tag in `Pagination` component. 

@rassie, if you have time could you review it? Thank you!

**Closing issues**

- #1858