### PR TITLE
fix: if the resource is undefined useBreadcrumb throws error

### DIFF
--- a/packages/core/src/hooks/breadcrumb/index.ts
+++ b/packages/core/src/hooks/breadcrumb/index.ts
@@ -22,6 +22,10 @@ export const useBreadcrumb = (): UseBreadcrumbReturnType => {
 
     const breadcrumbs: BreadcrumbsType[] = [];
 
+    if (!resource?.name) {
+        return { breadcrumbs };
+    }
+
     const addBreadcrumb = (parentName: string) => {
         const parentResource = resources.find(
             (resource) => resource.name === parentName,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

The `useBreadcrumb` hook was throwing an error if the resource was undefined (eg next.js custom route).