### PR TITLE
fix: revert "stop event bubbling for Link component on buttons"

### DIFF
--- a/.changeset/gorgeous-yaks-dream.md
+++ b/.changeset/gorgeous-yaks-dream.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-nextjs-router": patch
+---
+
+We've updated Next.js version to `12.1.6`

--- a/examples/blog/ecommerce/package.json
+++ b/examples/blog/ecommerce/package.json
@@ -19,7 +19,7 @@
     "@pankod/refine-strapi-v4": "^3.25.4",
     "axios": "^0.26.1",
     "framer-motion": "^5.6.0",
-    "next": "^12.0.3",
+    "next": "^12.1.6",
     "next-compose-plugins": "^2.2.1",
     "nookies": "^2.5.2",
     "react": "^17.0.2",

--- a/examples/fineFoods/client/package.json
+++ b/examples/fineFoods/client/package.json
@@ -15,7 +15,7 @@
     "@pankod/refine-simple-rest": "^3.25.4",
     "gsap": "^3.8.0",
     "js-confetti": "^0.9.0",
-    "next": "^12.0.3",
+    "next": "^12.1.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/examples/i18n/nextjs/package.json
+++ b/examples/i18n/nextjs/package.json
@@ -13,7 +13,7 @@
         "@pankod/refine-core": "^3.29.0",
         "@pankod/refine-nextjs-router": "^3.25.0",
         "@pankod/refine-simple-rest": "^3.25.4",
-        "next": "^12.0.3",
+        "next": "^12.1.6",
         "next-compose-plugins": "^2.2.1",
         "next-i18next": "^8.9.0",
         "nookies": "^2.5.2",

--- a/examples/refine-next/package.json
+++ b/examples/refine-next/package.json
@@ -13,7 +13,7 @@
         "@pankod/refine-core": "^3.29.0",
         "@pankod/refine-nextjs-router": "^3.25.0",
         "@pankod/refine-simple-rest": "^3.25.4",
-        "next": "^12.0.3",
+        "next": "^12.1.6",
         "next-compose-plugins": "^2.2.1",
         "nookies": "^2.5.2",
         "react": "^17.0.2",

--- a/examples/refine-next/src/components/posts/list.tsx
+++ b/examples/refine-next/src/components/posts/list.tsx
@@ -1,48 +1,147 @@
-import { GetListResponse } from "@pankod/refine-core";
 import {
-    useTable,
+    IResourceComponentsProps,
+    GetListResponse,
+    useMany,
+    useTranslate,
+} from "@pankod/refine-core";
+import {
     List,
     Table,
+    TextField,
+    useTable,
+    getDefaultSortOrder,
+    DateField,
     Space,
     EditButton,
-    ShowButton,
     DeleteButton,
+    useSelect,
+    TagField,
+    FilterDropdown,
+    Select,
+    ShowButton,
+    Button,
+    SaveButton,
+    useEditableTable,
 } from "@pankod/refine-antd";
