### PR TITLE
refactor: remove default values from refine contexts

### DIFF
--- a/.changeset/late-gifts-camp.md
+++ b/.changeset/late-gifts-camp.md
@@ -1,6 +1,8 @@
 ---
 "@pankod/refine-antd": patch
 "@pankod/refine-core": patch
+"@pankod/refine-nextjs-router": patch
+"@pankod/refine-react-hook-form": patch
 ---
 
 Removed dummy default values from internal contexts.

--- a/.changeset/late-gifts-camp.md
+++ b/.changeset/late-gifts-camp.md
@@ -13,4 +13,5 @@ Updated contexts:
 -   Notification
 -   Translation (i18n)
 -   unsavedWarn
--   **BREAKING:** `useGetLocale` hook now can return `undefined` instead of a fallback value of `en` in cases of `i18nProvider` being `undefined`.
+
+**BREAKING:** `useGetLocale` hook now can return `undefined` instead of a fallback value of `en` in cases of `i18nProvider` being `undefined`.

--- a/.changeset/late-gifts-camp.md
+++ b/.changeset/late-gifts-camp.md
@@ -1,0 +1,13 @@
+---
+"@pankod/refine-antd": minor
+"@pankod/refine-core": minor
+---
+
+Removed dummy default values from internal contexts.
+Updated contexts:
+
+-   Auth
+-   Access Control
+-   Notification
+-   Translation (i18n)
+-   unsavedWarn

--- a/.changeset/late-gifts-camp.md
+++ b/.changeset/late-gifts-camp.md
@@ -1,6 +1,6 @@
 ---
-"@pankod/refine-antd": minor
-"@pankod/refine-core": minor
+"@pankod/refine-antd": patch
+"@pankod/refine-core": patch
 ---
 
 Removed dummy default values from internal contexts.

--- a/.changeset/late-gifts-camp.md
+++ b/.changeset/late-gifts-camp.md
@@ -13,3 +13,4 @@ Updated contexts:
 -   Notification
 -   Translation (i18n)
 -   unsavedWarn
+-   **BREAKING:** `useGetLocale` hook now can return `undefined` instead of a fallback value of `en` in cases of `i18nProvider` being `undefined`.

