### PR TITLE
fix: remove web-vitals dependency from examples

### DIFF
--- a/examples/ably/package.json
+++ b/examples/ably/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/accessControl/casbin/package.json
+++ b/examples/accessControl/casbin/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/accessControl/cerbos/package.json
+++ b/examples/accessControl/cerbos/package.json
@@ -16,8 +16,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/antdAuditLog/package.json
+++ b/examples/antdAuditLog/package.json
@@ -17,8 +17,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/authProvider/auth0/package.json
+++ b/examples/authProvider/auth0/package.json
@@ -17,8 +17,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/authProvider/googleLogin/package.json
+++ b/examples/authProvider/googleLogin/package.json
@@ -17,8 +17,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/authProvider/otpLogin/package.json
+++ b/examples/authProvider/otpLogin/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/authentication/package.json
+++ b/examples/authentication/package.json
@@ -15,8 +15,7 @@
 		"react-markdown": "^6.0.1",
 		"react-mde": "^11.1.0",
 		"react-scripts": "^5.0.0",
-		"typescript": "^4.4.3",
-		"web-vitals": "^1.1.1"
+		"typescript": "^4.4.3"
 	},
 	"scripts": {
 		"start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/authorization/package.json
+++ b/examples/authorization/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/base/mui/package.json
+++ b/examples/base/mui/package.json
@@ -16,8 +16,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "FAST_REFRESH=false DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/base/package.json
+++ b/examples/base/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "FAST_REFRESH=false DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/baseHeadless/package.json
+++ b/examples/baseHeadless/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/blog/hackathonize/package.json
+++ b/examples/blog/hackathonize/package.json
@@ -19,8 +19,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/blog/invoiceGenerator/package.json
+++ b/examples/blog/invoiceGenerator/package.json
@@ -23,8 +23,7 @@
     "react-dom": "^17.0.2",
     "react-pdf": "^5.7.1",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "dev": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/blog/issueTracker/package.json
+++ b/examples/blog/issueTracker/package.json
@@ -19,8 +19,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/blog/jobPosting/package.json
+++ b/examples/blog/jobPosting/package.json
@@ -20,8 +20,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "dev": "DISABLE_ESLINT_PLUGIN=true craco start",

--- a/examples/blog/mailSubscription/package.json
+++ b/examples/blog/mailSubscription/package.json
@@ -19,8 +19,7 @@
     "react-dom": "^17.0.2",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "dev": "react-scripts start",

--- a/examples/blog/refeedback/package.json
+++ b/examples/blog/refeedback/package.json
@@ -18,8 +18,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "dev": "react-scripts start",

--- a/examples/blog/refineflix/package.json
+++ b/examples/blog/refineflix/package.json
@@ -17,8 +17,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "dev": "react-scripts start",

--- a/examples/blog/win95/package.json
+++ b/examples/blog/win95/package.json
@@ -20,8 +20,7 @@
         "react-scripts": "^5.0.0",
         "react95": "^3.11.1",
         "styled-components": "^5.3.3",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "dev": "react-scripts start",

--- a/examples/calendar/package.json
+++ b/examples/calendar/package.json
@@ -13,8 +13,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "FAST_REFRESH=false DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/core/useImport/package.json
+++ b/examples/core/useImport/package.json
@@ -14,8 +14,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/core/useModal/package.json
+++ b/examples/core/useModal/package.json
@@ -14,8 +14,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/core/useSelect/package.json
+++ b/examples/core/useSelect/package.json
@@ -14,8 +14,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/customPages/package.json
+++ b/examples/customPages/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/customization/customFooter/package.json
+++ b/examples/customization/customFooter/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/customization/customLogin/package.json
+++ b/examples/customization/customLogin/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/customization/customSider/package.json
+++ b/examples/customization/customSider/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/customization/customTheme/package.json
+++ b/examples/customization/customTheme/package.json
@@ -17,8 +17,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true craco start",

--- a/examples/customization/offLayoutArea/package.json
+++ b/examples/customization/offLayoutArea/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/customization/rtl/package.json
+++ b/examples/customization/rtl/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/customization/topMenuLayout/package.json
+++ b/examples/customization/topMenuLayout/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/dataProvider/airtable/package.json
+++ b/examples/dataProvider/airtable/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/dataProvider/altogic/package.json
+++ b/examples/dataProvider/altogic/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/dataProvider/appwrite/package.json
+++ b/examples/dataProvider/appwrite/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/dataProvider/hasura/package.json
+++ b/examples/dataProvider/hasura/package.json
@@ -17,8 +17,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/dataProvider/multiple/package.json
+++ b/examples/dataProvider/multiple/package.json
@@ -15,8 +15,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/dataProvider/nestjsxCrud/package.json
+++ b/examples/dataProvider/nestjsxCrud/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/dataProvider/nhost/package.json
+++ b/examples/dataProvider/nhost/package.json
@@ -18,8 +18,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/dataProvider/strapi-graphql/package.json
+++ b/examples/dataProvider/strapi-graphql/package.json
@@ -17,8 +17,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/dataProvider/strapi-v4/package.json
+++ b/examples/dataProvider/strapi-v4/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/dataProvider/strapi/package.json
+++ b/examples/dataProvider/strapi/package.json
@@ -20,8 +20,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/dataProvider/supabase/package.json
+++ b/examples/dataProvider/supabase/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/e2e/package.json
+++ b/examples/e2e/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/field/useCheckboxGroup/package.json
+++ b/examples/field/useCheckboxGroup/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/field/useRadioGroup/package.json
+++ b/examples/field/useRadioGroup/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/field/useSelect/mui/package.json
+++ b/examples/field/useSelect/mui/package.json
@@ -16,8 +16,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "FAST_REFRESH=false DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/field/useSelect/package.json
+++ b/examples/field/useSelect/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/fineFoods/admin/mui/package.json
+++ b/examples/fineFoods/admin/mui/package.json
@@ -26,8 +26,7 @@
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
         "recharts": "^2.1.9",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "devDependencies": {
         "@types/react-input-mask": "^3.0.1"

--- a/examples/fineFoods/admin/package.json
+++ b/examples/fineFoods/admin/package.json
@@ -32,8 +32,7 @@
 		"react-mde": "^11.1.0",
 		"react-scripts": "^5.0.0",
 		"tslib": "^2.3.1",
-		"typescript": "^4.4.3",
-		"web-vitals": "^1.1.1"
+		"typescript": "^4.4.3"
 	},
 	"scripts": {
 		"start": "FAST_REFRESH=false DISABLE_ESLINT_PLUGIN=true craco start",

--- a/examples/form/antd/customValidation/package.json
+++ b/examples/form/antd/customValidation/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/form/antd/useDrawerForm/package.json
+++ b/examples/form/antd/useDrawerForm/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/form/antd/useForm/package.json
+++ b/examples/form/antd/useForm/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/form/antd/useModalForm/package.json
+++ b/examples/form/antd/useModalForm/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/form/antd/useStepsForm/package.json
+++ b/examples/form/antd/useStepsForm/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/form/mui/useDrawerForm/package.json
+++ b/examples/form/mui/useDrawerForm/package.json
@@ -16,8 +16,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "FAST_REFRESH=false DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/form/mui/useForm/package.json
+++ b/examples/form/mui/useForm/package.json
@@ -16,8 +16,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "FAST_REFRESH=false DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/form/mui/useModalForm/package.json
+++ b/examples/form/mui/useModalForm/package.json
@@ -16,8 +16,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "FAST_REFRESH=false DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/form/mui/useStepsForm/package.json
+++ b/examples/form/mui/useStepsForm/package.json
@@ -16,8 +16,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "FAST_REFRESH=false DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/form/reactHookForm/useForm/package.json
+++ b/examples/form/reactHookForm/useForm/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/form/reactHookForm/useModalForm/package.json
+++ b/examples/form/reactHookForm/useModalForm/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/form/reactHookForm/useStepsForm/package.json
+++ b/examples/form/reactHookForm/useStepsForm/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/i18n/react/package.json
+++ b/examples/i18n/react/package.json
@@ -19,8 +19,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/importExport/mui/package.json
+++ b/examples/importExport/mui/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/importExport/package.json
+++ b/examples/importExport/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/inputs/customInputs/package.json
+++ b/examples/inputs/customInputs/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/inputs/datePicker/package.json
+++ b/examples/inputs/datePicker/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/list/useSimpleList/package.json
+++ b/examples/list/useSimpleList/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/multi-level-menu/package.json
+++ b/examples/multi-level-menu/package.json
@@ -16,8 +16,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/multi-tenancy/appwrite/package.json
+++ b/examples/multi-tenancy/appwrite/package.json
@@ -17,8 +17,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/multi-tenancy/strapi/package.json
+++ b/examples/multi-tenancy/strapi/package.json
@@ -14,8 +14,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/mutationMode/package.json
+++ b/examples/mutationMode/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/reactToastify/package.json
+++ b/examples/reactToastify/package.json
@@ -17,8 +17,7 @@
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
     "react-toastify": "^8.1.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/real-world-example/package.json
+++ b/examples/real-world-example/package.json
@@ -19,8 +19,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/routerProvider/react-location/package.json
+++ b/examples/routerProvider/react-location/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/search/package.json
+++ b/examples/search/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/storybook/mui/package.json
+++ b/examples/storybook/mui/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/storybook/package.json
+++ b/examples/storybook/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/table/antd/advancedTable/package.json
+++ b/examples/table/antd/advancedTable/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/table/antd/tableFilter/package.json
+++ b/examples/table/antd/tableFilter/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/table/antd/useDeleteMany/package.json
+++ b/examples/table/antd/useDeleteMany/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/table/antd/useEditableTable/package.json
+++ b/examples/table/antd/useEditableTable/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/table/antd/useTable/package.json
+++ b/examples/table/antd/useTable/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/table/antd/useUpdateMany/package.json
+++ b/examples/table/antd/useUpdateMany/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/table/mui/advancedTable/package.json
+++ b/examples/table/mui/advancedTable/package.json
@@ -17,8 +17,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/table/mui/dataGridPro/package.json
+++ b/examples/table/mui/dataGridPro/package.json
@@ -18,8 +18,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "FAST_REFRESH=false DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/table/mui/useDataGrid/package.json
+++ b/examples/table/mui/useDataGrid/package.json
@@ -17,8 +17,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "FAST_REFRESH=false DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/table/reactTable/advanced/package.json
+++ b/examples/table/reactTable/advanced/package.json
@@ -17,8 +17,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/table/reactTable/basic/package.json
+++ b/examples/table/reactTable/basic/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/tutorial/antd/package.json
+++ b/examples/tutorial/antd/package.json
@@ -17,8 +17,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/tutorial/headless/package.json
+++ b/examples/tutorial/headless/package.json
@@ -16,8 +16,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/tutorial/mui/package.json
+++ b/examples/tutorial/mui/package.json
@@ -16,8 +16,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/ui/useModal/package.json
+++ b/examples/ui/useModal/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/upload/base64Upload/package.json
+++ b/examples/upload/base64Upload/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/upload/mui/base64/package.json
+++ b/examples/upload/mui/base64/package.json
@@ -16,8 +16,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "FAST_REFRESH=false DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/upload/mui/multipart/package.json
+++ b/examples/upload/mui/multipart/package.json
@@ -16,8 +16,7 @@
         "react-markdown": "^6.0.1",
         "react-mde": "^11.1.0",
         "react-scripts": "^5.0.0",
-        "typescript": "^4.4.3",
-        "web-vitals": "^1.1.1"
+        "typescript": "^4.4.3"
     },
     "scripts": {
         "start": "FAST_REFRESH=false DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/upload/multipartUpload/package.json
+++ b/examples/upload/multipartUpload/package.json
@@ -15,8 +15,7 @@
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
-    "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1"
+    "typescript": "^4.4.3"
   },
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",

--- a/examples/web3/ethereumLogin/package.json
+++ b/examples/web3/ethereumLogin/package.json
@@ -20,7 +20,6 @@
     "react-mde": "^11.1.0",
     "react-scripts": "^5.0.0",
     "typescript": "^4.4.3",
-    "web-vitals": "^1.1.1",
     "web3": "^1.6.1",
     "web3modal": "^1.9.4"
   },


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

We removed the `web-vitals` dependency that was preventing our CodeSandbox examples from working