### PR TITLE
fix(mui-fine-foods): centering language select on the header

### DIFF
--- a/examples/fineFoods/admin/mui/src/components/header/index.tsx
+++ b/examples/fineFoods/admin/mui/src/components/header/index.tsx
@@ -271,6 +271,7 @@ export const Header: React.FC = () => {
                                             <Stack
                                                 direction="row"
                                                 alignItems="center"
+                                                justifyContent="center"
                                             >
                                                 <Avatar
                                                     sx={{


### PR DESCRIPTION
Centering language select on `<Header>` component in Material UI Fine Foods example.