### PR TITLE
test: update `useMenu` tests

### DIFF
--- a/.changeset/sweet-tigers-pay.md
+++ b/.changeset/sweet-tigers-pay.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": patch
+---
+
+Update `key`s in `<Sider/>` component to use `route`

--- a/documentation/docs/guides-and-concepts/multi-tenancy/appwrite.md
+++ b/documentation/docs/guides-and-concepts/multi-tenancy/appwrite.md
@@ -263,7 +263,7 @@ export const CustomSider: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}

--- a/documentation/docs/guides-and-concepts/multi-tenancy/strapi.md
+++ b/documentation/docs/guides-and-concepts/multi-tenancy/strapi.md
@@ -338,7 +338,7 @@ export const CustomSider: React.FC = () => {
             if (children.length > 0) {
                 return (
                     <SubMenu
-                        key={name}
+                        key={route}
                         icon={icon ?? <Icons.UnorderedListOutlined />}
                         title={label}
                     >
@@ -357,7 +357,7 @@ export const CustomSider: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}
@@ -393,7 +393,7 @@ export const CustomSider: React.FC = () => {
                 }}
             >
                 <Menu.Item
-                    key={selectedKey}
+                    key={route}
                     icon={<Icons.AppstoreAddOutlined />}
                 >
                     <StoreSelect

--- a/documentation/docs/guides-and-concepts/real-time.md
+++ b/documentation/docs/guides-and-concepts/real-time.md
@@ -224,7 +224,7 @@ export const CustomSider: React.FC = () => {
             if (children.length > 0) {
                 return (
                     <SubMenu
-                        key={name}
+                        key={route}
                         icon={icon ?? <Icons.UnorderedListOutlined />}
                         title={label}
                     >
@@ -243,7 +243,7 @@ export const CustomSider: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}
@@ -355,7 +355,7 @@ export const CustomSider: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}

--- a/documentation/docs/ui-frameworks/antd/customization/sider.md
+++ b/documentation/docs/ui-frameworks/antd/customization/sider.md
@@ -45,7 +45,7 @@ export const CustomMenu: React.FC = () => {
             if (children.length > 0) {
                 return (
                     <SubMenu
-                        key={name}
+                        key={route}
                         icon={icon ?? <Icons.UnorderedListOutlined />}
                         title={label}
                     >
@@ -64,7 +64,7 @@ export const CustomMenu: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}
@@ -215,7 +215,7 @@ export const CustomMenu: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}

--- a/examples/ably/src/components/sider/index.tsx
+++ b/examples/ably/src/components/sider/index.tsx
@@ -43,7 +43,7 @@ export const CustomSider: React.FC = () => {
             if (children.length > 0) {
                 return (
                     <SubMenu
-                        key={name}
+                        key={route}
                         icon={icon ?? <Icons.UnorderedListOutlined />}
                         title={label}
                     >
@@ -62,7 +62,7 @@ export const CustomSider: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}

--- a/examples/customization/customSider/src/components/sider/index.tsx
+++ b/examples/customization/customSider/src/components/sider/index.tsx
@@ -27,7 +27,7 @@ export const CustomSider: React.FC = () => {
             if (children.length > 0) {
                 return (
                     <SubMenu
-                        key={name}
+                        key={route}
                         icon={icon ?? <UnorderedListOutlined />}
                         title={label}
                     >
@@ -46,7 +46,7 @@ export const CustomSider: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}

--- a/examples/customization/offLayoutArea/src/components/sider/index.tsx
+++ b/examples/customization/offLayoutArea/src/components/sider/index.tsx
@@ -22,7 +22,7 @@ export const FixedSider: React.FC = () => {
             if (children.length > 0) {
                 return (
                     <SubMenu
-                        key={name}
+                        key={route}
                         icon={icon ?? <Icons.UnorderedListOutlined />}
                         title={label}
                     >
@@ -41,7 +41,7 @@ export const FixedSider: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}

--- a/examples/multi-tenancy/appwrite/src/components/sider/index.tsx
+++ b/examples/multi-tenancy/appwrite/src/components/sider/index.tsx
@@ -27,7 +27,7 @@ export const CustomSider: React.FC = () => {
             if (children.length > 0) {
                 return (
                     <SubMenu
-                        key={name}
+                        key={route}
                         icon={icon ?? <Icons.UnorderedListOutlined />}
                         title={label}
                     >
@@ -46,7 +46,7 @@ export const CustomSider: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}

--- a/examples/multi-tenancy/strapi/src/components/sider/index.tsx
+++ b/examples/multi-tenancy/strapi/src/components/sider/index.tsx
@@ -29,7 +29,7 @@ export const CustomSider: React.FC = () => {
             if (children.length > 0) {
                 return (
                     <SubMenu
-                        key={name}
+                        key={route}
                         icon={icon ?? <Icons.UnorderedListOutlined />}
                         title={label}
                     >
@@ -48,7 +48,7 @@ export const CustomSider: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}
@@ -79,10 +79,7 @@ export const CustomSider: React.FC = () => {
         >
             {Title && <Title collapsed={collapsed} />}
             <Menu selectedKeys={[selectedKey]} mode="inline">
-                <Menu.Item
-                    key={selectedKey}
-                    icon={<Icons.AppstoreAddOutlined />}
-                >
+                <Menu.Item key={route} icon={<Icons.AppstoreAddOutlined />}>
                     <StoreSelect
                         onSelect={() => {
                             setCollapsed(true);

--- a/packages/antd/src/components/layout/sider/index.tsx
+++ b/packages/antd/src/components/layout/sider/index.tsx
@@ -38,7 +38,7 @@ export const Sider: React.FC = () => {
             if (children.length > 0) {
                 return (
                     <SubMenu
-                        key={name}
+                        key={route}
                         icon={icon ?? <UnorderedListOutlined />}
                         title={label}
                     >
@@ -57,7 +57,7 @@ export const Sider: React.FC = () => {
                     action="list"
                 >
                     <Menu.Item
-                        key={selectedKey}
+                        key={route}
                         style={{
                             fontWeight: isSelected ? "bold" : "normal",
                         }}

--- a/packages/antd/src/hooks/useMenu/index.tsx
+++ b/packages/antd/src/hooks/useMenu/index.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useMenu as useMenuCore, ITreeMenu } from "@pankod/refine-core";
 
 type useMenuReturnType = {
@@ -18,5 +19,14 @@ type useMenuReturnType = {
 export const useMenu: () => useMenuReturnType = () => {
     const values = useMenuCore();
 
-    return values;
+    const menuValues = React.useMemo(() => {
+        return {
+            ...values,
+            defaultOpenKeys: values.selectedKey
+                .split("/")
+                .filter((x) => x !== ""),
+        };
+    }, [values]);
+
+    return menuValues;
 };

--- a/packages/core/src/hooks/menu/useMenu.spec.ts
+++ b/packages/core/src/hooks/menu/useMenu.spec.ts
@@ -1,5 +1,4 @@
 import { renderHook } from "@testing-library/react-hooks";
-import { act } from "react-dom/test-utils";
 
 import { TestWrapper } from "@test";
 
@@ -44,15 +43,73 @@ describe("useMenu Hook", () => {
         expect(result.current.selectedKey).toEqual("/posts/create");
     });
 
-    it("should have the defaultOpenKeys = [posts, create]", async () => {
+    it("should have the defaultOpenKeys = [/CMS]", async () => {
         const { result } = renderHook(() => useMenu(), {
             wrapper: TestWrapper({
-                routerInitialEntries: ["/posts/create"],
+                routerInitialEntries: ["/CMS/posts"],
+                resources: [
+                    {
+                        name: "CMS",
+                    },
+                    {
+                        name: "posts",
+                        parentName: "CMS",
+                        route: "asdasd",
+                    },
+                    {
+                        name: "categories",
+                        parentName: "CMS",
+                    },
+                    {
+                        name: "posts",
+                        parentName: "categories",
+                        options: {
+                            label: "else-new",
+                            route: "else-new",
+                        },
+                        canDelete: true,
+                    },
+                ],
             }),
         });
 
         expect(result.current.defaultOpenKeys).toEqual(
-            expect.arrayContaining(["posts", "create"]),
+            expect.arrayContaining(["/CMS"]),
+        );
+    });
+
+    it("should have the defaultOpenKeys = [/CMS]", async () => {
+        const { result } = renderHook(() => useMenu(), {
+            wrapper: TestWrapper({
+                routerInitialEntries: ["/else-new"],
+                resources: [
+                    {
+                        name: "CMS",
+                    },
+                    {
+                        name: "posts",
+                        parentName: "CMS",
+                        route: "asdasd",
+                    },
+                    {
+                        name: "categories",
+                        parentName: "CMS",
+                    },
+                    {
+                        name: "posts",
+                        parentName: "categories",
+                        options: {
+                            label: "else-new",
+                            route: "else-new",
+                        },
+                        canDelete: true,
+                    },
+                ],
+            }),
+        });
+
+        expect(result.current.defaultOpenKeys).toEqual(
+            expect.arrayContaining(["/CMS", "/CMS/categories"]),
         );
     });
 });

--- a/packages/core/test/index.tsx
+++ b/packages/core/test/index.tsx
@@ -30,6 +30,7 @@ import {
     MockAccessControlProvider,
     MockLiveProvider,
 } from "@test";
+import { routeGenerator } from "../src";
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -57,7 +58,7 @@ export interface ITestWrapperProps {
 export const TestWrapper: (props: ITestWrapperProps) => React.FC = ({
     authProvider,
     dataProvider,
-    resources,
+    resources: resourcesFromProps,
     i18nProvider,
     notificationProvider,
     accessControlProvider,
@@ -66,6 +67,28 @@ export const TestWrapper: (props: ITestWrapperProps) => React.FC = ({
     liveProvider,
     auditLogProvider,
 }) => {
+    const resources: IResourceItem[] = [];
+    resourcesFromProps?.map((resource) => {
+        resources.push({
+            key: resource.key,
+            name: resource.name,
+            label: resource.options?.label,
+            icon: resource.icon,
+            route:
+                resource.options?.route ??
+                routeGenerator(resource, resourcesFromProps),
+            canCreate: !!resource.create,
+            canEdit: !!resource.edit,
+            canShow: !!resource.show,
+            canDelete: resource.canDelete,
+            create: resource.create,
+            show: resource.show,
+            list: resource.list,
+            edit: resource.edit,
+            options: resource.options,
+            parentName: resource.parentName,
+        });
+    });
     // eslint-disable-next-line react/display-name
     return ({ children }): React.ReactElement => {
         const withResource = resources ? (


### PR DESCRIPTION
While updating `useMenu` tests, I've noticed that `<Sider/>` in `@pankod/refine-antd` uses the same key for all items and resulting in opening all menus at once initially.

- [x] updated `useMenu` tests in `@pankod/refine-core`
- [x] updated `Menu.Item.keys` in `@pankod/refine-antd`'s `<Sider/>`
- [x] updated `<Sider />` in documentations and examples
- [x] updated `TestWrapper` in `@pankod/refine-core` with resources modifiers.
- [x] reverted behavioral change in _deprecated_ `useMenu` hook in `@pankod/refine-antd`