### PR TITLE
fix: stop event bubbling for Link component on buttons

### DIFF
--- a/.changeset/nice-rice-flow.md
+++ b/.changeset/nice-rice-flow.md
@@ -1,0 +1,6 @@
+---
+"@pankod/refine-antd": patch
+"@pankod/refine-mui": patch
+---
+
+Could not stop `e.preventDefault()` redirection in Next.js `<Link>` component. So we added in `e.stopPropagation()` for [Ant Design Buttons](https://refine.dev/docs/ui-frameworks/antd/components/buttons/clone-button/) and [Material UI Buttons](https://refine.dev/docs/ui-frameworks/mui/components/buttons/clone-button/)

--- a/packages/antd/src/components/buttons/clone/index.tsx
+++ b/packages/antd/src/components/buttons/clone/index.tsx
@@ -78,6 +78,7 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
+                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/antd/src/components/buttons/create/index.tsx
+++ b/packages/antd/src/components/buttons/create/index.tsx
@@ -74,6 +74,7 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
+                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/antd/src/components/buttons/edit/index.tsx
+++ b/packages/antd/src/components/buttons/edit/index.tsx
@@ -78,6 +78,7 @@ export const EditButton: React.FC<EditButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
+                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/antd/src/components/buttons/list/index.tsx
+++ b/packages/antd/src/components/buttons/list/index.tsx
@@ -73,6 +73,7 @@ export const ListButton: React.FC<ListButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
+                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/antd/src/components/buttons/show/index.tsx
+++ b/packages/antd/src/components/buttons/show/index.tsx
@@ -79,6 +79,7 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
+                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/mui/src/components/buttons/clone/index.tsx
+++ b/packages/mui/src/components/buttons/clone/index.tsx
@@ -76,6 +76,7 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
+                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/mui/src/components/buttons/create/index.tsx
+++ b/packages/mui/src/components/buttons/create/index.tsx
@@ -70,6 +70,7 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
+                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/mui/src/components/buttons/edit/index.tsx
+++ b/packages/mui/src/components/buttons/edit/index.tsx
@@ -75,6 +75,7 @@ export const EditButton: React.FC<EditButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
+                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/mui/src/components/buttons/list/index.tsx
+++ b/packages/mui/src/components/buttons/list/index.tsx
@@ -72,6 +72,7 @@ export const ListButton: React.FC<ListButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
+                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/mui/src/components/buttons/show/index.tsx
+++ b/packages/mui/src/components/buttons/show/index.tsx
@@ -77,6 +77,7 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
+                    e.stopPropagation();
                     onClick(e);
                 }
             }}


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Could not stop `e.preventDefault()` redirection in Next.js `<Link>` component. So we added in `e.stopPropagation()` for [Ant Design Buttons](https://refine.dev/docs/ui-frameworks/antd/components/buttons/clone-button/) and [Material UI Buttons](https://refine.dev/docs/ui-frameworks/mui/components/buttons/clone-button/)

**Closing issues**

- #1944 