### PR TITLE
test: update async tests and remove errors

### DIFF
--- a/packages/core/src/components/authenticated/index.spec.tsx
+++ b/packages/core/src/components/authenticated/index.spec.tsx
@@ -22,6 +22,12 @@ jest.mock("react-router-dom", () => ({
 }));
 
 describe("Authenticated", () => {
+    beforeEach(() => {
+        jest.spyOn(console, "error").mockImplementation((message) => {
+            if (typeof message !== "undefined") console.warn(message);
+        });
+    });
+
     it("should render children successfully", async () => {
         const { getByText } = render(
             <Authenticated>Custom Authenticated</Authenticated>,

--- a/packages/core/src/components/canAccess/index.spec.tsx
+++ b/packages/core/src/components/canAccess/index.spec.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { render, TestWrapper, wait } from "@test";
+import { render, TestWrapper } from "@test";
 
 import { CanAccess } from ".";
 
 describe("CanAccess Component", () => {
     it("should render children", async () => {
-        const { container, getByText } = render(
+        const { container, findByText } = render(
             <CanAccess action="access" resource="posts">
                 Accessible
             </CanAccess>,
@@ -24,7 +24,7 @@ describe("CanAccess Component", () => {
         );
 
         expect(container).toBeTruthy();
-        await wait(() => getByText("Accessible"));
+        await findByText("Accessible");
     });
 
     it("should not render children", async () => {
@@ -42,13 +42,11 @@ describe("CanAccess Component", () => {
         );
 
         expect(container).toBeTruthy();
-        await wait(() =>
-            expect(queryByText("Accessible")).not.toBeInTheDocument(),
-        );
+        expect(queryByText("Accessible")).not.toBeInTheDocument();
     });
 
     it("should successfully pass the own attirbute to its children", async () => {
-        const { container, getByText } = render(
+        const { container, findByText } = render(
             <CanAccess action="access" resource="posts" data-id="refine">
                 <p>Accessible</p>
             </CanAccess>,
@@ -63,15 +61,13 @@ describe("CanAccess Component", () => {
 
         expect(container).toBeTruthy();
 
-        await wait(() =>
-            expect(
-                getByText("Accessible").closest("p")?.getAttribute("data-id"),
-            ).toBe("refine"),
-        );
+        const el = await findByText("Accessible");
+
+        expect(el.closest("p")?.getAttribute("data-id"));
     });
 
     it("should fallback successfully render when not accessible", async () => {
-        const { container, queryByText, getByText } = render(
+        const { container, queryByText, findByText } = render(
             <CanAccess
                 action="access"
                 resource="posts"
@@ -90,9 +86,7 @@ describe("CanAccess Component", () => {
 
         expect(container).toBeTruthy();
 
-        await wait(() =>
-            expect(queryByText("Accessible")).not.toBeInTheDocument(),
-        );
-        await wait(() => getByText("Access Denied"));
+        expect(queryByText("Accessible")).not.toBeInTheDocument();
+        await findByText("Access Denied");
     });
 });

--- a/packages/core/src/components/containers/refine/index.spec.tsx
+++ b/packages/core/src/components/containers/refine/index.spec.tsx
@@ -68,8 +68,11 @@ describe("Refine Container", () => {
                 <>
                     <h1>Posts</h1>
                     <table>
-                        <td>foo</td>
-                        <tr>bar</tr>
+                        <tbody>
+                            <tr>
+                                <td>foo</td>
+                            </tr>
+                        </tbody>
                     </table>
                 </>
             );

--- a/packages/core/src/components/routeChangeHandler/index.spec.tsx
+++ b/packages/core/src/components/routeChangeHandler/index.spec.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { render, fireEvent, TestWrapper, act } from "@test";
-import ReactRouterDom from "react-router-dom";
+import { render, TestWrapper, act } from "@test";
 
 import { RouteChangeHandler } from "./index";
 
@@ -25,31 +24,43 @@ describe("routeChangeHandler", () => {
         expect(container.innerHTML).toHaveLength(0);
     });
 
-    it("should call checkAuth on route change", () => {
+    it("should call checkAuth on route change", async () => {
         const checkAuthMockedAuthProvider = {
             ...mockAuthProvider,
             checkAuth: jest.fn().mockImplementation(() => Promise.resolve()),
         };
 
-        render(<RouteChangeHandler />, {
-            wrapper: TestWrapper({
-                authProvider: checkAuthMockedAuthProvider,
-            }),
+        await act(async () => {
+            jest.useFakeTimers();
+
+            render(<RouteChangeHandler />, {
+                wrapper: TestWrapper({
+                    authProvider: checkAuthMockedAuthProvider,
+                }),
+            });
+
+            jest.runAllTimers();
         });
 
         expect(checkAuthMockedAuthProvider.checkAuth).toBeCalledTimes(1);
     });
 
-    it("should ignore checkAuth Promise.reject", () => {
+    it("should ignore checkAuth Promise.reject", async () => {
         const checkAuthMockedAuthProvider = {
             ...mockAuthProvider,
             checkAuth: jest.fn().mockImplementation(() => Promise.reject()),
         };
 
-        render(<RouteChangeHandler />, {
-            wrapper: TestWrapper({
-                authProvider: checkAuthMockedAuthProvider,
-            }),
+        await act(async () => {
+            jest.useFakeTimers();
+
+            render(<RouteChangeHandler />, {
+                wrapper: TestWrapper({
+                    authProvider: checkAuthMockedAuthProvider,
+                }),
+            });
+
+            jest.runAllTimers();
         });
 
         expect(checkAuthMockedAuthProvider.checkAuth).toBeCalledTimes(1);

--- a/packages/core/src/contexts/undoableQueue/index.spec.tsx
+++ b/packages/core/src/contexts/undoableQueue/index.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { act } from "@test";
+import { act, waitFor } from "@test";
 import { renderHook } from "@testing-library/react-hooks";
 
 import { undoableQueueReducer } from "./undoableQueueContext";
@@ -20,60 +20,53 @@ describe("Notification Reducer", () => {
     };
 
     it("should render notification item with ADD action", () => {
-        act(async () => {
-            const { result, waitForNextUpdate } = renderHook(() =>
-                React.useReducer(undoableQueueReducer, []),
-            );
-            const [, dispatch] = result.current;
+        const { result } = renderHook(() =>
+            React.useReducer(undoableQueueReducer, []),
+        );
 
+        const [, dispatch] = result.current;
+
+        act(() => {
             dispatch({ type: "ADD", payload: providerProps.notifications[0] });
-
-            await waitForNextUpdate();
-            const [state] = result.current;
-
-            expect(state).toEqual([
-                {
-                    id: "1",
-                    resource: "posts",
-                    seconds: 5000,
-                    isRunning: true,
-                },
-            ]);
         });
+
+        const [state] = result.current;
+
+        expect(state).toEqual([
+            {
+                id: "1",
+                resource: "posts",
+                seconds: 5000,
+                isRunning: true,
+            },
+        ]);
     });
 
-    it("remove notification item with DELETE action", () => {
-        act(async () => {
-            const { result, waitForNextUpdate } = renderHook(() =>
-                React.useReducer(
-                    undoableQueueReducer,
-                    providerProps.notifications,
-                ),
-            );
-            const [, dispatch] = result.current;
+    it("remove notification item with DELETE action", async () => {
+        const { result } = renderHook(() =>
+            React.useReducer(undoableQueueReducer, providerProps.notifications),
+        );
+        const [, dispatch] = result.current;
 
+        act(() => {
             dispatch({
-                type: "DELETE",
+                type: "REMOVE",
                 payload: providerProps.notifications[0],
             });
-
-            await waitForNextUpdate();
-            const [state] = result.current;
-
-            expect(state).toEqual([]);
         });
+
+        const [state] = result.current;
+
+        expect(state).toEqual([]);
     });
 
-    it("decrease notification item by 1 second with DECREASE_NOTIFICATION_SECOND action", () => {
-        act(async () => {
-            const { result, waitForNextUpdate } = renderHook(() =>
-                React.useReducer(
-                    undoableQueueReducer,
-                    providerProps.notifications,
-                ),
-            );
-            const [, dispatch] = result.current;
+    it("decrease notification item by 1 second with DECREASE_NOTIFICATION_SECOND action", async () => {
+        const { result } = renderHook(() =>
+            React.useReducer(undoableQueueReducer, providerProps.notifications),
+        );
+        const [, dispatch] = result.current;
 
+        act(() => {
             dispatch({
                 type: "DECREASE_NOTIFICATION_SECOND",
                 payload: {
@@ -82,13 +75,12 @@ describe("Notification Reducer", () => {
                     resource: providerProps.notifications[0].resource,
                 },
             });
-
-            await waitForNextUpdate();
-            const [state] = result.current;
-
-            expect(state[0].seconds).toEqual(
-                providerProps.notifications[0].seconds - 1000,
-            );
         });
+
+        const [state] = result.current;
+
+        expect(state[0].seconds).toEqual(
+            providerProps.notifications[0].seconds - 1000,
+        );
     });
 });

--- a/packages/core/src/hooks/auth/useAuthenticated/index.spec.ts
+++ b/packages/core/src/hooks/auth/useAuthenticated/index.spec.ts
@@ -35,6 +35,11 @@ describe("useAuthenticated Hook", () => {
     });
 
     it("returns authenticated false and called checkError", async () => {
+        jest.spyOn(console, "error").mockImplementation((message) => {
+            if (message?.message === "Not Authenticated") return;
+            console.warn(message);
+        });
+
         const checkErrorMock = jest.fn();
         const { result, waitFor } = renderHook(() => useAuthenticated(), {
             wrapper: TestWrapper({
@@ -58,6 +63,11 @@ describe("useAuthenticated Hook", () => {
     });
 
     it("returns authenticated false and called checkError with custom redirect path", async () => {
+        jest.spyOn(console, "error").mockImplementation((message) => {
+            if (message?.redirectPath === "/custom-url") return;
+            console.warn(message);
+        });
+
         const checkErrorMock = jest.fn();
         const { result, waitFor } = renderHook(() => useAuthenticated(), {
             wrapper: TestWrapper({

--- a/packages/core/src/hooks/auth/useCheckError/index.spec.ts
+++ b/packages/core/src/hooks/auth/useCheckError/index.spec.ts
@@ -15,6 +15,11 @@ jest.mock("react-router-dom", () => ({
 describe("useCheckError Hook", () => {
     beforeEach(() => {
         mHistory.mockReset();
+
+        jest.spyOn(console, "error").mockImplementation((message) => {
+            if (message === "rejected" || message === "/customPath") return;
+            console.warn(message);
+        });
     });
 
     it("logout and redirect to login if check error rejected", async () => {
@@ -26,7 +31,7 @@ describe("useCheckError Hook", () => {
                     isProvided: true,
                     login: () => Promise.resolve(),
                     checkAuth: () => Promise.resolve(),
-                    checkError: () => Promise.reject(),
+                    checkError: () => Promise.reject("rejected"),
                     getPermissions: () => Promise.resolve(),
                     logout: logoutMock,
                     getUserIdentity: () => Promise.resolve(),

--- a/packages/core/src/hooks/auth/useGetIdentity/index.spec.ts
+++ b/packages/core/src/hooks/auth/useGetIdentity/index.spec.ts
@@ -27,6 +27,11 @@ describe("useGetIdentity Hook", () => {
     });
 
     it("throw error useGetIdentity", async () => {
+        jest.spyOn(console, "error").mockImplementation((message) => {
+            if (message?.message === "Not Authenticated") return;
+            console.warn(message);
+        });
+
         const { result, waitFor } = renderHook(() => useGetIdentity(), {
             wrapper: TestWrapper({
                 authProvider: {

--- a/packages/core/src/hooks/auth/useLogin/index.spec.ts
+++ b/packages/core/src/hooks/auth/useLogin/index.spec.ts
@@ -15,10 +15,15 @@ jest.mock("react-router-dom", () => ({
 describe("useLogin Hook", () => {
     beforeEach(() => {
         mHistory.mockReset();
+        jest.spyOn(console, "error").mockImplementation((message) => {
+            if (message?.message === "Wrong username") return;
+            if (typeof message === "undefined") return;
+            console.warn(message);
+        });
     });
 
     it("succeed login", async () => {
-        const { result, waitFor } = renderHook(() => useLogin(), {
+        const { result, waitForValueToChange } = renderHook(() => useLogin(), {
             wrapper: TestWrapper({
                 authProvider: {
                     login: ({ username }) => {
@@ -37,19 +42,17 @@ describe("useLogin Hook", () => {
             }),
         });
 
-        const { mutate: login } = result.current!;
+        const { mutate: login } = result.current ?? { mutate: () => 0 };
 
         await login({ username: "test" });
 
-        await waitFor(() => {
-            return !result.current?.isLoading;
-        });
+        await waitForValueToChange(() => result.current?.isLoading);
 
         expect(mHistory).toBeCalledWith("/", { replace: true });
     });
 
     it("should successfully login with no redirect", async () => {
-        const { result, waitFor } = renderHook(() => useLogin(), {
+        const { result, waitForValueToChange } = renderHook(() => useLogin(), {
             wrapper: TestWrapper({
                 authProvider: {
                     login: ({ username }) => {
@@ -68,19 +71,17 @@ describe("useLogin Hook", () => {
             }),
         });
 
-        const { mutate: login } = result.current!;
+        const { mutate: login } = result.current ?? { mutate: () => 0 };
 
         await login({ username: "test" });
 
-        await waitFor(() => {
-            return !result.current?.isLoading;
-        });
+        await waitForValueToChange(() => result.current?.isLoading);
 
         expect(mHistory).not.toBeCalled();
     });
 
     it("login and redirect to custom path", async () => {
-        const { result, waitFor } = renderHook(() => useLogin(), {
+        const { result, waitForValueToChange } = renderHook(() => useLogin(), {
             wrapper: TestWrapper({
                 authProvider: {
                     login: ({ username, redirectPath }) => {
@@ -99,19 +100,17 @@ describe("useLogin Hook", () => {
             }),
         });
 
-        const { mutate: login } = result.current!;
+        const { mutate: login } = result.current ?? { mutate: () => 0 };
 
         await login({ username: "test", redirectPath: "/custom-path" });
 
-        await waitFor(() => {
-            return !result.current?.isLoading;
-        });
+        await waitForValueToChange(() => result.current?.isLoading);
 
         expect(mHistory).toBeCalledWith("/custom-path", { replace: true });
     });
 
     it("If URL has 'to' params the app will redirect to 'to' values", async () => {
-        const { result, waitFor } = renderHook(() => useLogin(), {
+        const { result, waitForValueToChange } = renderHook(() => useLogin(), {
             wrapper: TestWrapper({
                 authProvider: {
                     login: ({ username, redirectPath }) => {
@@ -131,19 +130,17 @@ describe("useLogin Hook", () => {
             }),
         });
 
-        const { mutate: login } = result.current!;
+        const { mutate: login } = result.current ?? { mutate: () => 0 };
 
         await login({ username: "test", redirectPath: "/custom-path" });
 
-        await waitFor(() => {
-            return !result.current?.isLoading;
-        });
+        await waitForValueToChange(() => result.current?.isLoading);
 
         expect(mHistory).toBeCalledWith("/show/posts/5", { replace: true });
     });
 
     it("fail login", async () => {
-        const { result, waitFor } = renderHook(() => useLogin(), {
+        const { result, waitForValueToChange } = renderHook(() => useLogin(), {
             wrapper: TestWrapper({
                 authProvider: {
                     login: () => Promise.reject(new Error("Wrong username")),
@@ -156,21 +153,19 @@ describe("useLogin Hook", () => {
             }),
         });
 
-        const { mutate: login } = result.current!;
+        const { mutate: login } = result.current ?? { mutate: () => 0 };
 
         await login({ username: "demo" });
 
-        await waitFor(() => {
-            return !result.current?.isLoading;
-        });
+        await waitForValueToChange(() => result.current?.isLoading);
 
-        const { error } = result.current!;
+        const { error } = result.current ?? { error: undefined };
 
         expect(error).toEqual(new Error("Wrong username"));
     });
 
     it("login rejected with undefined error", async () => {
-        const { result, waitFor } = renderHook(() => useLogin(), {
+        const { result, waitForValueToChange } = renderHook(() => useLogin(), {
             wrapper: TestWrapper({
                 authProvider: {
                     login: () => Promise.reject(),
@@ -183,15 +178,13 @@ describe("useLogin Hook", () => {
             }),
         });
 
-        const { mutate: login } = result.current!;
+        const { mutate: login } = result.current ?? { mutate: () => 0 };
 
         await login({ username: "demo" });
 
-        await waitFor(() => {
-            return !result.current?.isLoading;
-        });
+        await waitForValueToChange(() => result.current?.isLoading);
 
-        const { error } = result.current!;
+        const { error } = result.current ?? { error: undefined };
 
         expect(error).not.toBeDefined();
     });

--- a/packages/core/src/hooks/auth/useLogout/index.spec.ts
+++ b/packages/core/src/hooks/auth/useLogout/index.spec.ts
@@ -15,6 +15,15 @@ jest.mock("react-router-dom", () => ({
 describe("useLogout Hook", () => {
     beforeEach(() => {
         mHistory.mockReset();
+        jest.spyOn(console, "error").mockImplementation((message) => {
+            if (
+                message?.message === "Logout rejected" ||
+                typeof message === "undefined"
+            )
+                return;
+
+            console.warn(message);
+        });
     });
 
     it("logout and redirect to login", async () => {

--- a/packages/core/src/hooks/auth/usePermissions/index.spec.ts
+++ b/packages/core/src/hooks/auth/usePermissions/index.spec.ts
@@ -29,6 +29,10 @@ describe("usePermissions Hook", () => {
     });
 
     it("returns error for not authenticated", async () => {
+        jest.spyOn(console, "error").mockImplementation((message) => {
+            if (!message.includes("Not Authenticated")) console.warn(message);
+        });
+
         const { result, waitFor } = renderHook(() => usePermissions(), {
             wrapper: TestWrapper({
                 authProvider: {

--- a/packages/core/src/hooks/data/useCreate.ts
+++ b/packages/core/src/hooks/data/useCreate.ts
@@ -129,7 +129,7 @@ export const useCreate = <
                 log?.({
                     action: "create",
                     resource,
-                    data: data.data,
+                    data: data?.data,
                     meta: {
                         dataProviderName,
                         id: data?.data?.id ?? undefined,

--- a/packages/core/src/hooks/data/useCreateMany.ts
+++ b/packages/core/src/hooks/data/useCreateMany.ts
@@ -126,7 +126,7 @@ export const useCreateMany = <
                 log?.({
                     action: "create",
                     resource,
-                    data: response.data,
+                    data: response?.data,
                     meta: {
                         dataProviderName,
                     },

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -99,7 +99,7 @@ export const useList = <
                 log?.({
                     action: "list",
                     resource,
-                    data: data.data,
+                    data: data?.data,
                     meta: {
                         config,
                         metaData,

--- a/packages/core/src/hooks/data/useMany.ts
+++ b/packages/core/src/hooks/data/useMany.ts
@@ -92,7 +92,7 @@ export const useMany = <
                 log?.({
                     action: "getMany",
                     resource,
-                    data: data.data,
+                    data: data?.data,
                     meta: {
                         ids,
                         metaData,

--- a/packages/core/src/hooks/data/useOne.ts
+++ b/packages/core/src/hooks/data/useOne.ts
@@ -86,7 +86,7 @@ export const useOne = <
                 log?.({
                     action: "getOne",
                     resource,
-                    data: data.data,
+                    data: data?.data,
                     meta: {
                         id,
                         metaData,

--- a/packages/core/src/hooks/data/useUpdate.ts
+++ b/packages/core/src/hooks/data/useUpdate.ts
@@ -312,7 +312,7 @@ export const useUpdate = <
                 log?.({
                     action: "update",
                     resource,
-                    data: data.data,
+                    data: data?.data,
                     previousData: {},
                     meta: {
                         id,

--- a/packages/core/src/hooks/data/useUpdateMany.ts
+++ b/packages/core/src/hooks/data/useUpdateMany.ts
@@ -339,7 +339,7 @@ export const useUpdateMany = <
                 log?.({
                     action: "update",
                     resource,
-                    data: data.data,
+                    data: data?.data,
                     previousData: {},
                     meta: {
                         ids,

--- a/packages/core/src/hooks/import/index.spec.tsx
+++ b/packages/core/src/hooks/import/index.spec.tsx
@@ -268,6 +268,13 @@ describe("useImport hook", () => {
     });
 
     describe("batchSize = undefined", () => {
+        beforeEach(() => {
+            jest.spyOn(console, "error").mockImplementation((message) => {
+                if (message?.message === "something happened") return;
+                console.warn(message);
+            });
+        });
+
         it("should call mutate method of result of useCreateMany one time with correct values if batchSize=undefined", async () => {
             const mockDataProvider = {
                 default: {

--- a/packages/core/src/hooks/menu/useMenu.spec.ts
+++ b/packages/core/src/hooks/menu/useMenu.spec.ts
@@ -3,6 +3,32 @@ import { renderHook } from "@testing-library/react-hooks";
 import { TestWrapper } from "@test";
 
 import { useMenu } from ".";
+import { IResourceItem } from "src/interfaces";
+import { routeGenerator } from "@definitions/helpers";
+
+const prepareResources = (items: IResourceItem[]): IResourceItem[] => {
+    const resources: IResourceItem[] = [];
+    items?.map((resource) => {
+        resources.push({
+            key: resource.key,
+            name: resource.name,
+            label: resource.options?.label,
+            icon: resource.icon,
+            route: resource.options?.route ?? routeGenerator(resource, items),
+            canCreate: !!resource.create,
+            canEdit: !!resource.edit,
+            canShow: !!resource.show,
+            canDelete: resource.canDelete,
+            create: resource.create,
+            show: resource.show,
+            list: resource.list,
+            edit: resource.edit,
+            options: resource.options,
+            parentName: resource.parentName,
+        });
+    });
+    return resources;
+};
 
 describe("useMenu Hook", () => {
     it("should be empty by default", async () => {
@@ -47,7 +73,7 @@ describe("useMenu Hook", () => {
         const { result } = renderHook(() => useMenu(), {
             wrapper: TestWrapper({
                 routerInitialEntries: ["/CMS/posts"],
-                resources: [
+                resources: prepareResources([
                     {
                         name: "CMS",
                     },
@@ -69,7 +95,7 @@ describe("useMenu Hook", () => {
                         },
                         canDelete: true,
                     },
-                ],
+                ]),
             }),
         });
 
@@ -82,7 +108,7 @@ describe("useMenu Hook", () => {
         const { result } = renderHook(() => useMenu(), {
             wrapper: TestWrapper({
                 routerInitialEntries: ["/else-new"],
-                resources: [
+                resources: prepareResources([
                     {
                         name: "CMS",
                     },
@@ -104,7 +130,7 @@ describe("useMenu Hook", () => {
                         },
                         canDelete: true,
                     },
-                ],
+                ]),
             }),
         });
 

--- a/packages/core/test/index.tsx
+++ b/packages/core/test/index.tsx
@@ -30,7 +30,6 @@ import {
     MockAccessControlProvider,
     MockLiveProvider,
 } from "@test";
-import { routeGenerator } from "../src";
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -58,7 +57,7 @@ export interface ITestWrapperProps {
 export const TestWrapper: (props: ITestWrapperProps) => React.FC = ({
     authProvider,
     dataProvider,
-    resources: resourcesFromProps,
+    resources,
     i18nProvider,
     notificationProvider,
     accessControlProvider,
@@ -67,28 +66,6 @@ export const TestWrapper: (props: ITestWrapperProps) => React.FC = ({
     liveProvider,
     auditLogProvider,
 }) => {
-    const resources: IResourceItem[] = [];
-    resourcesFromProps?.map((resource) => {
-        resources.push({
-            key: resource.key,
-            name: resource.name,
-            label: resource.options?.label,
-            icon: resource.icon,
-            route:
-                resource.options?.route ??
-                routeGenerator(resource, resourcesFromProps),
-            canCreate: !!resource.create,
-            canEdit: !!resource.edit,
-            canShow: !!resource.show,
-            canDelete: resource.canDelete,
-            create: resource.create,
-            show: resource.show,
-            list: resource.list,
-            edit: resource.edit,
-            options: resource.options,
-            parentName: resource.parentName,
-        });
-    });
     // eslint-disable-next-line react/display-name
     return ({ children }): React.ReactElement => {
         const withResource = resources ? (


### PR DESCRIPTION
With the last update on the `TestWrapper` tests were failing. Temporarily reverted the change on `resources` prop of `TestWrapper`.

Removed all `act` warnings and `console`'s  from `@pankod/refine-core` tests.