-import type { IResourceComponentsProps } from "@pankod/refine-core";
-import { IPost } from "../../interfaces";
+import { IPost, ICategory } from "src/interfaces";
 
 export const PostList: React.FC<
     IResourceComponentsProps<GetListResponse<IPost>>
 > = ({ initialData }) => {
-    const { tableProps } = useTable<IPost>({
+    const t = useTranslate();
+
+    const {
+        isEditing,
+        saveButtonProps,
+        cancelButtonProps,
+        editButtonProps,
+        tableProps,
+        sorter,
+    } = useEditableTable<IPost>({});
+
+    const categoryIds =
+        tableProps?.dataSource?.map((item) => item.category.id) ?? [];
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
         queryOptions: {
-            initialData,
+            enabled: categoryIds.length > 0,
         },
+    });
+
+    const { selectProps: categorySelectProps } = useSelect<ICategory>({
+        resource: "categories",
     });
 
     return (
         <List>
             <Table {...tableProps} rowKey="id">
-                <Table.Column dataIndex="id" title="ID" />
-                <Table.Column dataIndex="status" title="Status" />
-                <Table.Column dataIndex="title" title="Title" />
+                <Table.Column
+                    dataIndex="id"
+                    key="id"
+                    title="ID"
+                    render={(value) => <TextField value={value} />}
+                    defaultSortOrder={getDefaultSortOrder("id", sorter)}
+                    sorter
+                />
+                <Table.Column
+                    dataIndex="title"
+                    key="title"
+                    title={t("posts.fields.title")}
+                    render={(value) => <TextField value={value} />}
+                    defaultSortOrder={getDefaultSortOrder("title", sorter)}
+                    sorter
+                />
+                <Table.Column
+                    dataIndex="status"
+                    key="status"
+                    title={t("posts.fields.status.title")}
+                    render={(value) => <TagField value={value} />}
+                    defaultSortOrder={getDefaultSortOrder("status", sorter)}
+                    sorter
+                />
+                <Table.Column
+                    dataIndex="createdAt"
+                    key="createdAt"
+                    title={t("posts.fields.createdAt")}
+                    render={(value) => <DateField value={value} format="LLL" />}
+                    defaultSortOrder={getDefaultSortOrder("createdAt", sorter)}
+                    sorter
+                />
+                <Table.Column
+                    dataIndex={["category", "id"]}
+                    title={t("posts.fields.category.title")}
+                    render={(value) => {
+                        if (isLoading) {
+                            return <TextField value={t("loading")} />;
+                        }
+
+                        return (
+                            <TextField
+                                value={
+                                    categoriesData?.data.find(
+                                        (item) => item.id === value,
+                                    )?.title
+                                }
+                            />
+                        );
+                    }}
+                    filterDropdown={(props) => (
+                        <FilterDropdown {...props}>
+                            <Select
+                                style={{ minWidth: 200 }}
+                                mode="multiple"
+                                placeholder={t(
+                                    "posts.fields.category.filter.placeholder",
+                                )}
+                                {...categorySelectProps}
+                            />
+                        </FilterDropdown>
+                    )}
+                />
                 <Table.Column<IPost>
-                    title="Actions"
-                    dataIndex="actions"
-                    render={(_text, record): React.ReactNode => {
+                    title="Inline Actions"
+                    dataIndex="inlineActions"
+                    key="inlineActions"
+                    render={(_text, record) => {
+                        if (isEditing(record.id!)) {
+                            return (
+                                <Space>
+                                    <SaveButton
+                                        {...saveButtonProps}
+                                        size="small"
+                                    />
+                                    <Button {...cancelButtonProps} size="small">
+                                        Cancel
+                                    </Button>
+                                </Space>
+                            );
+                        }
                         return (
                             <Space>
                                 <EditButton
+                                    {...editButtonProps(record.id!)}
                                     size="small"
-                                    recordItemId={record.id}
-                                />
-                                <ShowButton
-                                    size="small"
-                                    recordItemId={record.id}
-                                />
-                                <DeleteButton
-                                    size="small"
-                                    recordItemId={record.id}
                                 />
                             </Space>
                         );

--- a/packages/antd/src/components/buttons/clone/index.tsx
+++ b/packages/antd/src/components/buttons/clone/index.tsx
@@ -78,7 +78,6 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
-                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/antd/src/components/buttons/create/index.tsx
+++ b/packages/antd/src/components/buttons/create/index.tsx
@@ -74,7 +74,6 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
-                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/antd/src/components/buttons/edit/index.tsx
+++ b/packages/antd/src/components/buttons/edit/index.tsx
@@ -78,7 +78,6 @@ export const EditButton: React.FC<EditButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
-                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/antd/src/components/buttons/list/index.tsx
+++ b/packages/antd/src/components/buttons/list/index.tsx
@@ -73,7 +73,6 @@ export const ListButton: React.FC<ListButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
-                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/antd/src/components/buttons/show/index.tsx
+++ b/packages/antd/src/components/buttons/show/index.tsx
@@ -79,7 +79,6 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
-                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/mui/src/components/buttons/clone/index.tsx
+++ b/packages/mui/src/components/buttons/clone/index.tsx
@@ -76,7 +76,6 @@ export const CloneButton: React.FC<CloneButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
-                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/mui/src/components/buttons/create/index.tsx
+++ b/packages/mui/src/components/buttons/create/index.tsx
@@ -70,7 +70,6 @@ export const CreateButton: React.FC<CreateButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
-                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/mui/src/components/buttons/edit/index.tsx
+++ b/packages/mui/src/components/buttons/edit/index.tsx
@@ -75,7 +75,6 @@ export const EditButton: React.FC<EditButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
-                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/mui/src/components/buttons/list/index.tsx
+++ b/packages/mui/src/components/buttons/list/index.tsx
@@ -72,7 +72,6 @@ export const ListButton: React.FC<ListButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
-                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/mui/src/components/buttons/show/index.tsx
+++ b/packages/mui/src/components/buttons/show/index.tsx
@@ -77,7 +77,6 @@ export const ShowButton: React.FC<ShowButtonProps> = ({
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
                 if (onClick) {
                     e.preventDefault();
-                    e.stopPropagation();
                     onClick(e);
                 }
             }}

--- a/packages/nextjs-router/package.json
+++ b/packages/nextjs-router/package.json
@@ -25,7 +25,7 @@
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@types/qs": "^6.9.7",
     "jest": "^27.5.1",
-    "next": "^12.0.3",
+    "next": "^12.1.6",
     "ts-jest": "^27.1.3",
     "tslib": "^2.3.1",
     "tsup": "^5.11.13"


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

We are upgrading our Next.js version and reverting the no longer required PR #1945 