### PR TITLE
refactor(buttons-variant): fix the variant of delete button

### DIFF
--- a/.changeset/metal-hotels-tap.md
+++ b/.changeset/metal-hotels-tap.md
@@ -2,6 +2,4 @@
 "@pankod/refine-mui": patch
 ---
 
-We fixed,
-Delete button component default variant.
-The variant of the delete button in the action buttons of the edit crud component.
+-   Update default variant of <DeleteButton/> to text and replace overrides in the crud components.

--- a/.changeset/metal-hotels-tap.md
+++ b/.changeset/metal-hotels-tap.md
@@ -2,4 +2,4 @@
 "@pankod/refine-mui": patch
 ---
 
--   Update default variant of <DeleteButton/> to text and replace overrides in the crud components.
+Update default variant of `<DeleteButton>` to `text` and replace overrides in the `<Edit>` crud component.

--- a/.changeset/metal-hotels-tap.md
+++ b/.changeset/metal-hotels-tap.md
@@ -1,0 +1,7 @@
+---
+"@pankod/refine-mui": patch
+---
+
+We fixed,
+Delete button component default variant.
+The variant of the delete button in the action buttons of the edit crud component.

--- a/examples/tutorial/mui/src/pages/posts/list.tsx
+++ b/examples/tutorial/mui/src/pages/posts/list.tsx
@@ -22,7 +22,6 @@ export const PostList: React.FC = () => {
             {
                 field: "category.id",
                 headerName: "Category",
-                type: "number",
                 minWidth: 250,
                 flex: 1,
                 valueGetter: (params) => {
@@ -54,14 +53,26 @@ export const PostList: React.FC = () => {
             },
             {
                 headerName: "Actions",
+                headerAlign: "center",
                 field: "actions",
-                minWidth: 250,
+                minWidth: 180,
+                align: "center",
+                flex: 1,
                 renderCell: function render(params) {
                     return (
                         <Stack direction="row" spacing={1}>
-                            <EditButton hideText recordItemId={params.row.id} />
-                            <ShowButton hideText recordItemId={params.row.id} />
+                            <EditButton
+                                size="small"
+                                hideText
+                                recordItemId={params.row.id}
+                            />
+                            <ShowButton
+                                size="small"
+                                hideText
+                                recordItemId={params.row.id}
+                            />
                             <DeleteButton
+                                size="small"
                                 hideText
                                 recordItemId={params.row.id}
                             />

--- a/packages/mui/src/components/buttons/delete/index.tsx
+++ b/packages/mui/src/components/buttons/delete/index.tsx
@@ -118,7 +118,6 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({
     return (
         <div>
             <LoadingButton
-                variant="outlined"
                 color="error"
                 onClick={handleClickOpen}
                 disabled={data?.can === false}

--- a/packages/mui/src/components/crud/edit/index.tsx
+++ b/packages/mui/src/components/crud/edit/index.tsx
@@ -149,6 +149,7 @@ export const Edit: React.FC<EditProps> = ({
                             <DeleteButton
                                 data-testid="edit-delete-button"
                                 mutationMode={mutationMode}
+                                variant="outlined"
                                 onSuccess={() => {
                                     list(resource.route ?? resource.name);
                                 }}


### PR DESCRIPTION
In this PR, We fixed the delete button component default variant and the variant of the delete button in the action buttons of the edit crud component.