### PR TITLE
fix: update <CssBaseline> component import order

### DIFF
--- a/documentation/docs/ui-frameworks/mui/tutorial.md
+++ b/documentation/docs/ui-frameworks/mui/tutorial.md
@@ -209,11 +209,9 @@ import dataProvider from "@pankod/refine-simple-rest";
 const App: React.FC = () => {
     return (
         <ThemeProvider theme={LightTheme}>
+            <CssBaseline />
+            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
             <RefineSnackbarProvider>
-                <CssBaseline />
-                <GlobalStyles
-                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
-                />
                 <Refine
                     routerProvider={routerProvider}
                     dataProvider={dataProvider(
@@ -343,11 +341,9 @@ import dataProvider from "@pankod/refine-simple-rest";
 export const App: React.FC = () => {
     return (
         <ThemeProvider theme={LightTheme}>
+            <CssBaseline />
+            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
             <RefineSnackbarProvider>
-                <CssBaseline />
-                <GlobalStyles
-                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
-                />
                 <Refine
                     routerProvider={routerProvider}
                     dataProvider={dataProvider(
@@ -539,11 +535,9 @@ const API_URL = "https://api.fake-rest.refine.dev";
 const App: React.FC = () => {
     return (
         <ThemeProvider theme={LightTheme}>
+            <CssBaseline />
+            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
             <RefineSnackbarProvider>
-                <CssBaseline />
-                <GlobalStyles
-                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
-                />
                 <Refine
                     routerProvider={routerProvider}
                     dataProvider={dataProvider(API_URL)}
@@ -845,11 +839,9 @@ import { PostList, PostShow } from "./pages/posts";
 export const App: React.FC = () => {
     return (
         <ThemeProvider theme={LightTheme}>
+            <CssBaseline />
+            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
             <RefineSnackbarProvider>
-                <CssBaseline />
-                <GlobalStyles
-                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
-                />
                 <Refine
                     routerProvider={routerProvider}
                     dataProvider={dataProvider(
@@ -1147,11 +1139,9 @@ const API_URL = "https://api.fake-rest.refine.dev";
 const App: React.FC = () => {
     return (
         <ThemeProvider theme={LightTheme}>
+            <CssBaseline />
+            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
             <RefineSnackbarProvider>
-                <CssBaseline />
-                <GlobalStyles
-                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
-                />
                 <Refine
                     authProvider={authProvider}
                     routerProvider={routerProvider}
@@ -1431,11 +1421,9 @@ const API_URL = "https://api.fake-rest.refine.dev";
 const App: React.FC = () => {
     return (
         <ThemeProvider theme={LightTheme}>
+            <CssBaseline />
+            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
             <RefineSnackbarProvider>
-                <CssBaseline />
-                <GlobalStyles
-                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
-                />
                 <Refine
                     authProvider={authProvider}
                     routerProvider={routerProvider}
@@ -1602,11 +1590,9 @@ const API_URL = "https://api.fake-rest.refine.dev";
 const App: React.FC = () => {
     return (
         <ThemeProvider theme={LightTheme}>
+            <CssBaseline />
+            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
             <RefineSnackbarProvider>
-                <CssBaseline />
-                <GlobalStyles
-                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
-                />
                 <Refine
                     authProvider={authProvider}
                     routerProvider={routerProvider}

--- a/examples/fineFoods/admin/mui/src/App.tsx
+++ b/examples/fineFoods/admin/mui/src/App.tsx
@@ -49,11 +49,9 @@ const App: React.FC = () => {
 
     return (
         <ColorModeContextProvider>
+            <CssBaseline />
+            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
             <RefineSnackbarProvider>
-                <CssBaseline />
-                <GlobalStyles
-                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
-                />
                 <Refine
                     routerProvider={routerProvider}
                     dataProvider={dataProvider(

--- a/examples/form/mui/useDrawerForm/src/App.tsx
+++ b/examples/form/mui/useDrawerForm/src/App.tsx
@@ -19,11 +19,9 @@ import { PostsList } from "pages/posts";
 const App: React.FC = () => {
     return (
         <ThemeProvider theme={LightTheme}>
+            <CssBaseline />
+            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
             <RefineSnackbarProvider>
-                <CssBaseline />
-                <GlobalStyles
-                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
-                />
                 <Refine
                     routerProvider={routerProvider}
                     dataProvider={dataProvider(

--- a/examples/form/mui/useModalForm/src/App.tsx
+++ b/examples/form/mui/useModalForm/src/App.tsx
@@ -19,11 +19,9 @@ import { PostsList } from "pages/posts";
 const App: React.FC = () => {
     return (
         <ThemeProvider theme={LightTheme}>
+            <CssBaseline />
+            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
             <RefineSnackbarProvider>
-                <CssBaseline />
-                <GlobalStyles
-                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
-                />
                 <Refine
                     routerProvider={routerProvider}
                     dataProvider={dataProvider(

--- a/examples/form/mui/useStepsForm/src/App.tsx
+++ b/examples/form/mui/useStepsForm/src/App.tsx
@@ -19,11 +19,9 @@ import { PostsList, PostCreate, PostEdit } from "pages/posts";
 const App: React.FC = () => {
     return (
         <ThemeProvider theme={LightTheme}>
+            <CssBaseline />
+            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
             <RefineSnackbarProvider>
-                <CssBaseline />
-                <GlobalStyles
-                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
-                />
                 <Refine
                     routerProvider={routerProvider}
                     dataProvider={dataProvider(

--- a/examples/tutorial/mui/src/App.tsx
+++ b/examples/tutorial/mui/src/App.tsx
@@ -19,11 +19,9 @@ const API_URL = "https://api.fake-rest.refine.dev";
 const App: React.FC = () => {
     return (
         <ThemeProvider theme={LightTheme}>
+            <CssBaseline />
+            <GlobalStyles styles={{ html: { WebkitFontSmoothing: "auto" } }} />
             <RefineSnackbarProvider>
-                <CssBaseline />
-                <GlobalStyles
-                    styles={{ html: { WebkitFontSmoothing: "auto" } }}
-                />
                 <Refine
                     routerProvider={routerProvider}
                     dataProvider={dataProvider(API_URL)}


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Fix `<CssBaseline>` import order for Material UI examples and docs