### PR TITLE
fix: eslint react/display-name issue on examples

### DIFF
--- a/examples/base/mui/src/pages/useModalForm/list.tsx
+++ b/examples/base/mui/src/pages/useModalForm/list.tsx
@@ -62,10 +62,9 @@ export const UseModalFormList: React.FC = () => {
                 field: "actions",
                 headerName: "Actions",
                 width: 150,
-                // eslint-disable-next-line react/display-name
-                renderCell: (params) => (
-                    <EditButton onClick={() => showEdit(params.id)} />
-                ),
+                renderCell: function render({ row }) {
+                    return <EditButton onClick={() => showEdit(row.id)} />;
+                },
             },
         ],
         [],

--- a/examples/base/mui/src/pages/useStepsForm/list.tsx
+++ b/examples/base/mui/src/pages/useStepsForm/list.tsx
@@ -18,8 +18,9 @@ const columns: GridColumns = [
     {
         field: "action",
         headerName: "Actions",
-        // eslint-disable-next-line react/display-name
-        renderCell: (params) => <EditButton recordItemId={params.id} />,
+        renderCell: function render({ row }) {
+            return <EditButton recordItemId={row.id} />;
+        },
     },
 ];
 

--- a/examples/baseHeadless/src/pages/posts/list.tsx
+++ b/examples/baseHeadless/src/pages/posts/list.tsx
@@ -41,10 +41,13 @@ export const PostList: React.FC = () => {
                 id: "action",
                 Header: "Action",
                 accessor: "id",
-                // eslint-disable-next-line react/display-name
-                Cell: ({ value }) => (
-                    <button onClick={() => edit("posts", value)}>Edit</button>
-                ),
+                Cell: function render({ value }) {
+                    return (
+                        <button onClick={() => edit("posts", value)}>
+                            Edit
+                        </button>
+                    );
+                },
             },
         ],
         [],

