### PR TITLE
refactor: rename mui notification provider

### DIFF
--- a/.changeset/orange-islands-leave.md
+++ b/.changeset/orange-islands-leave.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": patch
+---
+
+Renamed export `notificationProviderHandle` from `@pankod/refine-mui` to `notificationProvider` for consistency across packages

--- a/examples/fineFoods/admin/mui/src/App.tsx
+++ b/examples/fineFoods/admin/mui/src/App.tsx
@@ -2,7 +2,7 @@ import { Refine } from "@pankod/refine-core";
 import {
     ErrorComponent,
     ReadyPage,
-    notificationProviderHandle,
+    notificationProvider,
     Layout,
     GlobalStyles,
     CssBaseline,
@@ -87,7 +87,7 @@ const App: React.FC = () => {
                         catchAll={<ErrorComponent />}
                         syncWithLocation
                         warnWhenUnsavedChanges
-                        notificationProvider={notificationProviderHandle}
+                        notificationProvider={notificationProvider}
                         resources={[
                             {
                                 name: "orders",

--- a/packages/mui/src/providers/notificationProvider/index.spec.tsx
+++ b/packages/mui/src/providers/notificationProvider/index.spec.tsx
@@ -5,7 +5,7 @@ import { OpenNotificationParams } from "@pankod/refine-core";
 
 import { CircularDeterminate } from "@components/circularDeterminate";
 
-import { notificationProviderHandle } from ".";
+import { notificationProvider } from ".";
 
 const cancelMutationMock = jest.fn();
 
@@ -42,7 +42,7 @@ describe("Notistack notificationProvider", () => {
             } as any),
     );
 
-    const notificationProvider = notificationProviderHandle();
+    const notificationProvider = notificationProvider();
 
     // This test cover the case when the type is not "progress" ("success" or "error")
 

--- a/packages/mui/src/providers/notificationProvider/index.tsx
+++ b/packages/mui/src/providers/notificationProvider/index.tsx
@@ -7,7 +7,7 @@ import { CircularDeterminate } from "@components";
 import { IconButton } from "@mui/material";
 import { UndoOutlined } from "@mui/icons-material";
 
-export const notificationProviderHandle = (): NotificationProvider => {
+export const notificationProvider = (): NotificationProvider => {
     const { closeSnackbar, enqueueSnackbar } = useSnackbar();
 
     const notificationProvider: NotificationProvider = {


### PR DESCRIPTION
Renamed `notificationProviderHandle` in `@pankod/refine-mui` to `notificationProvider` for consistency across packages.