### PR TITLE
Fix: Material UI fine foods products page default filter values

### DIFF
--- a/examples/fineFoods/admin/mui/src/components/product/categoryFilter.tsx
+++ b/examples/fineFoods/admin/mui/src/components/product/categoryFilter.tsx
@@ -21,11 +21,8 @@ export const CategoryFilter: React.FC<ProductItemProps> = ({
 }) => {
     const t = useTranslate();
 
-    const selectedCategories =
-        getDefaultFilter("category.id", filters, "in") ?? [];
-
     const [filterCategories, setFilterCategories] =
-        useState<string[]>(selectedCategories);
+        useState<string[]>(getDefaultFilter("category.id", filters, "in") ?? []);
 
     const { data: categories, isLoading } = useList<ICategory>({
         resource: "categories",

--- a/examples/fineFoods/admin/mui/src/components/product/categoryFilter.tsx
+++ b/examples/fineFoods/admin/mui/src/components/product/categoryFilter.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect } from "react";
 import { LoadingButton } from "@mui/lab";
-import { CrudFilters, useList, useTranslate } from "@pankod/refine-core";
+import {
+    CrudFilters,
+    getDefaultFilter,
+    useList,
+    useTranslate,
+} from "@pankod/refine-core";
 import { Stack, Grid } from "@pankod/refine-mui";
 
 import { ICategory } from "interfaces";
@@ -16,7 +21,11 @@ export const CategoryFilter: React.FC<ProductItemProps> = ({
 }) => {
     const t = useTranslate();
 
-    const [filterCategories, setFilterCategories] = useState<string[]>([]);
+    const selectedCategories =
+        getDefaultFilter("category.id", filters, "in") ?? [];
+
+    const [filterCategories, setFilterCategories] =
+        useState<string[]>(selectedCategories);
 
     const { data: categories, isLoading } = useList<ICategory>({
         resource: "categories",
@@ -26,10 +35,10 @@ export const CategoryFilter: React.FC<ProductItemProps> = ({
         setFilters?.([
             {
                 field: "category.id",
-                operator: "contains",
-                value: filterCategories,
+                operator: "in",
+                value:
+                    filterCategories.length > 0 ? filterCategories : undefined,
             },
-            ...filters,
         ]);
     }, [filterCategories]);
 

--- a/examples/fineFoods/admin/mui/src/pages/products/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/products/list.tsx
@@ -3,7 +3,7 @@ import {
     useTranslate,
     IResourceComponentsProps,
     useTable,
-    GetListResponse,
+    getDefaultFilter,
 } from "@pankod/refine-core";
 import { useModalForm } from "@pankod/refine-react-hook-form";
 import {
@@ -92,6 +92,11 @@ export const ProductList: React.FC<IResourceComponentsProps> = () => {
                                     inputProps={{
                                         "aria-label": "product search",
                                     }}
+                                    value={getDefaultFilter(
+                                        "name",
+                                        filters,
+                                        "contains",
+                                    )}
                                     onChange={(
                                         e: React.ChangeEvent<HTMLInputElement>,
                                     ) => {
@@ -99,9 +104,11 @@ export const ProductList: React.FC<IResourceComponentsProps> = () => {
                                             {
                                                 field: "name",
                                                 operator: "contains",
-                                                value: e.target.value,
+                                                value:
+                                                    e.target.value !== ""
+                                                        ? e.target.value
+                                                        : undefined,
                                             },
-                                            ...filters,
                                         ]);
                                     }}
                                 />

--- a/examples/fineFoods/admin/mui/src/pages/stores/create.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/stores/create.tsx
@@ -13,7 +13,9 @@ import {
     Typography,
     FormHelperText,
     Create,
+    TextFieldProps,
 } from "@pankod/refine-mui";
+import InputMask from "react-input-mask";
 
 import { IStore } from "interfaces";
 
@@ -131,16 +133,24 @@ export const StoreCreate: React.FC<IResourceComponentsProps> = () => {
                                 >
                                     {t("stores.fields.gsm")}
                                 </FormLabel>
-                                <TextField
+                                <InputMask
+                                    mask="(999) 999 99 99"
+                                    disabled={false}
                                     {...register("gsm", {
                                         required: t("errors.required.field", {
                                             field: "Phone",
                                         }),
                                     })}
-                                    size="small"
-                                    margin="none"
-                                    variant="outlined"
-                                />
+                                >
+                                    {(props: TextFieldProps) => (
+                                        <TextField
+                                            {...props}
+                                            size="small"
+                                            margin="none"
+                                            variant="outlined"
+                                        />
+                                    )}
+                                </InputMask>
                                 {errors.gsm && (
                                     <FormHelperText error>
                                         {errors.gsm.message}

--- a/examples/fineFoods/admin/mui/src/pages/stores/edit.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/stores/edit.tsx
@@ -13,7 +13,9 @@ import {
     TextField,
     Typography,
     FormHelperText,
+    TextFieldProps,
 } from "@pankod/refine-mui";
+import InputMask from "react-input-mask";
 
 import { IStore } from "interfaces";
 
@@ -137,16 +139,26 @@ export const StoreEdit: React.FC<IResourceComponentsProps> = () => {
                                 >
                                     {t("stores.fields.gsm")}
                                 </FormLabel>
-                                <TextField
+
+                                <InputMask
+                                    mask="(999) 999 99 99"
+                                    disabled={false}
                                     {...register("gsm", {
                                         required: t("errors.required.field", {
                                             field: "Phone",
                                         }),
                                     })}
-                                    size="small"
-                                    margin="none"
-                                    variant="outlined"
-                                />
+                                >
+                                    {(props: TextFieldProps) => (
+                                        <TextField
+                                            {...props}
+                                            size="small"
+                                            margin="none"
+                                            variant="outlined"
+                                        />
+                                    )}
+                                </InputMask>
+
                                 {errors.gsm && (
                                     <FormHelperText error>
                                         {errors.gsm.message}


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

- add`<InputMask>` for gsm input on store create/edit 
- products filters default values from syncWithLocation