### PR TITLE
style(crud): spacing fix at the crud components 

### DIFF
--- a/.changeset/stupid-toes-hear.md
+++ b/.changeset/stupid-toes-hear.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": patch
+---
+
+Fix the spacing of header and footer actions in crud components and updated their snapshot tests.

--- a/packages/mui/src/components/crud/create/index.tsx
+++ b/packages/mui/src/components/crud/create/index.tsx
@@ -90,7 +90,12 @@ export const Create: React.FC<CreateProps> = ({
             />
             <CardContent {...cardContentProps}>{children}</CardContent>
             <CardActions
-                sx={{ display: "flex", justifyContent: "flex-end" }}
+                sx={{
+                    display: "flex",
+                    justifyContent: "flex-end",
+                    gap: "16px",
+                    padding: "16px",
+                }}
                 {...cardActionsProps}
             >
                 {actionButtons ?? (

--- a/packages/mui/src/components/crud/edit/index.tsx
+++ b/packages/mui/src/components/crud/edit/index.tsx
@@ -24,6 +24,7 @@ import {
     CardContentProps,
     CardActionsProps,
     Typography,
+    Box,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 
@@ -116,7 +117,7 @@ export const Edit: React.FC<EditProps> = ({
                     </IconButton>
                 }
                 action={
-                    <>
+                    <Box display="flex" gap="16px">
                         {!recordItemId && (
                             <ListButton
                                 data-testid="edit-list-button"
@@ -127,13 +128,18 @@ export const Edit: React.FC<EditProps> = ({
                             resourceNameOrRouteName={resource.route}
                             recordItemId={id}
                         />
-                    </>
+                    </Box>
                 }
                 {...cardHeaderProps}
             />
             <CardContent {...cardContentProps}>{children}</CardContent>
             <CardActions
-                sx={{ display: "flex", justifyContent: "flex-end" }}
+                sx={{
+                    display: "flex",
+                    justifyContent: "flex-end",
+                    gap: "16px",
+                    padding: "16px",
+                }}
                 {...cardActionsProps}
             >
                 {actionButtons ?? (

--- a/packages/mui/src/components/crud/list/__snapshots__/index.spec.tsx.snap
+++ b/packages/mui/src/components/crud/list/__snapshots__/index.spec.tsx.snap
@@ -17,6 +17,13 @@ exports[`<List/> JSON Rest Server renders given data 1`] = `
           Posts
         </h5>
       </div>
+      <div
+        class="MuiCardHeader-action css-sgoict-MuiCardHeader-action"
+      >
+        <div
+          class="MuiBox-root css-10egq61"
+        />
+      </div>
     </div>
     <div
       class="MuiCardContent-root css-46bh2p-MuiCardContent-root"

--- a/packages/mui/src/components/crud/list/index.tsx
+++ b/packages/mui/src/components/crud/list/index.tsx
@@ -16,6 +16,7 @@ import {
     CardHeaderProps,
     CardContentProps,
     Typography,
+    Box,
 } from "@mui/material";
 
 import { CreateButton, CreateButtonProps } from "@components";
@@ -79,7 +80,11 @@ export const List: React.FC<ListProps> = ({
                         )}
                     </Typography>
                 }
-                action={defaultExtra}
+                action={
+                    <Box display="flex" gap="16px">
+                        {defaultExtra}
+                    </Box>
+                }
                 {...cardHeaderProps}
             />
             <CardContent {...cardContentProps}>{children}</CardContent>

--- a/packages/mui/src/components/crud/show/index.tsx
+++ b/packages/mui/src/components/crud/show/index.tsx
@@ -105,7 +105,7 @@ export const Show: React.FC<ShowProps> = ({
                     </IconButton>
                 }
                 action={
-                    <Box sx={{ display: "flex" }}>
+                    <Box display="flex" gap="16px">
                         {!recordItemId && (
                             <ListButton
                                 data-testid="show-list-button"
@@ -139,7 +139,7 @@ export const Show: React.FC<ShowProps> = ({
                 {...cardHeaderProps}
             />
             <CardContent {...cardContentProps}>{children}</CardContent>
-            <CardActions {...cardActionsProps}>
+            <CardActions sx={{ padding: "16px" }} {...cardActionsProps}>
                 {actionButtons ? [actionButtons] : undefined}
             </CardActions>
         </Card>


### PR DESCRIPTION
In this PR, We have fixed the spacing of `<CardHeader>` actions and `<CardAction>` components in crud components.