### PR TITLE
feat(header): default header component and state of render in layout

### DIFF
--- a/packages/mui/src/components/layout/header/index.tsx
+++ b/packages/mui/src/components/layout/header/index.tsx
@@ -16,18 +16,16 @@ export const Header: React.FC = () => {
                     justifyContent="flex-end"
                     alignItems="center"
                 >
-                    <Stack direction="row" alignItems="center">
-                        <Stack
-                            direction="row"
-                            gap="4px"
-                            alignItems="center"
-                            justifyContent="center"
-                        >
-                            <Typography variant="subtitle2">
-                                {user?.name}
-                            </Typography>
-                            <Avatar src={user?.avatar} alt={user?.name} />
-                        </Stack>
+                    <Stack
+                        direction="row"
+                        gap="16px"
+                        alignItems="center"
+                        justifyContent="center"
+                    >
+                        <Typography variant="subtitle2">
+                            {user?.name}
+                        </Typography>
+                        <Avatar src={user?.avatar} alt={user?.name} />
                     </Stack>
                 </Stack>
             </Toolbar>

--- a/packages/mui/src/components/layout/header/index.tsx
+++ b/packages/mui/src/components/layout/header/index.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { useGetIdentity } from "@pankod/refine-core";
+import { AppBar, Stack, Toolbar, Typography, Avatar } from "@mui/material";
+
+export const Header: React.FC = () => {
+    const { data: user } = useGetIdentity();
+
+    const shouldRenderHeader = user && (user.name || user.avatar);
+
+    return shouldRenderHeader ? (
+        <AppBar color="default" position="sticky" elevation={1}>
+            <Toolbar>
+                <Stack
+                    direction="row"
+                    width="100%"
+                    justifyContent="flex-end"
+                    alignItems="center"
+                >
+                    <Stack direction="row" alignItems="center">
+                        <Stack
+                            direction="row"
+                            gap="4px"
+                            alignItems="center"
+                            justifyContent="center"
+                        >
+                            <Typography variant="subtitle2">
+                                {user?.name}
+                            </Typography>
+                            <Avatar src={user?.avatar} alt={user?.name} />
+                        </Stack>
+                    </Stack>
+                </Stack>
+            </Toolbar>
+        </AppBar>
+    ) : null;
+};

--- a/packages/mui/src/components/layout/index.tsx
+++ b/packages/mui/src/components/layout/index.tsx
@@ -4,6 +4,7 @@ import { LayoutProps } from "@pankod/refine-core";
 import { Box } from "@mui/material";
 
 import { Sider as DefaultSider } from "./sider";
+import { Header as DefaultHeader } from "./header";
 
 export const Layout: React.FC<LayoutProps> = ({
     Sider,
@@ -13,6 +14,7 @@ export const Layout: React.FC<LayoutProps> = ({
     children,
 }) => {
     const SiderToRender = Sider ?? DefaultSider;
+    const HeaderToRender = Header ?? DefaultHeader;
 
     return (
         <Box display="flex" flexDirection="row">
@@ -25,7 +27,7 @@ export const Layout: React.FC<LayoutProps> = ({
                     minHeight: "100vh",
                 }}
             >
-                {Header && <Header />}
+                <HeaderToRender />
                 <Box
                     component="main"
                     sx={{


### PR DESCRIPTION
In this PR, We have created the header component in the layout. If the user identifications are defined ( user name, avatar ) that we reached from   `useGetIdentity()`, the header component is rendered with the username and avatar by default.