### PR TITLE
Mui sider dashboard icon

### DIFF
--- a/.changeset/sweet-wolves-act.md
+++ b/.changeset/sweet-wolves-act.md
@@ -2,4 +2,4 @@
 "@pankod/refine-mui": patch
 ---
 
-dashboard icon changed from `<ListOutlined>` to `<Dashboard>` in `<Sider>` for **Material UI** package
+dashboard icon changed from `<ListOutlined>` to [`<Dashboard>`](https://mui.com/material-ui/material-icons/?query=Dashboard&selected=Dashboard) in `<Sider>` for **Material UI** package

--- a/.changeset/sweet-wolves-act.md
+++ b/.changeset/sweet-wolves-act.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": patch
+---
+
+dashboard icon changed from `<ListOutlined>` to `<Dashboard>` in `<Sider>` for **Material UI** package

--- a/documentation/docs/ui-frameworks/mui/customization/sider.md
+++ b/documentation/docs/ui-frameworks/mui/customization/sider.md
@@ -257,7 +257,7 @@ export const CustomMenu: React.FC = () => {
                                 color: "primary.contrastText",
                             }}
                         >
-                             {<Dashboard />}
+                             <Dashboard />
                         </ListItemIcon>
                         <ListItemText
                             primary={t("dashboard.title", "Dashboard")}

--- a/documentation/docs/ui-frameworks/mui/customization/sider.md
+++ b/documentation/docs/ui-frameworks/mui/customization/sider.md
@@ -41,6 +41,7 @@ import {
     Title as DefaultTitle,
 } from "@pankod/refine-mui";
 import {
+    Dashboard,
     ListOutlined,
     ExpandLess,
     ExpandMore,
@@ -256,7 +257,7 @@ export const CustomMenu: React.FC = () => {
                                 color: "primary.contrastText",
                             }}
                         >
-                            {<ListOutlined />}
+                             {<Dashboard />}
                         </ListItemIcon>
                         <ListItemText
                             primary={t("dashboard.title", "Dashboard")}

--- a/packages/mui/src/components/layout/sider/index.tsx
+++ b/packages/mui/src/components/layout/sider/index.tsx
@@ -245,7 +245,7 @@ export const Sider: React.FC = () => {
                                 color: "primary.contrastText",
                             }}
                         >
-                            {<Dashboard />}
+                            <Dashboard />
                         </ListItemIcon>
                         <ListItemText
                             primary={translate("dashboard.title", "Dashboard")}

--- a/packages/mui/src/components/layout/sider/index.tsx
+++ b/packages/mui/src/components/layout/sider/index.tsx
@@ -19,6 +19,7 @@ import {
     ChevronLeft,
     ChevronRight,
     MenuRounded,
+    Dashboard,
 } from "@mui/icons-material";
 import {
     CanAccess,
@@ -244,7 +245,7 @@ export const Sider: React.FC = () => {
                                 color: "primary.contrastText",
                             }}
                         >
-                            {<ListOutlined />}
+                            {<Dashboard />}
                         </ListItemIcon>
                         <ListItemText
                             primary={translate("dashboard.title", "Dashboard")}


### PR DESCRIPTION
Dashboard icon changed from `<ListOutlined>` to `<Dashboard>` in `<Sider>` for **Material UI** package
