### PR TITLE
refactor(buttons): svgIconProps passed to buttons

### DIFF
--- a/.changeset/polite-impalas-attack.md
+++ b/.changeset/polite-impalas-attack.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": minor
+---
+
+Passed svgButtonProps to mui buttons

--- a/.changeset/polite-impalas-attack.md
+++ b/.changeset/polite-impalas-attack.md
@@ -1,5 +1,5 @@
 ---
-"@pankod/refine-mui": minor
+"@pankod/refine-mui": patch
 ---
 
 Passed svgButtonProps to mui buttons

--- a/examples/fineFoods/admin/mui/src/pages/users/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/users/list.tsx
@@ -101,10 +101,14 @@ export const UserList: React.FC<IResourceComponentsProps> = () => {
                 headerName: t("table.actions"),
                 renderCell: ({ row }) => (
                     <ShowButton
+                        svgIconProps={{ fontSize: "small" }}
                         variant="outlined"
                         size="small"
                         hideText
                         recordItemId={row.id}
+                        sx={{
+                            minWidth: "24px",
+                        }}
                     />
                 ),
                 align: "center",

--- a/packages/mui/src/components/buttons/clone/index.tsx
+++ b/packages/mui/src/components/buttons/clone/index.tsx
@@ -8,8 +8,7 @@ import {
     useResource,
     useRouterContext,
 } from "@pankod/refine-core";
-
-import { Button, ButtonProps } from "@mui/material";
+import { Button, ButtonProps, SvgIconProps } from "@mui/material";
 import AddBoxOutlinedIcon from "@mui/icons-material/AddBoxOutlined";
 
 export type CloneButtonProps = ButtonProps & {
@@ -17,6 +16,7 @@ export type CloneButtonProps = ButtonProps & {
     recordItemId?: BaseKey;
     hideText?: boolean;
     ignoreAccessControlProvider?: boolean;
+    svgIconProps?: SvgIconProps;
 };
 
 /**
@@ -30,6 +30,7 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
     recordItemId,
     hideText = false,
     ignoreAccessControlProvider = false,
+    svgIconProps,
     children,
     onClick,
     ...rest
@@ -80,12 +81,14 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
         >
             <Button
                 disabled={data?.can === false}
-                startIcon={!hideText && <AddBoxOutlinedIcon />}
+                startIcon={
+                    !hideText && <AddBoxOutlinedIcon {...svgIconProps} />
+                }
                 title={disabledTitle()}
                 {...rest}
             >
                 {hideText ? (
-                    <AddBoxOutlinedIcon />
+                    <AddBoxOutlinedIcon {...svgIconProps} />
                 ) : (
                     children ?? translate("buttons.clone", "Clone")
                 )}

--- a/packages/mui/src/components/buttons/create/index.tsx
+++ b/packages/mui/src/components/buttons/create/index.tsx
@@ -7,14 +7,14 @@ import {
     useResource,
     useRouterContext,
 } from "@pankod/refine-core";
-
-import { Button, ButtonProps } from "@mui/material";
+import { Button, ButtonProps, SvgIconProps } from "@mui/material";
 import AddBoxOutlinedIcon from "@mui/icons-material/AddBoxOutlined";
 
 export type CreateButtonProps = ButtonProps & {
     resourceNameOrRouteName?: string;
     hideText?: boolean;
     ignoreAccessControlProvider?: boolean;
+    svgIconProps?: SvgIconProps;
 };
 
 /**
@@ -26,6 +26,7 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
     resourceNameOrRouteName,
     hideText = false,
     ignoreAccessControlProvider = false,
+    svgIconProps,
     children,
     onClick,
     ...rest
@@ -74,12 +75,15 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
         >
             <Button
                 disabled={data?.can === false}
-                startIcon={!hideText && <AddBoxOutlinedIcon />}
+                startIcon={
+                    !hideText && <AddBoxOutlinedIcon {...svgIconProps} />
+                }
                 title={disabledTitle()}
+                variant="contained"
                 {...rest}
             >
                 {hideText ? (
-                    <AddBoxOutlinedIcon />
+                    <AddBoxOutlinedIcon {...svgIconProps} />
                 ) : (
                     children ?? translate("buttons.create", "Create")
                 )}

--- a/packages/mui/src/components/buttons/delete/index.tsx
+++ b/packages/mui/src/components/buttons/delete/index.tsx
@@ -17,6 +17,7 @@ import {
     Dialog,
     DialogActions,
     DialogTitle,
+    SvgIconProps,
 } from "@mui/material";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import { LoadingButton } from "@mui/lab";
@@ -33,6 +34,7 @@ export type DeleteButtonProps = ButtonProps & {
     confirmTitle?: string;
     confirmOkText?: string;
     confirmCancelText?: string;
+    svgIconProps?: SvgIconProps;
 } & SuccessErrorNotification;
 
 /**
@@ -55,6 +57,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     confirmTitle,
     confirmOkText,
     confirmCancelText,
+    svgIconProps,
     ...rest
 }) => {
     const { resourceName, id } = useResource({
@@ -115,11 +118,11 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
                 onClick={handleClickOpen}
                 disabled={data?.can === false}
                 loading={id === variables?.id && isLoading}
-                startIcon={!hideText && <DeleteOutlineIcon />}
+                startIcon={!hideText && <DeleteOutlineIcon {...svgIconProps} />}
                 {...rest}
             >
                 {hideText ? (
-                    <DeleteOutlineIcon />
+                    <DeleteOutlineIcon {...svgIconProps} />
                 ) : (
                     children ?? translate("buttons.delete", "Delete")
                 )}

--- a/packages/mui/src/components/buttons/edit/index.tsx
+++ b/packages/mui/src/components/buttons/edit/index.tsx
@@ -7,8 +7,7 @@ import {
     useResource,
     useRouterContext,
 } from "@pankod/refine-core";
-
-import { Button, ButtonProps } from "@mui/material";
+import { Button, ButtonProps, SvgIconProps } from "@mui/material";
 import EditOutlinedIcon from "@mui/icons-material/EditOutlined";
 
 export type EditButtonProps = ButtonProps & {
@@ -16,6 +15,7 @@ export type EditButtonProps = ButtonProps & {
     recordItemId?: BaseKey;
     hideText?: boolean;
     ignoreAccessControlProvider?: boolean;
+    svgIconProps?: SvgIconProps;
 };
 
 /**
@@ -29,6 +29,7 @@ export const EditButton: React.FC<EditButtonProps> = ({
     recordItemId,
     hideText = false,
     ignoreAccessControlProvider = false,
+    svgIconProps,
     children,
     onClick,
     ...rest
@@ -79,12 +80,12 @@ export const EditButton: React.FC<EditButtonProps> = ({
         >
             <Button
                 disabled={data?.can === false}
-                startIcon={!hideText && <EditOutlinedIcon />}
+                startIcon={!hideText && <EditOutlinedIcon {...svgIconProps} />}
                 title={disabledTitle()}
                 {...rest}
             >
                 {hideText ? (
-                    <EditOutlinedIcon />
+                    <EditOutlinedIcon {...svgIconProps} />
                 ) : (
                     children ?? translate("buttons.edit", "Edit")
                 )}

--- a/packages/mui/src/components/buttons/export/index.tsx
+++ b/packages/mui/src/components/buttons/export/index.tsx
@@ -3,10 +3,12 @@ import { useTranslate } from "@pankod/refine-core";
 
 import ImportExportOutlinedIcon from "@mui/icons-material/ImportExportOutlined";
 import { LoadingButton, LoadingButtonProps } from "@mui/lab";
+import { SvgIconProps } from "@mui/material";
 
 export type ExportButtonProps = LoadingButtonProps & {
     hideText?: boolean;
     loading?: boolean;
+    svgIconProps?: SvgIconProps;
 };
 
 /**
@@ -18,6 +20,7 @@ export const ExportButton: React.FC<ExportButtonProps> = ({
     hideText = false,
     children,
     loading = false,
+    svgIconProps,
     ...rest
 }) => {
     const translate = useTranslate();
@@ -26,12 +29,14 @@ export const ExportButton: React.FC<ExportButtonProps> = ({
         <LoadingButton
             {...rest}
             loading={loading}
-            startIcon={!hideText && <ImportExportOutlinedIcon />}
+            startIcon={
+                !hideText && <ImportExportOutlinedIcon {...svgIconProps} />
+            }
         >
             {hideText ? (
-                <ImportExportOutlinedIcon />
+                <ImportExportOutlinedIcon {...svgIconProps} />
             ) : (
-                children ?? translate("LoadingButtons.export", "Export")
+                children ?? translate("buttons.export", "Export")
             )}
         </LoadingButton>
     );

--- a/packages/mui/src/components/buttons/import/index.tsx
+++ b/packages/mui/src/components/buttons/import/index.tsx
@@ -4,11 +4,13 @@ import { LoadingButton } from "@mui/lab";
 import ImportExportOutlinedIcon from "@mui/icons-material/ImportExportOutlined";
 
 import { useTranslate, UseImportInputPropsType } from "@pankod/refine-core";
+import { SvgIconProps } from "@mui/material";
 
 export type ImportButtonProps = {
     inputProps: UseImportInputPropsType;
     hideText?: boolean;
     loading?: boolean;
+    svgIconProps?: SvgIconProps;
 };
 
 /**
@@ -20,6 +22,7 @@ export const ImportButton: React.FC<ImportButtonProps> = ({
     inputProps,
     hideText = false,
     loading = false,
+    svgIconProps,
     children,
 }) => {
     const translate = useTranslate();
@@ -29,11 +32,13 @@ export const ImportButton: React.FC<ImportButtonProps> = ({
             <input {...inputProps} id="contained-button-file" multiple hidden />
             <LoadingButton
                 component="span"
-                startIcon={!hideText && <ImportExportOutlinedIcon />}
+                startIcon={
+                    !hideText && <ImportExportOutlinedIcon {...svgIconProps} />
+                }
                 loading={loading}
             >
                 {hideText ? (
-                    <ImportExportOutlinedIcon />
+                    <ImportExportOutlinedIcon {...svgIconProps} />
                 ) : (
                     children ?? translate("buttons.import", "Import")
                 )}

--- a/packages/mui/src/components/buttons/list/index.tsx
+++ b/packages/mui/src/components/buttons/list/index.tsx
@@ -8,13 +8,14 @@ import {
     useRouterContext,
 } from "@pankod/refine-core";
 
-import { Button, ButtonProps } from "@mui/material";
+import { Button, ButtonProps, SvgIconProps } from "@mui/material";
 import ListOutlinedIcon from "@mui/icons-material/ListOutlined";
 
 export type ListButtonProps = ButtonProps & {
     resourceNameOrRouteName?: string;
     hideText?: boolean;
     ignoreAccessControlProvider?: boolean;
+    svgIconProps?: SvgIconProps;
 };
 
 /**
@@ -27,6 +28,7 @@ export const ListButton: React.FC<ListButtonProps> = ({
     resourceNameOrRouteName,
     hideText = false,
     ignoreAccessControlProvider = false,
+    svgIconProps,
     children,
     onClick,
     ...rest
@@ -75,12 +77,12 @@ export const ListButton: React.FC<ListButtonProps> = ({
         >
             <Button
                 disabled={data?.can === false}
-                startIcon={!hideText && <ListOutlinedIcon />}
+                startIcon={!hideText && <ListOutlinedIcon {...svgIconProps} />}
                 title={disabledTitle()}
                 {...rest}
             >
                 {hideText ? (
-                    <ListOutlinedIcon />
+                    <ListOutlinedIcon {...svgIconProps} />
                 ) : (
                     children ??
                     translate(

--- a/packages/mui/src/components/buttons/refresh/index.tsx
+++ b/packages/mui/src/components/buttons/refresh/index.tsx
@@ -8,7 +8,7 @@ import {
     useResource,
 } from "@pankod/refine-core";
 
-import { ButtonProps } from "@mui/material";
+import { ButtonProps, SvgIconProps } from "@mui/material";
 import RefreshOutlinedIcon from "@mui/icons-material/RefreshOutlined";
 import { LoadingButton } from "@mui/lab";
 
@@ -18,6 +18,7 @@ export type RefreshButtonProps = ButtonProps & {
     hideText?: boolean;
     metaData?: MetaDataQuery;
     dataProviderName?: string;
+    svgIconProps?: SvgIconProps;
 };
 
 /**
@@ -31,6 +32,7 @@ export const RefreshButton: React.FC<RefreshButtonProps> = ({
     hideText = false,
     metaData,
     dataProviderName,
+    svgIconProps,
     children,
     onClick,
     ...rest
@@ -55,13 +57,13 @@ export const RefreshButton: React.FC<RefreshButtonProps> = ({
 
     return (
         <LoadingButton
-            startIcon={!hideText && <RefreshOutlinedIcon />}
+            startIcon={!hideText && <RefreshOutlinedIcon {...svgIconProps} />}
             loading={isFetching}
             onClick={(e) => (onClick ? onClick(e) : refetch())}
             {...rest}
         >
             {hideText ? (
-                <RefreshOutlinedIcon />
+                <RefreshOutlinedIcon {...svgIconProps} />
             ) : (
                 children ?? translate("buttons.refresh", "Refresh")
             )}

--- a/packages/mui/src/components/buttons/save/index.tsx
+++ b/packages/mui/src/components/buttons/save/index.tsx
@@ -4,9 +4,11 @@ import { useTranslate } from "@pankod/refine-core";
 
 import SaveOutlinedIcon from "@mui/icons-material/SaveOutlined";
 import { LoadingButton, LoadingButtonProps } from "@mui/lab";
+import { SvgIconProps } from "@mui/material";
 
 export type SaveButtonProps = LoadingButtonProps & {
     hideText?: boolean;
+    svgIconProps?: SvgIconProps;
 };
 
 /**
@@ -16,15 +18,19 @@ export type SaveButtonProps = LoadingButtonProps & {
  */
 export const SaveButton: React.FC<SaveButtonProps> = ({
     hideText = false,
+    svgIconProps,
     children,
     ...rest
 }) => {
     const translate = useTranslate();
 
     return (
-        <LoadingButton startIcon={!hideText && <SaveOutlinedIcon />} {...rest}>
+        <LoadingButton
+            startIcon={!hideText && <SaveOutlinedIcon {...svgIconProps} />}
+            {...rest}
+        >
             {hideText ? (
-                <SaveOutlinedIcon />
+                <SaveOutlinedIcon {...svgIconProps} />
             ) : (
                 children ?? translate("buttons.save", "Save")
             )}

--- a/packages/mui/src/components/buttons/show/index.tsx
+++ b/packages/mui/src/components/buttons/show/index.tsx
@@ -9,7 +9,7 @@ import {
     useRouterContext,
 } from "@pankod/refine-core";
 
-import { Button, ButtonProps } from "@mui/material";
+import { Button, ButtonProps, SvgIconProps } from "@mui/material";
 import VisibilityOutlinedIcon from "@mui/icons-material/VisibilityOutlined";
 
 export type ShowButtonProps = ButtonProps & {
@@ -17,6 +17,7 @@ export type ShowButtonProps = ButtonProps & {
     recordItemId?: BaseKey;
     hideText?: boolean;
     ignoreAccessControlProvider?: boolean;
+    svgIconProps?: SvgIconProps;
 };
 
 /**
@@ -30,6 +31,7 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
     recordItemId,
     hideText = false,
     ignoreAccessControlProvider = false,
+    svgIconProps,
     children,
     onClick,
     ...rest
@@ -80,12 +82,14 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
         >
             <Button
                 disabled={data?.can === false}
-                startIcon={!hideText && <VisibilityOutlinedIcon />}
+                startIcon={
+                    !hideText && <VisibilityOutlinedIcon {...svgIconProps} />
+                }
                 title={disabledTitle()}
                 {...rest}
             >
                 {hideText ? (
-                    <VisibilityOutlinedIcon />
+                    <VisibilityOutlinedIcon {...svgIconProps} />
                 ) : (
                     children ?? translate("buttons.show", "Show")
                 )}

--- a/packages/mui/src/components/fields/date/index.tsx
+++ b/packages/mui/src/components/fields/date/index.tsx
@@ -20,7 +20,7 @@ export type DateFieldProps = FieldProps<ConfigType> &
 
 /**
  * This field is used to display dates. It uses {@link https://day.js.org/docs/en/display/format `Day.js`} to display date format and
- * Material UI {@link https://mui.com/material-ui/react-typography/#main-content `<Typography.Link>`} component
+ * Material UI {@link https://mui.com/material-ui/react-typography/#main-content `<Typography>`} component
  */
 export const DateField: React.FC<DateFieldProps> = ({
     value,

--- a/packages/mui/src/components/fields/text/index.tsx
+++ b/packages/mui/src/components/fields/text/index.tsx
@@ -7,7 +7,7 @@ import { FieldProps } from "src/interfaces/field";
 export type TextFieldProps = FieldProps<ReactNode> & TypographyProps;
 
 /**
- * This field lets you show basic text. It uses Materail UI {@link https://mui.com/material-ui/react-typography/#main-content `<Typography.Link>`} component.
+ * This field lets you show basic text. It uses Materail UI {@link https://mui.com/material-ui/react-typography/#main-content `<Typography>`} component.
  *
  */
 const TextField: React.FC<TextFieldProps> = ({ value, ...rest }) => {


### PR DESCRIPTION
In this PR, We have been passed svgIconProps to all buttons that served from @pankod/refine-mui. 