--- a/documentation/docs/core/providers/i18n-provider.md
+++ b/documentation/docs/core/providers/i18n-provider.md
@@ -454,7 +454,7 @@ export const Header: React.FC = () => {
     const currentLocale = locale();
 
     const menu = (
-        <Menu selectedKeys={[currentLocale]}>
+        <Menu selectedKeys={currentLocale ? [currentLocale] : []}>
             {[...(i18n.languages || [])].sort().map((lang: string) => (
                 <Menu.Item
                     key={lang}

--- a/examples/fineFoods/admin/src/components/header/index.tsx
+++ b/examples/fineFoods/admin/src/components/header/index.tsx
@@ -167,7 +167,7 @@ export const Header: React.FC = () => {
     }, [value]);
 
     const menu = (
-        <Menu selectedKeys={[currentLocale]}>
+        <Menu selectedKeys={currentLocale ? [currentLocale] : []}>
             {[...(i18n.languages ?? [])].sort().map((lang: string) => (
                 <Menu.Item
                     key={lang}

--- a/examples/i18n/nextjs/src/components/header/index.tsx
+++ b/examples/i18n/nextjs/src/components/header/index.tsx
@@ -22,7 +22,7 @@ export const Header: React.FC = () => {
     const currentLocale = locale();
 
     const menu = (
-        <Menu selectedKeys={[currentLocale]}>
+        <Menu selectedKeys={currentLocale ? [currentLocale] : []}>
             {[...(locales || [])].sort().map((lang: string) => (
                 <Menu.Item
                     key={lang}

--- a/examples/i18n/react/src/components/header/index.tsx
+++ b/examples/i18n/react/src/components/header/index.tsx
@@ -20,7 +20,7 @@ export const Header: React.FC = () => {
     const currentLocale = locale();
 
     const menu = (
-        <Menu selectedKeys={[currentLocale]}>
+        <Menu selectedKeys={currentLocale ? [currentLocale] : []}>
             {[...(i18n.languages || [])].sort().map((lang: string) => (
                 <Menu.Item
                     key={lang}

--- a/packages/antd/src/components/crud/edit/index.spec.tsx
+++ b/packages/antd/src/components/crud/edit/index.spec.tsx
@@ -1,6 +1,6 @@
-import React, { ReactNode } from "react";
+import React, { ComponentProps, ReactNode } from "react";
 import { Route, Routes } from "react-router-dom";
-import { AccessControlProvider } from "@pankod/refine-core";
+import { Refine } from "@pankod/refine-core";
 import { Button } from "antd";
 
 import { render, TestWrapper, waitFor } from "@test";
@@ -8,7 +8,9 @@ import { Edit } from "./";
 
 const renderEdit = (
     edit: ReactNode,
-    accessControlProvider?: AccessControlProvider,
+    accessControlProvider?: ComponentProps<
+        typeof Refine
+    >["accessControlProvider"],
 ) => {
     return render(
         <Routes>

--- a/packages/antd/src/components/crud/edit/index.spec.tsx
+++ b/packages/antd/src/components/crud/edit/index.spec.tsx
@@ -1,6 +1,6 @@
-import React, { ComponentProps, ReactNode } from "react";
+import React, { ReactNode } from "react";
 import { Route, Routes } from "react-router-dom";
-import { Refine } from "@pankod/refine-core";
+import { AccessControlProvider } from "@pankod/refine-core";
 import { Button } from "antd";
 
 import { render, TestWrapper, waitFor } from "@test";
@@ -8,9 +8,7 @@ import { Edit } from "./";
 
 const renderEdit = (
     edit: ReactNode,
-    accessControlProvider?: ComponentProps<
-        typeof Refine
-    >["accessControlProvider"],
+    accessControlProvider?: AccessControlProvider,
 ) => {
     return render(
         <Routes>

--- a/packages/antd/src/components/crud/list/index.spec.tsx
+++ b/packages/antd/src/components/crud/list/index.spec.tsx
@@ -1,6 +1,6 @@
-import React, { ReactNode } from "react";
+import React, { ComponentProps, ReactNode } from "react";
 import { Route, Routes } from "react-router-dom";
-import { AccessControlProvider } from "@pankod/refine-core";
+import { Refine } from "@pankod/refine-core";
 import { Table } from "antd";
 
 import { render, TestWrapper, waitFor } from "@test";
@@ -8,7 +8,9 @@ import { List } from "./index";
 
 const renderList = (
     list: ReactNode,
-    accessControlProvider?: AccessControlProvider,
+    accessControlProvider?: ComponentProps<
+        typeof Refine
+    >["accessControlProvider"],
 ) => {
     return render(
         <Routes>

--- a/packages/antd/src/components/crud/list/index.spec.tsx
+++ b/packages/antd/src/components/crud/list/index.spec.tsx
@@ -1,6 +1,6 @@
-import React, { ComponentProps, ReactNode } from "react";
+import React, { ReactNode } from "react";
 import { Route, Routes } from "react-router-dom";
-import { Refine } from "@pankod/refine-core";
+import { AccessControlProvider } from "@pankod/refine-core";
 import { Table } from "antd";
 
 import { render, TestWrapper, waitFor } from "@test";
@@ -8,9 +8,7 @@ import { List } from "./index";
 
 const renderList = (
     list: ReactNode,
-    accessControlProvider?: ComponentProps<
-        typeof Refine
-    >["accessControlProvider"],
+    accessControlProvider?: AccessControlProvider,
 ) => {
     return render(
         <Routes>

--- a/packages/antd/src/components/crud/show/index.spec.tsx
+++ b/packages/antd/src/components/crud/show/index.spec.tsx
@@ -1,7 +1,7 @@
-import React, { ReactNode } from "react";
+import React, { ComponentProps, ReactNode } from "react";
 import { Route, Routes } from "react-router-dom";
 import { Button } from "antd";
-import { AccessControlProvider } from "@pankod/refine-core";
+import { Refine } from "@pankod/refine-core";
 
 import { render, TestWrapper, waitFor } from "@test";
 
@@ -9,7 +9,9 @@ import { Show } from "./index";
 
 const renderShow = (
     show: ReactNode,
-    accessControlProvider?: AccessControlProvider,
+    accessControlProvider?: ComponentProps<
+        typeof Refine
+    >["accessControlProvider"],
 ) => {
     return render(
         <Routes>

--- a/packages/antd/src/components/crud/show/index.spec.tsx
+++ b/packages/antd/src/components/crud/show/index.spec.tsx
@@ -1,7 +1,7 @@
-import React, { ComponentProps, ReactNode } from "react";
+import React, { ReactNode } from "react";
 import { Route, Routes } from "react-router-dom";
 import { Button } from "antd";
-import { Refine } from "@pankod/refine-core";
+import { AccessControlProvider } from "@pankod/refine-core";
 
 import { render, TestWrapper, waitFor } from "@test";
 
@@ -9,9 +9,7 @@ import { Show } from "./index";
 
 const renderShow = (
     show: ReactNode,
-    accessControlProvider?: ComponentProps<
-        typeof Refine
-    >["accessControlProvider"],
+    accessControlProvider?: AccessControlProvider,
 ) => {
     return render(
         <Routes>

--- a/packages/antd/src/providers/notificationProvider/index.spec.tsx
+++ b/packages/antd/src/providers/notificationProvider/index.spec.tsx
@@ -22,7 +22,7 @@ describe("Antd notificationProvider", () => {
     const notificationCloseSpy = jest.spyOn(notification, "close");
 
     it("should render notification type succes notification", async () => {
-        notificationProvider.open(mockNotification);
+        notificationProvider.open?.(mockNotification);
 
         expect(notificationOpenSpy).toBeCalledTimes(1);
         expect(notificationOpenSpy).toBeCalledWith({
@@ -33,7 +33,7 @@ describe("Antd notificationProvider", () => {
     });
 
     it("should render notification type error notification", async () => {
-        notificationProvider.open({
+        notificationProvider.open?.({
             ...mockNotification,
             type: "error",
         });
@@ -48,7 +48,7 @@ describe("Antd notificationProvider", () => {
     });
 
     it("should render notification with description", async () => {
-        notificationProvider.open({
+        notificationProvider.open?.({
             ...mockNotification,
             description: "Notification Description",
         });
@@ -62,7 +62,7 @@ describe("Antd notificationProvider", () => {
     });
 
     it("should render notification type error notification", async () => {
-        notificationProvider.open({
+        notificationProvider.open?.({
             ...mockNotification,
             type: "progress",
             cancelMutation,
@@ -87,7 +87,7 @@ describe("Antd notificationProvider", () => {
     });
 
     it("should close notification", async () => {
-        notificationProvider.close("notification-key");
+        notificationProvider.close?.("notification-key");
 
         expect(notificationCloseSpy).toBeCalledTimes(1);
         expect(notificationCloseSpy).toBeCalledWith("notification-key");

--- a/packages/antd/test/index.tsx
+++ b/packages/antd/test/index.tsx
@@ -1,27 +1,24 @@
-import React from "react";
+import React, { ComponentProps } from "react";
 import { BrowserRouter } from "react-router-dom";
 
 import { Refine } from "@pankod/refine-core";
 
 import { MockRouterProvider, MockJSONServer } from "@test";
-import {
-    I18nProvider,
-    AccessControlProvider,
-    AuthProvider,
-    DataProvider,
-    NotificationProvider,
-    IResourceItem,
-} from "@pankod/refine-core";
+import { I18nProvider, DataProvider, IResourceItem } from "@pankod/refine-core";
 
 const List = () => {
     return <div>hede</div>;
 };
 export interface ITestWrapperProps {
     dataProvider?: DataProvider;
-    authProvider?: AuthProvider;
+    authProvider?: ComponentProps<typeof Refine>["authProvider"];
     resources?: IResourceItem[];
-    notificationProvider?: NotificationProvider;
-    accessControlProvider?: AccessControlProvider;
+    notificationProvider?: ComponentProps<
+        typeof Refine
+    >["notificationProvider"];
+    accessControlProvider?: ComponentProps<
+        typeof Refine
+    >["accessControlProvider"];
     i18nProvider?: I18nProvider;
     routerInitialEntries?: string[];
     DashboardPage?: React.FC;

--- a/packages/antd/test/index.tsx
+++ b/packages/antd/test/index.tsx
@@ -1,7 +1,12 @@
-import React, { ComponentProps } from "react";
+import React from "react";
 import { BrowserRouter } from "react-router-dom";
 
-import { Refine } from "@pankod/refine-core";
+import {
+    AccessControlProvider,
+    AuthProvider,
+    NotificationProvider,
+    Refine,
+} from "@pankod/refine-core";
 
 import { MockRouterProvider, MockJSONServer } from "@test";
 import { I18nProvider, DataProvider, IResourceItem } from "@pankod/refine-core";
@@ -11,14 +16,10 @@ const List = () => {
 };
 export interface ITestWrapperProps {
     dataProvider?: DataProvider;
-    authProvider?: ComponentProps<typeof Refine>["authProvider"];
+    authProvider?: AuthProvider;
     resources?: IResourceItem[];
-    notificationProvider?: ComponentProps<
-        typeof Refine
-    >["notificationProvider"];
-    accessControlProvider?: ComponentProps<
-        typeof Refine
-    >["accessControlProvider"];
+    notificationProvider?: NotificationProvider;
+    accessControlProvider?: AccessControlProvider;
     i18nProvider?: I18nProvider;
     routerInitialEntries?: string[];
     DashboardPage?: React.FC;

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -21,10 +21,7 @@ import { UndoableQueueContextProvider } from "@contexts/undoableQueue";
 import { UnsavedWarnContextProvider } from "@contexts/unsavedWarn";
 import { RouterContextProvider } from "@contexts/router";
 import { AccessControlContextProvider } from "@contexts/accessControl";
-import {
-    NotificationContextProvider,
-    defaultNotificationProvider,
-} from "@contexts/notification";
+import { NotificationContextProvider } from "@contexts/notification";
 import { ReadyPage as DefaultReadyPage, RouteChangeHandler } from "@components";
 import {
     MutationMode,
@@ -53,7 +50,7 @@ export interface RefineProps {
     dataProvider: IDataContextProvider | IDataMultipleContextProvider;
     liveProvider?: ILiveContext;
     routerProvider: IRouterProvider;
-    notificationProvider?: INotificationContext;
+    notificationProvider?: Required<INotificationContext>;
     accessControlProvider?: Required<IAccessControlContext>;
     resources?: ResourceProps[];
     i18nProvider?: I18nProvider;
@@ -88,7 +85,7 @@ export const Refine: React.FC<RefineProps> = ({
     authProvider,
     dataProvider,
     routerProvider,
-    notificationProvider = defaultNotificationProvider,
+    notificationProvider,
     accessControlProvider,
     resources: resourcesFromProps,
     DashboardPage,
@@ -157,7 +154,7 @@ export const Refine: React.FC<RefineProps> = ({
 
     return (
         <QueryClientProvider client={queryClient}>
-            <NotificationContextProvider {...notificationProvider}>
+            <NotificationContextProvider {...(notificationProvider ?? {})}>
                 <AuthContextProvider
                     {...authProvider}
                     isProvided={!!authProvider}
@@ -170,7 +167,7 @@ export const Refine: React.FC<RefineProps> = ({
                                         i18nProvider={i18nProvider}
                                     >
                                         <AccessControlContextProvider
-                                            {...accessControlProvider}
+                                            {...(accessControlProvider ?? {})}
                                         >
                                             <UndoableQueueContextProvider>
                                                 <RefineContextProvider

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -23,7 +23,6 @@ import { ReadyPage as DefaultReadyPage, RouteChangeHandler } from "@components";
 import {
     MutationMode,
     IDataContextProvider,
-    IAuthContext,
     I18nProvider,
     LayoutProps,
     TitleProps,
@@ -31,9 +30,10 @@ import {
     ResourceProps,
     ILiveContext,
     LiveModeProps,
-    IAccessControlContext,
-    INotificationContext,
     IDataMultipleContextProvider,
+    AuthProvider,
+    NotificationProvider,
+    AccessControlProvider,
 } from "../../../interfaces";
 import { routeGenerator } from "@definitions";
 
@@ -43,24 +43,12 @@ interface QueryClientConfig {
     defaultOptions?: DefaultOptions;
 }
 export interface RefineProps {
-    authProvider?: Partial<
-        Omit<IAuthContext, "isProvided" | "isAuthenticated">
-    > &
-        Required<
-            Pick<
-                IAuthContext,
-                | "login"
-                | "logout"
-                | "checkAuth"
-                | "checkError"
-                | "getPermissions"
-            >
-        >;
+    authProvider?: AuthProvider;
     dataProvider: IDataContextProvider | IDataMultipleContextProvider;
     liveProvider?: ILiveContext;
     routerProvider: IRouterProvider;
-    notificationProvider?: Required<INotificationContext>;
-    accessControlProvider?: Required<IAccessControlContext>;
+    notificationProvider?: NotificationProvider;
+    accessControlProvider?: AccessControlProvider;
     resources?: ResourceProps[];
     i18nProvider?: I18nProvider;
     catchAll?: React.ReactNode;

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -43,7 +43,19 @@ interface QueryClientConfig {
     defaultOptions?: DefaultOptions;
 }
 export interface RefineProps {
-    authProvider?: IAuthContext;
+    authProvider?: Partial<
+        Omit<IAuthContext, "isProvided" | "isAuthenticated">
+    > &
+        Required<
+            Pick<
+                IAuthContext,
+                | "login"
+                | "logout"
+                | "checkAuth"
+                | "checkError"
+                | "getPermissions"
+            >
+        >;
     dataProvider: IDataContextProvider | IDataMultipleContextProvider;
     liveProvider?: ILiveContext;
     routerProvider: IRouterProvider;
@@ -153,8 +165,8 @@ export const Refine: React.FC<RefineProps> = ({
         <QueryClientProvider client={queryClient}>
             <NotificationContextProvider {...(notificationProvider ?? {})}>
                 <AuthContextProvider
-                    {...authProvider}
-                    isProvided={!!authProvider}
+                    {...(authProvider ?? {})}
+                    isProvided={Boolean(authProvider)}
                 >
                     <DataContextProvider {...dataProvider}>
                         <LiveContextProvider liveProvider={liveProvider}>

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -11,10 +11,7 @@ import { ReactQueryDevtools } from "react-query/devtools";
 import { AuthContextProvider } from "@contexts/auth";
 import { DataContextProvider } from "@contexts/data";
 import { LiveContextProvider } from "@contexts/live";
-import {
-    defaultProvider,
-    TranslationContextProvider,
-} from "@contexts/translation";
+import { TranslationContextProvider } from "@contexts/translation";
 import { ResourceContextProvider, IResourceItem } from "@contexts/resource";
 import { RefineContextProvider } from "@contexts/refine";
 import { UndoableQueueContextProvider } from "@contexts/undoableQueue";
@@ -94,7 +91,7 @@ export const Refine: React.FC<RefineProps> = ({
     catchAll,
     children,
     liveProvider,
-    i18nProvider = defaultProvider.i18nProvider,
+    i18nProvider,
     mutationMode = "pessimistic",
     syncWithLocation = false,
     warnWhenUnsavedChanges = false,

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -20,10 +20,7 @@ import { RefineContextProvider } from "@contexts/refine";
 import { UndoableQueueContextProvider } from "@contexts/undoableQueue";
 import { UnsavedWarnContextProvider } from "@contexts/unsavedWarn";
 import { RouterContextProvider } from "@contexts/router";
-import {
-    defaultAccessControlContext,
-    AccessControlContextProvider,
-} from "@contexts/accessControl";
+import { AccessControlContextProvider } from "@contexts/accessControl";
 import {
     NotificationContextProvider,
     defaultNotificationProvider,
@@ -92,7 +89,7 @@ export const Refine: React.FC<RefineProps> = ({
     dataProvider,
     routerProvider,
     notificationProvider = defaultNotificationProvider,
-    accessControlProvider = defaultAccessControlContext,
+    accessControlProvider,
     resources: resourcesFromProps,
     DashboardPage,
     ReadyPage,

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -54,7 +54,7 @@ export interface RefineProps {
     liveProvider?: ILiveContext;
     routerProvider: IRouterProvider;
     notificationProvider?: INotificationContext;
-    accessControlProvider?: IAccessControlContext;
+    accessControlProvider?: Required<IAccessControlContext>;
     resources?: ResourceProps[];
     i18nProvider?: I18nProvider;
     catchAll?: React.ReactNode;

--- a/packages/core/src/components/pages/error/index.tsx
+++ b/packages/core/src/components/pages/error/index.tsx
@@ -52,12 +52,13 @@ export const ErrorComponent: React.FC = () => {
             <h1>
                 {translate(
                     "pages.error.404",
+                    undefined,
                     "Sorry, the page you visited does not exist.",
                 )}
             </h1>
             {errorMessage && <p>{errorMessage}</p>}
             <button onClick={() => push("/")}>
-                {translate("pages.error.backHome", "Back Home")}
+                {translate("pages.error.backHome", undefined, "Back Home")}
             </button>
         </>
     );

--- a/packages/core/src/components/pages/login/index.tsx
+++ b/packages/core/src/components/pages/login/index.tsx
@@ -32,7 +32,12 @@ export const LoginPage: React.FC = () => {
                     <tbody>
                         <tr>
                             <td>
-                                {translate("pages.login.username", "username")}:
+                                {translate(
+                                    "pages.login.username",
+                                    undefined,
+                                    "username",
+                                )}
+                                :
                             </td>
                             <td>
                                 <input
@@ -52,7 +57,12 @@ export const LoginPage: React.FC = () => {
                         </tr>
                         <tr>
                             <td>
-                                {translate("pages.login.password", "password")}:
+                                {translate(
+                                    "pages.login.password",
+                                    undefined,
+                                    "password",
+                                )}
+                                :
                             </td>
                             <td>
                                 <input

--- a/packages/core/src/components/routeChangeHandler/index.tsx
+++ b/packages/core/src/components/routeChangeHandler/index.tsx
@@ -11,7 +11,7 @@ export const RouteChangeHandler: React.FC = () => {
     const location = useLocation();
 
     useEffect(() => {
-        checkAuth().catch(() => false);
+        checkAuth?.().catch(() => false);
     }, [location?.pathname]);
 
     return null;

--- a/packages/core/src/components/undoableQueue/index.tsx
+++ b/packages/core/src/components/undoableQueue/index.tsx
@@ -21,7 +21,7 @@ export const UndoableQueue: React.FC<{
                     notificationItem.doMutation();
                 }
                 if (!notificationItem.isSilent) {
-                    open({
+                    open?.({
                         key: `${notificationItem.id}-${notificationItem.resource}-notification`,
                         type: "progress",
                         message: translate(

--- a/packages/core/src/contexts/accessControl/IAccessControlContext.ts
+++ b/packages/core/src/contexts/accessControl/IAccessControlContext.ts
@@ -9,5 +9,5 @@ export type CanReturnType = {
     reason?: string;
 };
 export interface IAccessControlContext {
-    can: ({ resource, action, params }: CanParams) => Promise<CanReturnType>;
+    can?: ({ resource, action, params }: CanParams) => Promise<CanReturnType>;
 }

--- a/packages/core/src/contexts/accessControl/IAccessControlContext.ts
+++ b/packages/core/src/contexts/accessControl/IAccessControlContext.ts
@@ -11,3 +11,5 @@ export type CanReturnType = {
 export interface IAccessControlContext {
     can?: ({ resource, action, params }: CanParams) => Promise<CanReturnType>;
 }
+
+export type AccessControlProvider = Required<IAccessControlContext>;

--- a/packages/core/src/contexts/accessControl/index.tsx
+++ b/packages/core/src/contexts/accessControl/index.tsx
@@ -2,12 +2,11 @@ import React from "react";
 
 import { IAccessControlContext } from "./IAccessControlContext";
 
-export const defaultAccessControlContext: IAccessControlContext = {
-    can: () => Promise.resolve({ can: true }),
-};
+/** @deprecated default value for access control context has no use and is an empty object. */
+export const defaultAccessControlContext: IAccessControlContext = {};
 
 export const AccessControlContext = React.createContext<IAccessControlContext>(
-    defaultAccessControlContext,
+    {},
 );
 
 export const AccessControlContextProvider: React.FC<IAccessControlContext> = ({

--- a/packages/core/src/contexts/auth/IAuthContext.ts
+++ b/packages/core/src/contexts/auth/IAuthContext.ts
@@ -11,3 +11,13 @@ export interface IAuthContext {
     isProvided?: boolean;
     isAuthenticated?: boolean;
 }
+
+export type AuthProvider = Partial<
+    Omit<IAuthContext, "isProvided" | "isAuthenticated">
+> &
+    Required<
+        Pick<
+            IAuthContext,
+            "login" | "logout" | "checkAuth" | "checkError" | "getPermissions"
+        >
+    >;

--- a/packages/core/src/contexts/auth/IAuthContext.ts
+++ b/packages/core/src/contexts/auth/IAuthContext.ts
@@ -2,13 +2,12 @@ export type TLogoutData = void | false | string;
 export type TLoginData = void | false | string;
 
 export interface IAuthContext {
-    login: (params: any) => Promise<TLoginData>;
-    logout: (params: any) => Promise<TLogoutData>;
-    checkAuth: (params?: any) => Promise<void>;
-    checkError: (error: any) => Promise<void>;
-    getPermissions: (params?: any) => Promise<any>;
+    login?: (params: any) => Promise<TLoginData>;
+    logout?: (params: any) => Promise<TLogoutData>;
+    checkAuth?: (params?: any) => Promise<void>;
+    checkError?: (error: any) => Promise<void>;
+    getPermissions?: (params?: any) => Promise<any>;
     getUserIdentity?: () => Promise<any>;
     isProvided?: boolean;
     isAuthenticated?: boolean;
-    [key: string]: any;
 }

--- a/packages/core/src/contexts/auth/IAuthContext.ts
+++ b/packages/core/src/contexts/auth/IAuthContext.ts
@@ -1,23 +1,16 @@
 export type TLogoutData = void | false | string;
 export type TLoginData = void | false | string;
 
-export interface IAuthContext {
-    login?: (params: any) => Promise<TLoginData>;
-    logout?: (params: any) => Promise<TLogoutData>;
-    checkAuth?: (params?: any) => Promise<void>;
-    checkError?: (error: any) => Promise<void>;
-    getPermissions?: (params?: any) => Promise<any>;
+export interface AuthProvider {
+    login: (params: any) => Promise<TLoginData>;
+    logout: (params: any) => Promise<TLogoutData>;
+    checkAuth: (params?: any) => Promise<void>;
+    checkError: (error: any) => Promise<void>;
+    getPermissions: (params?: any) => Promise<any>;
     getUserIdentity?: () => Promise<any>;
+}
+
+export interface IAuthContext extends Partial<AuthProvider> {
     isProvided?: boolean;
     isAuthenticated?: boolean;
 }
-
-export type AuthProvider = Partial<
-    Omit<IAuthContext, "isProvided" | "isAuthenticated">
-> &
-    Required<
-        Pick<
-            IAuthContext,
-            "login" | "logout" | "checkAuth" | "checkError" | "getPermissions"
-        >
-    >;

--- a/packages/core/src/contexts/auth/index.tsx
+++ b/packages/core/src/contexts/auth/index.tsx
@@ -4,25 +4,12 @@ import { useQueryClient } from "react-query";
 import { useNavigation } from "@hooks";
 import { IAuthContext } from "../../interfaces";
 
-const defaultProvider: IAuthContext = {
-    login: () => Promise.resolve(),
-    logout: () => Promise.resolve(),
-    checkAuth: () => Promise.resolve(),
-    checkError: () => Promise.resolve(),
-    getPermissions: () => Promise.resolve(),
-    getUserIdentity: () => Promise.resolve(),
-};
-export const AuthContext = React.createContext<IAuthContext>(defaultProvider);
+export const AuthContext = React.createContext<IAuthContext>({});
 
-export const AuthContextProvider: React.FC<Partial<IAuthContext>> = ({
-    login = defaultProvider.login,
-    logout = defaultProvider.logout,
-    checkAuth = defaultProvider.checkAuth,
-    checkError = defaultProvider.checkError,
-    getPermissions = defaultProvider.getPermissions,
-    getUserIdentity = defaultProvider.getUserIdentity,
-    isProvided,
+export const AuthContextProvider: React.FC<IAuthContext> = ({
     children,
+    isProvided,
+    ...authOperations
 }) => {
     const { replace } = useNavigation();
     const [isAuthenticated, setAuthenticated] = useState(false);
@@ -36,7 +23,7 @@ export const AuthContextProvider: React.FC<Partial<IAuthContext>> = ({
 
     const loginFunc = async (params: any) => {
         try {
-            const result = await login(params);
+            const result = await authOperations.login?.(params);
             setAuthenticated(true);
             return Promise.resolve(result);
         } catch (error) {
@@ -47,7 +34,7 @@ export const AuthContextProvider: React.FC<Partial<IAuthContext>> = ({
 
     const logoutFunc = async (params: any) => {
         try {
-            const redirectPath = await logout(params);
+            const redirectPath = await authOperations.logout?.(params);
             setAuthenticated(false);
 
             return Promise.resolve(redirectPath);
@@ -59,7 +46,7 @@ export const AuthContextProvider: React.FC<Partial<IAuthContext>> = ({
 
     const checkAuthFunc = async (params: any) => {
         try {
-            await checkAuth(params);
+            await authOperations.checkAuth?.(params);
             setAuthenticated(true);
         } catch (error) {
             if ((error as { redirectPath?: string })?.redirectPath) {
@@ -73,14 +60,12 @@ export const AuthContextProvider: React.FC<Partial<IAuthContext>> = ({
     return (
         <AuthContext.Provider
             value={{
+                ...authOperations,
                 login: loginFunc,
                 logout: logoutFunc,
                 checkAuth: checkAuthFunc,
-                checkError,
-                getPermissions,
-                getUserIdentity,
-                isAuthenticated,
                 isProvided,
+                isAuthenticated,
             }}
         >
             {children}

--- a/packages/core/src/contexts/notification/INotificationContext.ts
+++ b/packages/core/src/contexts/notification/INotificationContext.ts
@@ -8,6 +8,6 @@ export interface OpenNotificationParams {
 }
 
 export interface INotificationContext {
-    open: (params: OpenNotificationParams) => void;
-    close: (key: string) => void;
+    open?: (params: OpenNotificationParams) => void;
+    close?: (key: string) => void;
 }

--- a/packages/core/src/contexts/notification/INotificationContext.ts
+++ b/packages/core/src/contexts/notification/INotificationContext.ts
@@ -11,3 +11,5 @@ export interface INotificationContext {
     open?: (params: OpenNotificationParams) => void;
     close?: (key: string) => void;
 }
+
+export type NotificationProvider = Required<INotificationContext>;

--- a/packages/core/src/contexts/notification/index.tsx
+++ b/packages/core/src/contexts/notification/index.tsx
@@ -2,18 +2,10 @@ import React, { createContext } from "react";
 
 import { INotificationContext } from "./INotificationContext";
 
-export const defaultNotificationProvider: INotificationContext = {
-    open: () => {
-        return {};
-    },
-    close: () => {
-        return {};
-    },
-};
+/** @deprecated default value for notification context has no use and is an empty object.  */
+export const defaultNotificationProvider: INotificationContext = {};
 
-export const NotificationContext = createContext<INotificationContext>(
-    defaultNotificationProvider,
-);
+export const NotificationContext = createContext<INotificationContext>({});
 
 export const NotificationContextProvider: React.FC<INotificationContext> = ({
     open,

--- a/packages/core/src/contexts/translation/ITranslationContext.ts
+++ b/packages/core/src/contexts/translation/ITranslationContext.ts
@@ -13,3 +13,5 @@ export interface I18nProvider {
 export interface ITranslationContext {
     i18nProvider?: I18nProvider;
 }
+
+export type TranslationProvider = Required<ITranslationContext>;

--- a/packages/core/src/contexts/translation/ITranslationContext.ts
+++ b/packages/core/src/contexts/translation/ITranslationContext.ts
@@ -11,5 +11,5 @@ export interface I18nProvider {
 }
 
 export interface ITranslationContext {
-    i18nProvider: I18nProvider;
+    i18nProvider?: I18nProvider;
 }

--- a/packages/core/src/contexts/translation/index.tsx
+++ b/packages/core/src/contexts/translation/index.tsx
@@ -2,17 +2,10 @@ import React from "react";
 
 import { ITranslationContext } from "../../interfaces";
 
-export const defaultProvider: ITranslationContext = {
-    i18nProvider: {
-        translate: (key: string, options: any, defaultMessage?: string) =>
-            defaultMessage || options,
-        changeLocale: () => Promise.resolve(),
-        getLocale: () => "en",
-    },
-};
+/** @deprecated default value for translation context has no use and is an empty object.  */
+export const defaultProvider: ITranslationContext = {};
 
-export const TranslationContext =
-    React.createContext<ITranslationContext>(defaultProvider);
+export const TranslationContext = React.createContext<ITranslationContext>({});
 
 export const TranslationContextProvider: React.FC<ITranslationContext> = ({
     children,

--- a/packages/core/src/contexts/unsavedWarn/IUnsavedWarnContext.ts
+++ b/packages/core/src/contexts/unsavedWarn/IUnsavedWarnContext.ts
@@ -1,4 +1,4 @@
 export interface IUnsavedWarnContext {
-    warnWhen: boolean;
-    setWarnWhen: (value: boolean) => void;
+    warnWhen?: boolean;
+    setWarnWhen?: (value: boolean) => void;
 }

--- a/packages/core/src/contexts/unsavedWarn/index.tsx
+++ b/packages/core/src/contexts/unsavedWarn/index.tsx
@@ -2,10 +2,7 @@ import React, { useState } from "react";
 
 import { IUnsavedWarnContext } from "./IUnsavedWarnContext";
 
-export const UnsavedWarnContext = React.createContext<IUnsavedWarnContext>({
-    warnWhen: false,
-    setWarnWhen: (value: boolean) => value,
-});
+export const UnsavedWarnContext = React.createContext<IUnsavedWarnContext>({});
 
 export const UnsavedWarnContextProvider: React.FC = ({ children }) => {
     const [warnWhen, setWarnWhen] = useState(false);

--- a/packages/core/src/hooks/accessControl/useCan/index.ts
+++ b/packages/core/src/hooks/accessControl/useCan/index.ts
@@ -26,12 +26,16 @@ export const useCan = ({
 
     const queryResponse = useQuery<CanReturnType>(
         ["useCan", { action, resource, params }],
-        () => can({ action, resource, params }),
+        // Enabled check for `can` is enough to be sure that it's defined in the query function but TS is not smart enough to know that.
+        () => can?.({ action, resource, params }) ?? { can: true },
         {
+            enabled: typeof can !== "undefined",
             ...queryOptions,
             retry: false,
         },
     );
 
-    return queryResponse;
+    return typeof can === "undefined"
+        ? ({ data: { can: true } } as typeof queryResponse)
+        : queryResponse;
 };

--- a/packages/core/src/hooks/accessControl/useCanWithoutCache.ts
+++ b/packages/core/src/hooks/accessControl/useCanWithoutCache.ts
@@ -1,8 +1,9 @@
 import { useContext } from "react";
 
 import { AccessControlContext } from "@contexts/accessControl";
+import { IAccessControlContext } from "../../interfaces";
 
-export const useCanWithoutCache = () => {
+export const useCanWithoutCache = (): IAccessControlContext => {
     const { can } = useContext(AccessControlContext);
 
     return { can };

--- a/packages/core/src/hooks/auth/useAuthenticated/index.ts
+++ b/packages/core/src/hooks/auth/useAuthenticated/index.ts
@@ -17,7 +17,7 @@ export const useAuthenticated = (
 
     const queryResponse = useQuery(
         ["useAuthenticated", params],
-        () => checkAuth(params),
+        () => checkAuth?.(params),
         {
             retry: false,
         },

--- a/packages/core/src/hooks/auth/useGetIdentity/index.spec.ts
+++ b/packages/core/src/hooks/auth/useGetIdentity/index.spec.ts
@@ -65,7 +65,7 @@ describe("useGetIdentity Hook", () => {
             return !result.current.isLoading;
         });
 
-        expect(result.current.status).toEqual("success");
+        expect(result.current.status).toEqual("idle");
         expect(result.current.data).not.toBeDefined();
     });
 });

--- a/packages/core/src/hooks/auth/useGetIdentity/index.ts
+++ b/packages/core/src/hooks/auth/useGetIdentity/index.ts
@@ -20,7 +20,8 @@ export const useGetIdentity = <TData = any>(): UseQueryResult<
 
     const queryResponse = useQuery<TData>(
         ["getUserIdentity"],
-        getUserIdentity!,
+        // Enabled check for `getUserIdentity` is enough to be sure that it's defined in the query function but TS is not smart enough to know that.
+        getUserIdentity ?? (() => Promise.resolve(undefined)),
         {
             enabled: !!getUserIdentity,
             retry: false,

--- a/packages/core/src/hooks/auth/useIsAuthenticated/index.ts
+++ b/packages/core/src/hooks/auth/useIsAuthenticated/index.ts
@@ -6,5 +6,5 @@ import { IAuthContext } from "../../../interfaces";
 export const useIsAuthenticated = () => {
     const { isAuthenticated } = useContext<IAuthContext>(AuthContext);
 
-    return isAuthenticated;
+    return Boolean(isAuthenticated);
 };

--- a/packages/core/src/hooks/auth/useLogin/index.ts
+++ b/packages/core/src/hooks/auth/useLogin/index.ts
@@ -48,10 +48,10 @@ export const useLogin = <TVariables = {}>(): UseMutationResult<
                         replace("/");
                     }
                 }
-                close("login-error");
+                close?.("login-error");
             },
             onError: (error: any) => {
-                open({
+                open?.({
                     message: error?.name || "Login Error",
                     description: error?.message || "Invalid credentials",
                     key: "login-error",

--- a/packages/core/src/hooks/auth/useLogout/index.ts
+++ b/packages/core/src/hooks/auth/useLogout/index.ts
@@ -36,7 +36,7 @@ export const useLogout = <TVariables = void>(): UseMutationResult<
                 }
             },
             onError: (error: Error) => {
-                open({
+                open?.({
                     key: "useLogout-error",
                     type: "error",
                     message: error?.name || "Logout Error",

--- a/packages/core/src/hooks/auth/usePermissions/index.ts
+++ b/packages/core/src/hooks/auth/usePermissions/index.ts
@@ -19,8 +19,12 @@ export const usePermissions = <TData = any>(
 
     const queryResponse = useQuery<TData>(
         ["usePermissions"],
-        getPermissions,
-        options,
+        // Enabled check for `getPermissions` is enough to be sure that it's defined in the query function but TS is not smart enough to know that.
+        getPermissions ?? (() => Promise.resolve(undefined)),
+        {
+            enabled: !!getPermissions,
+            ...options,
+        },
     );
 
     return queryResponse;

--- a/packages/core/src/hooks/notification/useHandleNotification/index.ts
+++ b/packages/core/src/hooks/notification/useHandleNotification/index.ts
@@ -3,7 +3,7 @@ import { useCallback } from "react";
 import { OpenNotificationParams } from "../../../interfaces";
 import { useNotification } from "@hooks";
 
-export const useHandleNotification = () => {
+export const useHandleNotification = (): typeof handleNotification => {
     const { open } = useNotification();
 
     const handleNotification = useCallback(
@@ -13,9 +13,9 @@ export const useHandleNotification = () => {
         ) => {
             if (notification !== false) {
                 if (notification) {
-                    open(notification);
+                    open?.(notification);
                 } else if (fallbackNotification) {
-                    open(fallbackNotification);
+                    open?.(fallbackNotification);
                 }
             }
         },

--- a/packages/core/src/hooks/notification/useNotification/index.ts
+++ b/packages/core/src/hooks/notification/useNotification/index.ts
@@ -1,8 +1,9 @@
 import { useContext } from "react";
 
 import { NotificationContext } from "@contexts/notification";
+import { INotificationContext } from "../../../interfaces";
 
-export const useNotification = () => {
+export const useNotification = (): INotificationContext => {
     const { open, close } = useContext(NotificationContext);
 
     return { open, close };

--- a/packages/core/src/hooks/refine/useWarnAboutChange/index.ts
+++ b/packages/core/src/hooks/refine/useWarnAboutChange/index.ts
@@ -6,8 +6,8 @@ import { IRefineContext, IUnsavedWarnContext } from "../../../interfaces";
 
 type UseWarnAboutChangeType = () => {
     warnWhenUnsavedChanges: IRefineContext["warnWhenUnsavedChanges"];
-    warnWhen: IUnsavedWarnContext["warnWhen"];
-    setWarnWhen: IUnsavedWarnContext["setWarnWhen"];
+    warnWhen: NonNullable<IUnsavedWarnContext["warnWhen"]>;
+    setWarnWhen: NonNullable<IUnsavedWarnContext["setWarnWhen"]>;
 };
 
 /**
@@ -21,5 +21,9 @@ export const useWarnAboutChange: UseWarnAboutChangeType = () => {
 
     const { warnWhen, setWarnWhen } = useContext(UnsavedWarnContext);
 
-    return { warnWhenUnsavedChanges, warnWhen, setWarnWhen };
+    return {
+        warnWhenUnsavedChanges,
+        warnWhen: Boolean(warnWhen),
+        setWarnWhen: setWarnWhen ?? (() => undefined),
+    };
 };

--- a/packages/core/src/hooks/translate/useGetLocale.spec.tsx
+++ b/packages/core/src/hooks/translate/useGetLocale.spec.tsx
@@ -3,10 +3,10 @@ import { TestWrapper } from "@test";
 import { useGetLocale } from "@hooks";
 
 describe("useGetLocale", () => {
-    it("should get default locale value if i18n provider not defined", () => {
+    it("should get undefined value if i18n provider not defined", () => {
         const { result } = renderHook(() => useGetLocale());
 
-        expect(result.current()).toBe("en");
+        expect(result.current()).toBe(undefined);
     });
 
     it("should get locale value from i18nProvider getLocale method", () => {

--- a/packages/core/src/hooks/translate/useGetLocale.ts
+++ b/packages/core/src/hooks/translate/useGetLocale.ts
@@ -1,7 +1,7 @@
 import { useContext, useCallback } from "react";
 import { TranslationContext } from "@contexts/translation";
 
-export type UseGetLocaleType = () => () => string;
+export type UseGetLocaleType = () => () => string | undefined;
 
 /**
  * If you need to know the current locale, refine provides the `useGetLocale` hook.
@@ -12,5 +12,5 @@ export type UseGetLocaleType = () => () => string;
 export const useGetLocale: UseGetLocaleType = () => {
     const { i18nProvider } = useContext(TranslationContext);
 
-    return useCallback(() => i18nProvider.getLocale(), []);
+    return useCallback(() => i18nProvider?.getLocale(), []);
 };

--- a/packages/core/src/hooks/translate/useSetLocale.ts
+++ b/packages/core/src/hooks/translate/useSetLocale.ts
@@ -10,5 +10,5 @@ import { TranslationContext } from "@contexts/translation";
 export const useSetLocale = () => {
     const { i18nProvider } = useContext(TranslationContext);
 
-    return useCallback((lang: string) => i18nProvider.changeLocale(lang), []);
+    return useCallback((lang: string) => i18nProvider?.changeLocale(lang), []);
 };

--- a/packages/core/src/hooks/translate/useTranslate.ts
+++ b/packages/core/src/hooks/translate/useTranslate.ts
@@ -11,10 +11,16 @@ export const useTranslate = () => {
     const { i18nProvider } = useContext(TranslationContext);
 
     return useCallback(
-        (key: string, options?: any, defaultMessage?: string) =>
-            i18nProvider?.translate(key, options, defaultMessage) ??
-            defaultMessage ??
-            key,
+        (key: string, options: string | unknown, defaultMessage?: string) => {
+            return (
+                i18nProvider?.translate(key, options, defaultMessage) ??
+                defaultMessage ??
+                (typeof options === "string" &&
+                typeof defaultMessage === "undefined"
+                    ? options
+                    : key)
+            );
+        },
         [],
     );
 };

--- a/packages/core/src/hooks/translate/useTranslate.ts
+++ b/packages/core/src/hooks/translate/useTranslate.ts
@@ -12,7 +12,9 @@ export const useTranslate = () => {
 
     return useCallback(
         (key: string, options?: any, defaultMessage?: string) =>
-            i18nProvider?.translate(key, options, defaultMessage),
+            i18nProvider?.translate(key, options, defaultMessage) ??
+            defaultMessage ??
+            key,
         [],
     );
 };

--- a/packages/core/src/hooks/translate/useTranslate.ts
+++ b/packages/core/src/hooks/translate/useTranslate.ts
@@ -1,4 +1,4 @@
-import { useContext, useCallback } from "react";
+import { useContext, useMemo } from "react";
 import { TranslationContext } from "@contexts/translation";
 
 /**
@@ -10,8 +10,19 @@ import { TranslationContext } from "@contexts/translation";
 export const useTranslate = () => {
     const { i18nProvider } = useContext(TranslationContext);
 
-    return useCallback(
-        (key: string, options: string | unknown, defaultMessage?: string) => {
+    const fn = useMemo(() => {
+        function translate(
+            key: string,
+            options?: any,
+            defaultMessage?: string,
+        ): string;
+        function translate(key: string, defaultMessage?: string): string;
+
+        function translate(
+            key: string,
+            options?: string | any,
+            defaultMessage?: string,
+        ) {
             return (
                 i18nProvider?.translate(key, options, defaultMessage) ??
                 defaultMessage ??
@@ -20,7 +31,10 @@ export const useTranslate = () => {
                     ? options
                     : key)
             );
-        },
-        [],
-    );
+        }
+
+        return translate;
+    }, [i18nProvider]);
+
+    return fn;
 };

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -2,15 +2,19 @@ export * from "./components";
 export * from "./hooks";
 
 export {
-    IAuthContext as AuthProvider,
+    IAuthContext,
+    AuthProvider,
     Pagination,
     IDataContextProvider as DataProvider,
     ILiveContext as LiveProvider,
     LiveEvent,
     IResourceContext as ResourceProvider,
-    ITranslationContext as TranslationProvider,
-    IAccessControlContext as AccessControlProvider,
-    INotificationContext as NotificationProvider,
+    ITranslationContext,
+    TranslationProvider,
+    IAccessControlContext,
+    AccessControlProvider,
+    INotificationContext,
+    NotificationProvider,
     I18nProvider,
     MutationMode,
     IResourceComponents,

--- a/packages/nextjs-router/src/checkAuthentication.ts
+++ b/packages/nextjs-router/src/checkAuthentication.ts
@@ -18,7 +18,7 @@ export const checkAuthentication = async (
     }
 
     try {
-        await authProvider.checkAuth(context);
+        await authProvider.checkAuth?.(context);
         isAuthenticated = true;
     } catch (error) {
         const encodeURI = () => {

--- a/packages/react-hook-form/src/useModalForm/index.ts
+++ b/packages/react-hook-form/src/useModalForm/index.ts
@@ -135,6 +135,7 @@ export const useModalForm = <
 
     const title = translate(
         `${resourceName}.titles.${actionProp}`,
+        undefined,
         `${userFriendlyResourceName(
             `${actionProp} ${resourceName}`,
             "singular",


### PR DESCRIPTION
Removed dummy default values from internal contexts.
Updated contexts:

-   Auth
-   Access Control
-   Notification
-   Translation (i18n)
-   unsavedWarn