--- a/examples/blog/win95/src/pages/posts/list.tsx
+++ b/examples/blog/win95/src/pages/posts/list.tsx
@@ -66,7 +66,7 @@ export const PostList = () => {
                 id: "category.id",
                 Header: "Category",
                 accessor: "category.id",
-                Cell: ({ cell }) => {
+                Cell: function render({ cell }) {
                     const { data, isLoading } = useOne<ICategory>({
                         resource: "categories",
                         id: (cell.row.original as any).categoryId,
@@ -83,10 +83,13 @@ export const PostList = () => {
                 id: "action",
                 Header: "Action",
                 accessor: "id",
-                // eslint-disable-next-line react/display-name
-                Cell: ({ value }) => (
-                    <Button onClick={() => edit("posts", value)}>Edit</Button>
-                ),
+                Cell: function render({ value }) {
+                    return (
+                        <Button onClick={() => edit("posts", value)}>
+                            Edit
+                        </Button>
+                    );
+                },
             },
         ],
         [],

--- a/examples/field/useSelect/mui/src/pages/posts/list.tsx
+++ b/examples/field/useSelect/mui/src/pages/posts/list.tsx
@@ -19,19 +19,9 @@ const columns: GridColumns = [
     {
         field: "actions",
         headerName: "Actions",
-        // eslint-disable-next-line react/display-name
-        renderCell: ({ row }) => (
-            <EditButton
-                svgIconProps={{ fontSize: "small" }}
-                variant="outlined"
-                size="small"
-                hideText
-                recordItemId={row.id}
-                sx={{
-                    minWidth: "24px",
-                }}
-            />
-        ),
+        renderCell: function render({ row }) {
+            return <EditButton hideText recordItemId={row.id} />;
+        },
         align: "center",
         headerAlign: "center",
         minWidth: 80,

--- a/examples/fineFoods/admin/mui/src/pages/categories/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/categories/list.tsx
@@ -65,10 +65,9 @@ export const CategoryList: React.FC<IResourceComponentsProps> = () => {
                 id: "title",
                 Header: t("categories.fields.title"),
                 accessor: "title",
-                // eslint-disable-next-line react/display-name
-                Cell: ({
+                Cell: function render({
                     row,
-                }: React.PropsWithChildren<CellProps<ICategory>>) => {
+                }: React.PropsWithChildren<CellProps<ICategory>>) {
                     return (
                         <Stack direction="row" spacing={3}>
                             <span {...row.getToggleRowExpandedProps()}>
@@ -87,21 +86,19 @@ export const CategoryList: React.FC<IResourceComponentsProps> = () => {
                 id: "isActive",
                 Header: t("categories.fields.isActive"),
                 accessor: "isActive",
-                // eslint-disable-next-line react/display-name
-                Cell: ({
+                Cell: function render({
                     value,
-                }: React.PropsWithChildren<CellProps<ICategory>>) => (
-                    <BooleanField value={value} />
-                ),
+                }: React.PropsWithChildren<CellProps<ICategory>>) {
+                    return <BooleanField value={value} />;
+                },
             },
             {
                 id: "actions",
                 Header: "Actions",
                 accessor: "id",
-                //eslint-disable-next-line react/display-name
-                Cell: ({
+                Cell: function render({
                     value,
-                }: React.PropsWithChildren<CellProps<{ id: number }>>) => {
+                }: React.PropsWithChildren<CellProps<{ id: number }>>) {
                     return (
                         <Stack direction="row">
                             {id ? (
@@ -339,20 +336,22 @@ const CategoryProductsTable: React.FC<{ record: ICategory }> = ({ record }) => {
         () => [
             {
                 field: "image",
-                // eslint-disable-next-line react/display-name
-                renderHeader: () => <></>,
+                renderHeader: function render() {
+                    return <></>;
+                },
                 filterable: false,
                 filterOperators: undefined,
                 disableColumnMenu: true,
                 hideSortIcons: true,
-                // eslint-disable-next-line react/display-name
-                renderCell: ({ row }) => (
-                    <Avatar
-                        alt={`${row.name}`}
-                        src={row.images[0]?.url}
-                        sx={{ width: 74, height: 74 }}
-                    />
-                ),
+                renderCell: function render({ row }) {
+                    return (
+                        <Avatar
+                            alt={`${row.name}`}
+                            src={row.images[0]?.url}
+                            sx={{ width: 74, height: 74 }}
+                        />
+                    );
+                },
                 flex: 1,
                 minWidth: 100,
             },
@@ -365,17 +364,18 @@ const CategoryProductsTable: React.FC<{ record: ICategory }> = ({ record }) => {
             {
                 field: "price",
                 headerName: t("products.fields.price"),
-                // eslint-disable-next-line react/display-name
-                renderCell: ({ value }) => (
-                    <NumberField
-                        options={{
-                            currency: "USD",
-                            style: "currency",
-                            notation: "compact",
-                        }}
-                        value={value / 100}
-                    />
-                ),
+                renderCell: function render({ value }) {
+                    return (
+                        <NumberField
+                            options={{
+                                currency: "USD",
+                                style: "currency",
+                                notation: "compact",
+                            }}
+                            value={value / 100}
+                        />
+                    );
+                },
                 flex: 1,
                 minWidth: 100,
             },
@@ -383,18 +383,18 @@ const CategoryProductsTable: React.FC<{ record: ICategory }> = ({ record }) => {
                 field: "isActive",
 
                 headerName: t("products.fields.isActive"),
-                // eslint-disable-next-line react/display-name
-                renderCell: ({ row }) => <BooleanField value={row.isActive} />,
+                renderCell: function render({ row }) {
+                    return <BooleanField value={row.isActive} />;
+                },
                 flex: 0.5,
                 minWidth: 100,
             },
             {
                 field: "createdAt",
                 headerName: t("products.fields.createdAt"),
-                // eslint-disable-next-line react/display-name
-                renderCell: ({ row }) => (
-                    <DateField value={row.createdAt} format="LLL" />
-                ),
+                renderCell: function render({ row }) {
+                    return <DateField value={row.createdAt} format="LLL" />;
+                },
                 flex: 1,
                 minWidth: 200,
             },
@@ -403,15 +403,17 @@ const CategoryProductsTable: React.FC<{ record: ICategory }> = ({ record }) => {
                 field: "actions",
                 headerName: t("table.actions"),
                 type: "actions",
-                getActions: ({ row }) => [
-                    <GridActionsCellItem
-                        key={1}
-                        label={t("buttons.edit")}
-                        icon={<Edit />}
-                        onClick={() => showEditDrawer(row.id)}
-                        showInMenu
-                    />,
-                ],
+                getActions: function render({ row }) {
+                    return [
+                        <GridActionsCellItem
+                            key={1}
+                            label={t("buttons.edit")}
+                            icon={<Edit />}
+                            onClick={() => showEditDrawer(row.id)}
+                            showInMenu
+                        />,
+                    ];
+                },
                 flex: 0.5,
                 minWidth: 100,
             },

--- a/examples/fineFoods/admin/mui/src/pages/couriers/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/couriers/list.tsx
@@ -30,18 +30,19 @@ export const CourierList: React.FC<IResourceComponentsProps> = () => {
             {
                 field: "name",
                 headerName: t("couriers.fields.name"),
-                // eslint-disable-next-line react/display-name
-                renderCell: ({ row }) => (
-                    <Stack alignItems="center" direction="row" spacing={2}>
-                        <Avatar
-                            alt={`${row.name} ${row.surname}`}
-                            src={row.avatar?.[0]?.url}
-                        />
-                        <Typography variant="body2">
-                            {row.name} {row.surname}
-                        </Typography>
-                    </Stack>
-                ),
+                renderCell: function render({ row }) {
+                    return (
+                        <Stack alignItems="center" direction="row" spacing={2}>
+                            <Avatar
+                                alt={`${row.name} ${row.surname}`}
+                                src={row.avatar?.[0]?.url}
+                            />
+                            <Typography variant="body2">
+                                {row.name} {row.surname}
+                            </Typography>
+                        </Stack>
+                    );
+                },
                 flex: 1,
                 minWidth: 200,
             },
@@ -60,20 +61,21 @@ export const CourierList: React.FC<IResourceComponentsProps> = () => {
             {
                 field: "address",
                 headerName: t("couriers.fields.address"),
-                // eslint-disable-next-line react/display-name
-                renderCell: ({ row }) => (
-                    <Tooltip title={row.address}>
-                        <Typography
-                            variant="body2"
-                            sx={{
-                                textOverflow: "ellipsis",
-                                overflow: "hidden",
-                            }}
-                        >
-                            {row.address}
-                        </Typography>
-                    </Tooltip>
-                ),
+                renderCell: function render({ row }) {
+                    return (
+                        <Tooltip title={row.address}>
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    textOverflow: "ellipsis",
+                                    overflow: "hidden",
+                                }}
+                            >
+                                {row.address}
+                            </Typography>
+                        </Tooltip>
+                    );
+                },
                 flex: 1,
                 minWidth: 300,
             },
@@ -81,28 +83,30 @@ export const CourierList: React.FC<IResourceComponentsProps> = () => {
                 field: "actions",
                 headerName: t("table.actions"),
                 type: "actions",
-                getActions: ({ row }) => [
-                    <GridActionsCellItem
-                        key={1}
-                        label={t("buttons.edit")}
-                        icon={<Edit color="success" />}
-                        onClick={() => edit("couriers", row.id)}
-                        showInMenu
-                    />,
-                    <GridActionsCellItem
-                        key={2}
-                        label={t("buttons.delete")}
-                        icon={<Close color="error" />}
-                        onClick={() => {
-                            mutateDelete({
-                                resource: "couriers",
-                                id: row.id,
-                                mutationMode: "undoable",
-                            });
-                        }}
-                        showInMenu
-                    />,
-                ],
+                getActions: function render({ row }) {
+                    return [
+                        <GridActionsCellItem
+                            key={1}
+                            label={t("buttons.edit")}
+                            icon={<Edit color="success" />}
+                            onClick={() => edit("couriers", row.id)}
+                            showInMenu
+                        />,
+                        <GridActionsCellItem
+                            key={2}
+                            label={t("buttons.delete")}
+                            icon={<Close color="error" />}
+                            onClick={() => {
+                                mutateDelete({
+                                    resource: "couriers",
+                                    id: row.id,
+                                    mutationMode: "undoable",
+                                });
+                            }}
+                            showInMenu
+                        />,
+                    ];
+                },
             },
         ],
         [],

--- a/examples/fineFoods/admin/mui/src/pages/couriers/show.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/couriers/show.tsx
@@ -69,35 +69,37 @@ export const CourierShow: React.FC<IResourceComponentsProps> = () => {
             {
                 field: "id",
                 headerName: t("reviews.fields.orderId"),
-                // eslint-disable-next-line react/display-name
-                renderCell: ({ row }) => (
-                    <Button
-                        onClick={() => {
-                            show("orders", row.order.id);
-                        }}
-                    >
-                        #{row.order.id}
-                    </Button>
-                ),
+                renderCell: function render({ row }) {
+                    return (
+                        <Button
+                            onClick={() => {
+                                show("orders", row.order.id);
+                            }}
+                        >
+                            #{row.order.id}
+                        </Button>
+                    );
+                },
                 width: 150,
             },
 
             {
                 field: "review",
                 headerName: t("reviews.fields.review"),
-                // eslint-disable-next-line react/display-name
-                renderCell: ({ row }) => (
-                    <Tooltip title={row.comment[0]}>
-                        <Typography
-                            sx={{
-                                textOverflow: "ellipsis",
-                                overflow: "hidden",
-                            }}
-                        >
-                            {row.comment[0]}
-                        </Typography>
-                    </Tooltip>
-                ),
+                renderCell: function render({ row }) {
+                    return (
+                        <Tooltip title={row.comment[0]}>
+                            <Typography
+                                sx={{
+                                    textOverflow: "ellipsis",
+                                    overflow: "hidden",
+                                }}
+                            >
+                                {row.comment[0]}
+                            </Typography>
+                        </Tooltip>
+                    );
+                },
                 flex: 1,
             },
             {
@@ -106,19 +108,20 @@ export const CourierShow: React.FC<IResourceComponentsProps> = () => {
                 headerAlign: "center",
                 flex: 1,
                 align: "center",
-                // eslint-disable-next-line react/display-name
-                renderCell: ({ row }) => (
-                    <Stack alignItems="center">
-                        <Typography variant="h5" fontWeight="bold">
-                            {row.star}
-                        </Typography>
-                        <Rating
-                            name="rating"
-                            defaultValue={row.star}
-                            readOnly
-                        />
-                    </Stack>
-                ),
+                renderCell: function render({ row }) {
+                    return (
+                        <Stack alignItems="center">
+                            <Typography variant="h5" fontWeight="bold">
+                                {row.star}
+                            </Typography>
+                            <Rating
+                                name="rating"
+                                defaultValue={row.star}
+                                readOnly
+                            />
+                        </Stack>
+                    );
+                },
             },
         ],
         [],

--- a/examples/fineFoods/client/pages/[id]/[category]/index.tsx
+++ b/examples/fineFoods/client/pages/[id]/[category]/index.tsx
@@ -28,8 +28,9 @@ const Category: React.FC<CategoryPageProps> = ({ category, products }) => {
             {
                 id: "product",
                 accessor: (row: any) => row,
-                // eslint-disable-next-line react/display-name
-                Cell: ({ value }) => <ProductListItem product={value} />,
+                Cell: function render({ value }) {
+                    return <ProductListItem product={value} />;
+                },
             },
         ],
         [],

--- a/examples/reactTable/advanced/src/pages/posts/list.tsx
+++ b/examples/reactTable/advanced/src/pages/posts/list.tsx
@@ -148,43 +148,45 @@ export const PostList: React.FC = () => {
             hooks.visibleColumns.push((columns) => [
                 {
                     id: "selection",
-                    // eslint-disable-next-line react/display-name
-                    Header: ({
+                    Header: function render({
                         getToggleAllPageRowsSelectedProps,
                         selectedFlatRows,
-                    }) => (
-                        <div>
-                            <IndeterminateCheckbox
-                                {...getToggleAllPageRowsSelectedProps()}
-                            />
+                    }) {
+                        return (
+                            <div>
+                                <IndeterminateCheckbox
+                                    {...getToggleAllPageRowsSelectedProps()}
+                                />
 
-                            {selectedFlatRows.length > 0 && (
-                                <button
-                                    onClick={() =>
-                                        deleteSelectedItems(
-                                            selectedFlatRows.map(
-                                                ({ original }: any) =>
-                                                    original.id,
-                                            ),
-                                        )
-                                    }
-                                >
-                                    Delete
-                                </button>
-                            )}
-                        </div>
-                    ),
-                    // eslint-disable-next-line react/display-name
-                    Cell: ({ row }: any) => (
-                        <div>
-                            <IndeterminateCheckbox
-                                {...row.getToggleRowSelectedProps()}
-                            />
-                            <span {...row.getToggleRowExpandedProps()}>
-                                {row.isExpanded ? "👇" : "👉"}
-                            </span>
-                        </div>
-                    ),
+                                {selectedFlatRows.length > 0 && (
+                                    <button
+                                        onClick={() =>
+                                            deleteSelectedItems(
+                                                selectedFlatRows.map(
+                                                    ({ original }: any) =>
+                                                        original.id,
+                                                ),
+                                            )
+                                        }
+                                    >
+                                        Delete
+                                    </button>
+                                )}
+                            </div>
+                        );
+                    },
+                    Cell: function render({ row }: any) {
+                        return (
+                            <div>
+                                <IndeterminateCheckbox
+                                    {...row.getToggleRowSelectedProps()}
+                                />
+                                <span {...row.getToggleRowExpandedProps()}>
+                                    {row.isExpanded ? "👇" : "👉"}
+                                </span>
+                            </div>
+                        );
+                    },
                 },
                 ...columns,
             ]);

--- a/examples/reactToastify/src/pages/posts/list.tsx
+++ b/examples/reactToastify/src/pages/posts/list.tsx
@@ -41,10 +41,13 @@ export const PostList: React.FC = () => {
                 id: "action",
                 Header: "Action",
                 accessor: "id",
-                // eslint-disable-next-line react/display-name
-                Cell: ({ value }) => (
-                    <button onClick={() => edit("posts", value)}>Edit</button>
-                ),
+                Cell: function render({ value }) {
+                    return (
+                        <button onClick={() => edit("posts", value)}>
+                            Edit
+                        </button>
+                    );
+                },
             },
         ],
         [],

--- a/examples/table/mui/advancedTable/src/pages/table/list.tsx
+++ b/examples/table/mui/advancedTable/src/pages/table/list.tsx
@@ -167,25 +167,29 @@ export const PostList: React.FC = () => {
             hooks.visibleColumns.push((columns: any) => [
                 {
                     id: "selection",
-                    // eslint-disable-next-line react/display-name
-                    Header: ({ getToggleAllPageRowsSelectedProps }: any) => (
-                        <>
-                            <IndeterminateCheckbox
-                                {...getToggleAllPageRowsSelectedProps()}
-                            />
-                        </>
-                    ),
-                    // eslint-disable-next-line react/display-name
-                    Cell: ({ row }: any) => (
-                        <>
-                            <IndeterminateCheckbox
-                                {...row.getToggleRowSelectedProps()}
-                            />
-                            <span {...row.getToggleRowExpandedProps()}>
-                                {row.isExpanded ? "👇" : "👉"}
-                            </span>
-                        </>
-                    ),
+                    Header: function render({
+                        getToggleAllPageRowsSelectedProps,
+                    }: any) {
+                        return (
+                            <>
+                                <IndeterminateCheckbox
+                                    {...getToggleAllPageRowsSelectedProps()}
+                                />
+                            </>
+                        );
+                    },
+                    Cell: function render({ row }: any) {
+                        return (
+                            <>
+                                <IndeterminateCheckbox
+                                    {...row.getToggleRowSelectedProps()}
+                                />
+                                <span {...row.getToggleRowExpandedProps()}>
+                                    {row.isExpanded ? "👇" : "👉"}
+                                </span>
+                            </>
+                        );
+                    },
                 },
                 ...columns,
             ]);

--- a/examples/tutorial/headless/src/pages/posts/list.tsx
+++ b/examples/tutorial/headless/src/pages/posts/list.tsx
@@ -70,31 +70,32 @@ export const PostList: React.FC = () => {
                 id: "action",
                 Header: "Action",
                 accessor: "id",
-                // eslint-disable-next-line react/display-name
-                Cell: ({ value }) => (
-                    <div className="flex gap-2">
-                        <button
-                            className="rounded border border-gray-200 p-2 text-xs font-medium leading-tight transition duration-150 ease-in-out hover:bg-indigo-500 hover:text-white"
-                            onClick={() => edit("posts", value)}
-                        >
-                            {EditIcon}
-                        </button>
-                        <button
-                            className="rounded border border-gray-200 p-2 text-xs font-medium leading-tight transition duration-150 ease-in-out hover:bg-indigo-500 hover:text-white"
-                            onClick={() => show("posts", value)}
-                        >
-                            {ShowIcon}
-                        </button>
-                        <button
-                            className="rounded border border-gray-200 p-2 text-xs font-medium leading-tight transition duration-150 ease-in-out hover:bg-red-500 hover:text-white"
-                            onClick={() =>
-                                mutate({ id: value, resource: "posts" })
-                            }
-                        >
-                            {DeleteIcon}
-                        </button>
-                    </div>
-                ),
+                Cell: function render({ value }) {
+                    return (
+                        <div className="flex gap-2">
+                            <button
+                                className="rounded border border-gray-200 p-2 text-xs font-medium leading-tight transition duration-150 ease-in-out hover:bg-indigo-500 hover:text-white"
+                                onClick={() => edit("posts", value)}
+                            >
+                                {EditIcon}
+                            </button>
+                            <button
+                                className="rounded border border-gray-200 p-2 text-xs font-medium leading-tight transition duration-150 ease-in-out hover:bg-indigo-500 hover:text-white"
+                                onClick={() => show("posts", value)}
+                            >
+                                {ShowIcon}
+                            </button>
+                            <button
+                                className="rounded border border-gray-200 p-2 text-xs font-medium leading-tight transition duration-150 ease-in-out hover:bg-red-500 hover:text-white"
+                                onClick={() =>
+                                    mutate({ id: value, resource: "posts" })
+                                }
+                            >
+                                {DeleteIcon}
+                            </button>
+                        </div>
+                    );
+                },
             },
         ],
         [],


### PR DESCRIPTION
In most cases, we ignored eslint's `react/display-name` rule. We've updated our examples to respect this rule