### PR TITLE
Add default `sx` property for Material UI buttons

### DIFF
--- a/.changeset/red-chefs-remain.md
+++ b/.changeset/red-chefs-remain.md
@@ -1,0 +1,11 @@
+---
+"@pankod/refine-mui": minor
+---
+
+Added default `sx` property for Material UI buttons.
+
+```tsx
+const { sx, ...restProps } = rest;
+
+<Button sx={{ minWidth: 0, ...sx }} {...restProps} />;
+```

--- a/examples/field/useSelect/mui/src/pages/posts/list.tsx
+++ b/examples/field/useSelect/mui/src/pages/posts/list.tsx
@@ -19,19 +19,9 @@ const columns: GridColumns = [
     {
         field: "actions",
         headerName: "Actions",
-        // eslint-disable-next-line react/display-name
-        renderCell: ({ row }) => (
-            <EditButton
-                svgIconProps={{ fontSize: "small" }}
-                variant="outlined"
-                size="small"
-                hideText
-                recordItemId={row.id}
-                sx={{
-                    minWidth: "24px",
-                }}
-            />
-        ),
+        renderCell: function render({ row }) {
+            return <EditButton hideText recordItemId={row.id} />;
+        },
         align: "center",
         headerAlign: "center",
         minWidth: 80,

--- a/examples/fineFoods/admin/mui/src/pages/orders/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/orders/list.tsx
@@ -270,7 +270,6 @@ export const OrderList: React.FC<IResourceComponentsProps> = () => {
 
     const { autocompleteProps: userAutocompleteProps } = useAutocomplete({
         resource: "users",
-        optionLabel: "fullName",
         defaultValue: getDefaultFilter("user.id", filters, "eq"),
     });
 

--- a/examples/fineFoods/admin/mui/src/pages/users/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/users/list.tsx
@@ -101,14 +101,10 @@ export const UserList: React.FC<IResourceComponentsProps> = () => {
                 headerName: t("table.actions"),
                 renderCell: ({ row }) => (
                     <ShowButton
-                        svgIconProps={{ fontSize: "small" }}
-                        variant="outlined"
                         size="small"
+                        variant="outlined"
                         hideText
                         recordItemId={row.id}
-                        sx={{
-                            minWidth: "24px",
-                        }}
                     />
                 ),
                 align: "center",

--- a/packages/mui/src/components/buttons/clone/index.tsx
+++ b/packages/mui/src/components/buttons/clone/index.tsx
@@ -66,6 +66,8 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
 
     const cloneUrl = generateCloneUrl(resource.route!, id!);
 
+    const { sx, ...restProps } = rest;
+
     return (
         <Link
             to={cloneUrl}
@@ -85,7 +87,8 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
                     !hideText && <AddBoxOutlinedIcon {...svgIconProps} />
                 }
                 title={disabledTitle()}
-                {...rest}
+                sx={{ minWidth: 0, ...sx }}
+                {...restProps}
             >
                 {hideText ? (
                     <AddBoxOutlinedIcon fontSize="small" {...svgIconProps} />

--- a/packages/mui/src/components/buttons/create/index.tsx
+++ b/packages/mui/src/components/buttons/create/index.tsx
@@ -60,6 +60,8 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
 
     const createUrl = generateCreateUrl(resource.route!);
 
+    const { sx, ...restProps } = rest;
+
     return (
         <Link
             to={createUrl}
@@ -80,7 +82,8 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
                 }
                 title={disabledTitle()}
                 variant="contained"
-                {...rest}
+                sx={{ minWidth: 0, ...sx }}
+                {...restProps}
             >
                 {hideText ? (
                     <AddBoxOutlinedIcon fontSize="small" {...svgIconProps} />

--- a/packages/mui/src/components/buttons/delete/index.tsx
+++ b/packages/mui/src/components/buttons/delete/index.tsx
@@ -112,6 +112,8 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
         );
     };
 
+    const { sx, ...restProps } = rest;
+
     return (
         <div>
             <LoadingButton
@@ -119,7 +121,8 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
                 disabled={data?.can === false}
                 loading={id === variables?.id && isLoading}
                 startIcon={!hideText && <DeleteOutlineIcon {...svgIconProps} />}
-                {...rest}
+                sx={{ minWidth: 0, ...sx }}
+                {...restProps}
             >
                 {hideText ? (
                     <DeleteOutlineIcon fontSize="small" {...svgIconProps} />

--- a/packages/mui/src/components/buttons/edit/index.tsx
+++ b/packages/mui/src/components/buttons/edit/index.tsx
@@ -65,6 +65,8 @@ export const EditButton: React.FC<EditButtonProps> = ({
 
     const editUrl = generateEditUrl(resource.route!, id!);
 
+    const { sx, ...restProps } = rest;
+
     return (
         <Link
             to={editUrl}
@@ -89,7 +91,8 @@ export const EditButton: React.FC<EditButtonProps> = ({
                     )
                 }
                 title={disabledTitle()}
-                {...rest}
+                sx={{ minWidth: 0, ...sx }}
+                {...restProps}
             >
                 {hideText ? (
                     <EditOutlinedIcon fontSize="small" {...svgIconProps} />

--- a/packages/mui/src/components/buttons/export/index.tsx
+++ b/packages/mui/src/components/buttons/export/index.tsx
@@ -25,6 +25,8 @@ export const ExportButton: React.FC<ExportButtonProps> = ({
 }) => {
     const translate = useTranslate();
 
+    const { sx, ...restProps } = rest;
+
     return (
         <LoadingButton
             {...rest}
@@ -32,6 +34,8 @@ export const ExportButton: React.FC<ExportButtonProps> = ({
             startIcon={
                 !hideText && <ImportExportOutlinedIcon {...svgIconProps} />
             }
+            sx={{ minWidth: 0, ...sx }}
+            {...restProps}
         >
             {hideText ? (
                 <ImportExportOutlinedIcon fontSize="small" {...svgIconProps} />

--- a/packages/mui/src/components/buttons/import/index.tsx
+++ b/packages/mui/src/components/buttons/import/index.tsx
@@ -4,9 +4,9 @@ import { LoadingButton } from "@mui/lab";
 import ImportExportOutlinedIcon from "@mui/icons-material/ImportExportOutlined";
 
 import { useTranslate, UseImportInputPropsType } from "@pankod/refine-core";
-import { SvgIconProps } from "@mui/material";
+import { ButtonProps, SvgIconProps } from "@mui/material";
 
-export type ImportButtonProps = {
+export type ImportButtonProps = ButtonProps & {
     inputProps: UseImportInputPropsType;
     hideText?: boolean;
     loading?: boolean;
@@ -24,8 +24,11 @@ export const ImportButton: React.FC<ImportButtonProps> = ({
     loading = false,
     svgIconProps,
     children,
+    ...rest
 }) => {
     const translate = useTranslate();
+
+    const { sx, ...restProps } = rest;
 
     return (
         <label htmlFor="contained-button-file">
@@ -36,6 +39,8 @@ export const ImportButton: React.FC<ImportButtonProps> = ({
                     !hideText && <ImportExportOutlinedIcon {...svgIconProps} />
                 }
                 loading={loading}
+                sx={{ minWidth: 0, ...sx }}
+                {...restProps}
             >
                 {hideText ? (
                     <ImportExportOutlinedIcon

--- a/packages/mui/src/components/buttons/list/index.tsx
+++ b/packages/mui/src/components/buttons/list/index.tsx
@@ -62,6 +62,8 @@ export const ListButton: React.FC<ListButtonProps> = ({
 
     const listUrl = generateListUrl(resource.route!);
 
+    const { sx, ...restProps } = rest;
+
     return (
         <Link
             to={listUrl}
@@ -79,7 +81,8 @@ export const ListButton: React.FC<ListButtonProps> = ({
                 disabled={data?.can === false}
                 startIcon={!hideText && <ListOutlinedIcon {...svgIconProps} />}
                 title={disabledTitle()}
-                {...rest}
+                sx={{ minWidth: 0, ...sx }}
+                {...restProps}
             >
                 {hideText ? (
                     <ListOutlinedIcon fontSize="small" {...svgIconProps} />

--- a/packages/mui/src/components/buttons/refresh/index.tsx
+++ b/packages/mui/src/components/buttons/refresh/index.tsx
@@ -55,12 +55,15 @@ export const RefreshButton: React.FC<RefreshButtonProps> = ({
         dataProviderName,
     });
 
+    const { sx, ...restProps } = rest;
+
     return (
         <LoadingButton
             startIcon={!hideText && <RefreshOutlinedIcon {...svgIconProps} />}
             loading={isFetching}
             onClick={(e) => (onClick ? onClick(e) : refetch())}
-            {...rest}
+            sx={{ minWidth: 0, ...sx }}
+            {...restProps}
         >
             {hideText ? (
                 <RefreshOutlinedIcon fontSize="small" {...svgIconProps} />

--- a/packages/mui/src/components/buttons/save/index.tsx
+++ b/packages/mui/src/components/buttons/save/index.tsx
@@ -24,10 +24,13 @@ export const SaveButton: React.FC<SaveButtonProps> = ({
 }) => {
     const translate = useTranslate();
 
+    const { sx, ...restProps } = rest;
+
     return (
         <LoadingButton
             startIcon={!hideText && <SaveOutlinedIcon {...svgIconProps} />}
-            {...rest}
+            sx={{ minWidth: 0, ...sx }}
+            {...restProps}
         >
             {hideText ? (
                 <SaveOutlinedIcon fontSize="small" {...svgIconProps} />

--- a/packages/mui/src/components/buttons/show/index.tsx
+++ b/packages/mui/src/components/buttons/show/index.tsx
@@ -67,6 +67,8 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
 
     const showUrl = generateShowUrl(resource.route!, id!);
 
+    const { sx, ...restProps } = rest;
+
     return (
         <Link
             to={showUrl}
@@ -86,7 +88,8 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
                     !hideText && <VisibilityOutlinedIcon {...svgIconProps} />
                 }
                 title={disabledTitle()}
-                {...rest}
+                sx={{ minWidth: 0, ...sx }}
+                {...restProps}
             >
                 {hideText ? (
                     <VisibilityOutlinedIcon


### PR DESCRIPTION
Add default `sx` property for Material UI buttons.

```tsx
const { sx, ...restProps } = rest;

<Button sx={{ minWidth: 0, ...sx }} {...restProps} />;
```