### PR TITLE
refactor(default-login-pages): updating texts with translations

### DIFF
--- a/.changeset/funny-onions-itch.md
+++ b/.changeset/funny-onions-itch.md
@@ -1,0 +1,6 @@
+---
+"@pankod/refine-core": patch
+"@pankod/refine-mui": patch
+---
+
+We have fixed texts with translations of default login pages in Material UI and Headless.

--- a/packages/core/src/components/pages/login/index.tsx
+++ b/packages/core/src/components/pages/login/index.tsx
@@ -21,7 +21,7 @@ export const LoginPage: React.FC = () => {
 
     return (
         <>
-            <h1>Login</h1>
+            <h1>{translate("pages.login.title", "Sign in your account")}</h1>
             <form
                 onSubmit={(e) => {
                     e.preventDefault();

--- a/packages/mui/src/components/pages/login/index.tsx
+++ b/packages/mui/src/components/pages/login/index.tsx
@@ -70,43 +70,27 @@ export const LoginPage: React.FC = () => {
                         </div>
                         <Box mt={4}>
                             <Card>
-                                <CardContent>
+                                <CardContent sx={{ paddingX: "32px" }}>
                                     <Typography
                                         component="h1"
-                                        variant="h4"
+                                        variant="h5"
                                         align="center"
                                         sx={{
                                             fontWeight: "700",
-                                            fontSize: "30px",
-                                            letterSpacing: "-0.04px",
-                                            lineHeight: "38px",
-                                            color: "text.primary",
+                                            margin: "12px 0",
                                         }}
                                     >
-                                        <Box
-                                            component="span"
-                                            color="primary.main"
-                                        >
-                                            {translate(
-                                                "pages.login.title",
-                                                "Sign in ",
-                                            )}
-                                        </Box>
-                                        <Box
-                                            component="span"
-                                            sx={{ color: "text.secondary" }}
-                                        >
-                                            {translate(
-                                                "pages.login.title",
-                                                "your account",
-                                            )}
-                                        </Box>
+                                        {translate(
+                                            "pages.login.title",
+                                            "Sign in your account",
+                                        )}
                                     </Typography>
                                     <Box
                                         component="form"
                                         onSubmit={handleSubmit((data) => {
                                             login(data);
                                         })}
+                                        gap="16px"
                                     >
                                         <TextField
                                             {...register("username", {
@@ -114,6 +98,7 @@ export const LoginPage: React.FC = () => {
                                             })}
                                             id="username"
                                             margin="normal"
+                                            size="small"
                                             fullWidth
                                             label={translate(
                                                 "pages.login.username",
@@ -128,6 +113,7 @@ export const LoginPage: React.FC = () => {
                                                 required: true,
                                             })}
                                             id="password"
+                                            size="small"
                                             margin="normal"
                                             fullWidth
                                             name="password"
@@ -186,7 +172,7 @@ export const LoginPage: React.FC = () => {
                                                 >
                                                     {translate(
                                                         "pages.login.forgotPassword",
-                                                        "Forgot?",
+                                                        "Forgot password?",
                                                     )}
                                                 </Typography>
                                             </Link>
@@ -197,7 +183,6 @@ export const LoginPage: React.FC = () => {
                                             variant="contained"
                                             sx={{
                                                 my: "8px",
-                                                height: "64px",
                                                 color: "white",
                                             }}
                                             disabled={isLoading}
@@ -224,8 +209,8 @@ export const LoginPage: React.FC = () => {
                                             >
                                                 {translate(
                                                     "pages.login.noAccount",
-                                                    "Don’t have an account? ",
-                                                )}{" "}
+                                                    "Don’t have an account?",
+                                                )}
                                             </Typography>
                                             <Typography
                                                 sx={{
@@ -239,7 +224,7 @@ export const LoginPage: React.FC = () => {
                                             >
                                                 {translate(
                                                     "pages.login.signup",
-                                                    " Sign up",
+                                                    "Sign up",
                                                 )}
                                             </Typography>
                                             <Typography
@@ -254,7 +239,7 @@ export const LoginPage: React.FC = () => {
                                                 {translate(
                                                     "pages.login.noAccount",
                                                     "here ",
-                                                )}{" "}
+                                                )}
                                             </Typography>
                                         </Link>
                                     </Box>

--- a/packages/mui/src/components/pages/login/index.tsx
+++ b/packages/mui/src/components/pages/login/index.tsx
@@ -192,56 +192,26 @@ export const LoginPage: React.FC = () => {
                                                 "Sign in",
                                             )}
                                         </Button>
-                                        <Link
-                                            href="#"
-                                            sx={{
-                                                textDecoration: "none",
-                                                display: "flex",
-                                            }}
-                                        >
-                                            <Typography
-                                                sx={{
-                                                    fontSize: "12px",
-                                                    letterSpacing: "-0.04px",
-                                                    lineHeight: "38px",
-                                                    color: "text.secondary",
-                                                }}
-                                            >
+                                        <Box style={{ marginTop: 8 }}>
+                                            <Typography variant="subtitle2">
                                                 {translate(
                                                     "pages.login.noAccount",
                                                     "Don’t have an account?",
-                                                )}
+                                                )}{" "}
+                                                <Link
+                                                    underline="none"
+                                                    href="#"
+                                                    style={{
+                                                        fontWeight: "bold",
+                                                    }}
+                                                >
+                                                    {translate(
+                                                        "pages.login.signup",
+                                                        "Sign up",
+                                                    )}
+                                                </Link>
                                             </Typography>
-                                            <Typography
-                                                sx={{
-                                                    fontWeight: "700",
-                                                    fontSize: "12px",
-                                                    letterSpacing: "-0.04px",
-                                                    lineHeight: "38px",
-                                                    color: "primary.main",
-                                                    marginLeft: "2px",
-                                                }}
-                                            >
-                                                {translate(
-                                                    "pages.login.signup",
-                                                    "Sign up",
-                                                )}
-                                            </Typography>
-                                            <Typography
-                                                sx={{
-                                                    fontSize: "12px",
-                                                    letterSpacing: "-0.04px",
-                                                    lineHeight: "38px",
-                                                    color: "text.secondary",
-                                                    marginLeft: "2px",
-                                                }}
-                                            >
-                                                {translate(
-                                                    "pages.login.noAccount",
-                                                    "here ",
-                                                )}
-                                            </Typography>
-                                        </Link>
+                                        </Box>
                                     </Box>
                                 </CardContent>
                             </Card>


### PR DESCRIPTION
In this PR, We have updated text of login pages in Material UI and Headless.