### PR TITLE
docs(tutorial): tutorial updated with react-hook-form info

### DIFF
--- a/documentation/docs/ui-frameworks/mui/tutorial.md
+++ b/documentation/docs/ui-frameworks/mui/tutorial.md
@@ -59,14 +59,14 @@ values={[
 <TabItem value="npm">
 
 ```bash
-npm i @pankod/refine-core @pankod/refine-mui @pankod/refine-react-router-v6
+npm i @pankod/refine-core @pankod/refine-mui @pankod/refine-react-router-v6 @pankod/refine-react-hook-form
 ```
 
   </TabItem>
     <TabItem value="yarn">
 
 ```bash
-yarn add  @pankod/refine-core @pankod/refine-mui @pankod/refine-react-router-v6
+yarn add  @pankod/refine-core @pankod/refine-mui @pankod/refine-react-router-v6 @pankod/refine-react-hook-form
 ```
 
   </TabItem>
@@ -239,7 +239,7 @@ export default App;
 :::
 
 :::info
-Refine application uses [`Montserrat`](https://fonts.google.com/specimen/Montserrat) font by default as it is defined in the [`typography`](https://github.com/pankod/refine/blob/next/packages/mui/src/theme/typography.ts) property of the theme.  But to use [`Montserrat`](https://fonts.google.com/specimen/Montserrat), you need to embed it to your `index.html` file.
+Refine application uses [`Montserrat`](https://fonts.google.com/specimen/Montserrat) font by default as it is defined in the [`typography`](https://github.com/pankod/refine/blob/next/packages/mui/src/theme/typography.ts) property of the theme. But to use [`Montserrat`](https://fonts.google.com/specimen/Montserrat), you need to embed it to your `index.html` file.
 For more information about adding font family in your Refine application, you can look at [`Material UI Theme Customization`](/ui-frameworks/mui/customization/theme.md#overriding-variables).
 
 ```html title="index.html"
@@ -990,7 +990,10 @@ export const PostList: React.FC = () => {
 
 ## Editing a record
 
-Until this point, we were basically working with reading operations such as fetching and displaying data from resources. From now on, we are going to start creating and updating records by using **refine**.
+Until this point, we were basically working with reading operations such as fetching and displaying data from resources. From now on, we are going to start creating and updating records by using **refine**
+
+The Material UI provides already styled, but still very customizable inputs that encapsulate adding labels and error handling with helper texts.However, we need a third party library to handle forms when using Material UI. React hook form is one of the best options for this job!
+The React Hook Form library has been integrated with **refine** ([`@pankod/refine-react-hook-form`](https://github.com/pankod/refine/tree/master/packages/react-hook-form)) . This means you can now use Material UI for your forms and manage them using [`@pankod/refine-react-hook-form`](https://github.com/pankod/refine/tree/master/packages/react-hook-form)!
 
 Let's start by creating a new `<PostEdit>` page responsible for `editing` a single record:
 

--- a/documentation/docs/ui-frameworks/mui/tutorial.md
+++ b/documentation/docs/ui-frameworks/mui/tutorial.md
@@ -992,7 +992,7 @@ export const PostList: React.FC = () => {
 
 Until this point, we were basically working with reading operations such as fetching and displaying data from resources. From now on, we are going to start creating and updating records by using **refine**
 
-The Material UI provides already styled, but still very customizable inputs that encapsulate adding labels and error handling with helper texts.However, we need a third party library to handle forms when using Material UI. React hook form is one of the best options for this job!
+The Material UI provides already styled, but still very customizable inputs that encapsulate adding labels and error handling with helper texts. However, we need a third-party library to handle forms when using Material UI. [React Hook Form](https://react-hook-form.com/) is one of the best options for this job!
 The React Hook Form library has been integrated with **refine** ([`@pankod/refine-react-hook-form`](https://github.com/pankod/refine/tree/master/packages/react-hook-form)) . This means you can now use Material UI for your forms and manage them using [`@pankod/refine-react-hook-form`](https://github.com/pankod/refine/tree/master/packages/react-hook-form)!
 
 Let's start by creating a new `<PostEdit>` page responsible for `editing` a single record:


### PR DESCRIPTION
In this PR, We have updated the `tutorial` document that was created for Material UI with information about the `react-hook-form`.