### PR TITLE
fix: remove `useMemo` for inside hook invoke error

### DIFF
--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -123,6 +123,11 @@ export const Refine: React.FC<RefineProps> = ({
         },
     });
 
+    const notificationProviderContextValues =
+        typeof notificationProvider === "function"
+            ? notificationProvider()
+            : notificationProvider ?? {};
+
     const resources: IResourceItem[] = [];
 
     resourcesFromProps?.map((resource) => {
@@ -152,12 +157,6 @@ export const Refine: React.FC<RefineProps> = ({
     }
 
     const { RouterComponent } = routerProvider;
-
-    const notificationProviderContextValues = React.useMemo(() => {
-        return typeof notificationProvider === "function"
-            ? notificationProvider()
-            : notificationProvider ?? {};
-    }, [notificationProvider]);
 
     return (
         <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
Fixed the issue on hook call inside `useMemo`.