### PR TITLE
fix: `useMenu` dashboard

### DIFF
--- a/.changeset/fresh-stingrays-relate.md
+++ b/.changeset/fresh-stingrays-relate.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": patch
+---
+
+Fix missing behavior for dashboard item in _deprecated_ `useMenu`

--- a/.changeset/spicy-elephants-breathe.md
+++ b/.changeset/spicy-elephants-breathe.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": patch
+---
+
+Add Dashboard item to default `<Sider/>`

--- a/.changeset/spotty-phones-sparkle.md
+++ b/.changeset/spotty-phones-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Remove dashboard item in `useMenu` hook

--- a/packages/antd/src/components/layout/sider/index.tsx
+++ b/packages/antd/src/components/layout/sider/index.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from "react";
 import { Layout, Menu, Grid } from "antd";
-import { LogoutOutlined, UnorderedListOutlined } from "@ant-design/icons";
+import {
+    DashboardOutlined,
+    LogoutOutlined,
+    UnorderedListOutlined,
+} from "@ant-design/icons";
 import {
     useTranslate,
     useLogout,
@@ -10,6 +14,7 @@ import {
     useIsExistAuthentication,
     useRouterContext,
     useMenu,
+    useRefineContext,
 } from "@pankod/refine-core";
 
 import { Title as DefaultTitle } from "@components";
@@ -26,6 +31,7 @@ export const Sider: React.FC = () => {
     const translate = useTranslate();
     const { menuItems, selectedKey, defaultOpenKeys } = useMenu();
     const breakpoint = Grid.useBreakpoint();
+    const { hasDashboard } = useRefineContext();
 
     const isMobile = !breakpoint.lg;
 
@@ -95,6 +101,22 @@ export const Sider: React.FC = () => {
                     }
                 }}
             >
+                {hasDashboard ? (
+                    <Menu.Item
+                        key="dashboard"
+                        style={{
+                            fontWeight: selectedKey === "/" ? "bold" : "normal",
+                        }}
+                        icon={<DashboardOutlined />}
+                    >
+                        <Link href="/" to="/">
+                            {translate("dashboard.title", "Dashboard")}
+                        </Link>
+                        {!collapsed && selectedKey === "/" && (
+                            <div className="ant-menu-tree-arrow" />
+                        )}
+                    </Menu.Item>
+                ) : null}
                 {renderTreeView(menuItems, selectedKey)}
 
                 {isExistAuthentication && (

--- a/packages/antd/src/components/layout/sider/index.tsx
+++ b/packages/antd/src/components/layout/sider/index.tsx
@@ -117,6 +117,7 @@ export const Sider: React.FC = () => {
                         )}
                     </Menu.Item>
                 ) : null}
