### PR TITLE
fix: mui error component responsive style

### DIFF
--- a/.changeset/young-bags-knock.md
+++ b/.changeset/young-bags-knock.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": patch
+---
+
+fixed the `<ErrorComponent/>` to be responsive to mobile screens

--- a/examples/base/mui/src/App.tsx
+++ b/examples/base/mui/src/App.tsx
@@ -9,6 +9,8 @@ import {
     LightTheme,
     DarkTheme,
     useMediaQuery,
+    CssBaseline,
+    GlobalStyles,
 } from "@pankod/refine-mui";
 import dataProvider from "@pankod/refine-simple-rest";
 import routerProvider from "@pankod/refine-react-router-v6";
@@ -35,6 +37,8 @@ const App: React.FC = () => {
 
     return (
         <ThemeProvider theme={theme}>
+            <CssBaseline />
+            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
             <Refine
                 authProvider={authProvider}
                 routerProvider={routerProvider}

--- a/packages/mui/src/components/pages/error/index.tsx
+++ b/packages/mui/src/components/pages/error/index.tsx
@@ -53,8 +53,18 @@ export const ErrorComponent: React.FC = () => {
     }, [params]);
 
     return (
-        <Grid justifyContent="center" display="flex" alignItems="center" p={24}>
-            <Grid direction="column" display="flex" alignItems="center">
+        <Grid
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+            mt={20}
+        >
+            <Grid
+                container
+                direction="column"
+                display="flex"
+                alignItems="center"
+            >
                 <Typography variant="h1">404</Typography>
                 <Stack direction="row" spacing="2">
                     <Typography>


### PR DESCRIPTION
In this PR, I fixed the `<ErrorComponent/>` to be responsive to mobile screens.