### PR TITLE
fix: add graphql-request dependency to peerDependencies

### DIFF
--- a/.changeset/old-pumpkins-attack.md
+++ b/.changeset/old-pumpkins-attack.md
@@ -1,0 +1,7 @@
+---
+"@pankod/refine-graphql": patch
+"@pankod/refine-hasura": patch
+"@pankod/refine-strapi-graphql": patch
+---
+
+Added `graphql-request` dependency to peerDependencies

--- a/examples/dataProvider/nhost/package.json
+++ b/examples/dataProvider/nhost/package.json
@@ -13,7 +13,6 @@
     "@types/react": "^17.0.4",
     "@types/react-dom": "^17.0.4",
     "graphql": "^15.6.1",
-    "graphql-request": "^3.5.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-markdown": "^6.0.1",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -39,7 +39,9 @@
     "pluralize": "^8.0.0"
   },
   "peerDependencies": {
-    "@pankod/refine-core": "^3.23.2"
+    "@pankod/refine-core": "^3.23.2",
+    "graphql-request": "^3.5.0",
+    "gql-query-builder": "^3.5.5"
   },
   "repository": {
     "type": "git",

--- a/packages/hasura/package.json
+++ b/packages/hasura/package.json
@@ -37,7 +37,9 @@
     "graphql-request": "^3.5.0"
   },
   "peerDependencies": {
-    "@pankod/refine-core": "^3.23.2"
+    "@pankod/refine-core": "^3.23.2",
+    "graphql-request": "^3.5.0",
+    "gql-query-builder": "^3.5.5"
   },
   "repository": {
     "type": "git",

--- a/packages/nhost/package.json
+++ b/packages/nhost/package.json
@@ -37,7 +37,8 @@
     "graphql": "^15.6.1"
   },
   "peerDependencies": {
-    "@pankod/refine-core": "^3.23.2"
+    "@pankod/refine-core": "^3.23.2",
+    "gql-query-builder": "^3.5.5"
   },
   "repository": {
     "type": "git",

--- a/packages/strapi-graphql/package.json
+++ b/packages/strapi-graphql/package.json
@@ -40,7 +40,9 @@
     "query-string": "^7.1.1"
   },
   "peerDependencies": {
-    "@pankod/refine-core": "^3.23.2"
+    "@pankod/refine-core": "^3.23.2",
+    "graphql-request": "^3.5.0",
+    "gql-query-builder": "^3.5.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

The `graphql-request` package was not added as a `peerDependency` in the packages `@pankod/refine-graphql`, `@pankod/refine-hasura` and `@pankod/refine-strapi-graphql`. This was causing issue #1929 .

**Closing issues**

- #1929