+
                 {renderTreeView(menuItems, selectedKey)}
 
                 {isExistAuthentication && (

--- a/packages/antd/src/hooks/useMenu/index.tsx
+++ b/packages/antd/src/hooks/useMenu/index.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { useMenu as useMenuCore, ITreeMenu } from "@pankod/refine-core";
+import {
+    useMenu as useMenuCore,
+    ITreeMenu,
+    useRefineContext,
+    useTranslate,
+} from "@pankod/refine-core";
+import { DashboardOutlined } from "@ant-design/icons";
 
 type useMenuReturnType = {
     defaultOpenKeys: string[];
@@ -18,10 +24,27 @@ type useMenuReturnType = {
  */
 export const useMenu: () => useMenuReturnType = () => {
     const values = useMenuCore();
+    const translate = useTranslate();
+    const { hasDashboard } = useRefineContext();
 
     const menuValues = React.useMemo(() => {
         return {
             ...values,
+            menuItems: [
+                ...(hasDashboard
+                    ? [
+                          {
+                              name: "Dashboard",
+                              icon: <DashboardOutlined />,
+                              route: `/`,
+                              key: "dashboard",
+                              label: translate("dashboard.title", "Dashboard"),
+                              children: [],
+                          },
+                      ]
+                    : []),
+                ...values.menuItems,
+            ],
             defaultOpenKeys: values.selectedKey
                 .split("/")
                 .filter((x) => x !== ""),

--- a/packages/core/src/hooks/menu/useMenu.tsx
+++ b/packages/core/src/hooks/menu/useMenu.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { DashboardOutlined } from "@ant-design/icons";
 import {
     useRefineContext,
     useTranslate,
@@ -56,19 +55,8 @@ export const useMenu: () => useMenuReturnType = () => {
     }, [resources, location, params]);
 
     const treeMenuItems: IMenuItem[] = React.useMemo(
-        () => [
-            ...(hasDashboard
-                ? [
-                      {
-                          name: "Dashboard",
-                          icon: <DashboardOutlined />,
-                          route: `/`,
-                          key: "dashboard",
-                          label: translate("dashboard.title", "Dashboard"),
-                      },
-                  ]
-                : []),
-            ...resources.map((resource) => {
+        () =>
+            resources.map((resource) => {
                 const route = `/${resource.route}`;
 
                 return {
@@ -84,7 +72,6 @@ export const useMenu: () => useMenuReturnType = () => {
                         ),
                 };
             }),
-        ],
         [resources, hasDashboard],
     );
     const menuItems: ITreeMenu[] = React.useMemo(

--- a/packages/mui/src/components/layout/sider/index.tsx
+++ b/packages/mui/src/components/layout/sider/index.tsx
@@ -29,6 +29,7 @@ import {
     useTranslate,
     useRouterContext,
     useMenu,
+    useRefineContext,
 } from "@pankod/refine-core";
 
 import { Title as DefaultTitle } from "../title";
@@ -44,6 +45,8 @@ export const Sider: React.FC = () => {
 
     const t = useTranslate();
     const { Link } = useRouterContext();
+    const { hasDashboard } = useRefineContext();
+    const translate = useTranslate();
 
     const { menuItems, selectedKey, defaultOpenKeys } = useMenu();
     const isExistAuthentication = useIsExistAuthentication();
@@ -207,6 +210,54 @@ export const Sider: React.FC = () => {
 
     const drawer = (
         <List disablePadding sx={{ mt: 1, color: "primary.contrastText" }}>
+            {hasDashboard ? (
+                <Tooltip
+                    title={translate("dashboard.title", "Dashboard")}
+                    placement="right"
+                    disableHoverListener={!collapsed}
+                    arrow
+                >
+                    <ListItemButton
+                        component={Link}
+                        href="/"
+                        to="/"
+                        selected={selectedKey === "/"}
+                        onClick={() => {
+                            setOpened(false);
+                        }}
+                        sx={{
+                            pl: 2,
+                            py: 1,
+                            "&.Mui-selected": {
+                                "&:hover": {
+                                    backgroundColor: "transparent",
+                                },
+                                backgroundColor: "transparent",
+                            },
+                            justifyContent: "center",
+                        }}
+                    >
+                        <ListItemIcon
+                            sx={{
+                                justifyContent: "center",
+                                minWidth: 36,
+                                color: "primary.contrastText",
+                            }}
+                        >
+                            {<ListOutlined />}
+                        </ListItemIcon>
+                        <ListItemText
+                            primary={translate("dashboard.title", "Dashboard")}
+                            primaryTypographyProps={{
+                                noWrap: true,
+                                fontSize: "14px",
+                                fontWeight:
+                                    selectedKey === "/" ? "bold" : "normal",
+                            }}
+                        />
+                    </ListItemButton>
+                </Tooltip>
+            ) : null}
             {renderTreeView(menuItems, selectedKey)}
             {isExistAuthentication && (
                 <Tooltip


### PR DESCRIPTION
- Removed dashboard item from `useMenu().menuItems` in `@pankod/refine-core`
- Added dashboard item to deprecated `useMenu` in `@pankod/refine-antd`
- Added dashboard item to `<Sider/>` in `@pankod/refine-antd` and `@pankod/refine-mui` packages.