### PR TITLE
docs: use menu redirects

### DIFF
--- a/documentation/docs/ui-frameworks/mui/customization/sider.md
+++ b/documentation/docs/ui-frameworks/mui/customization/sider.md
@@ -257,7 +257,7 @@ export const CustomMenu: React.FC = () => {
                                 color: "primary.contrastText",
                             }}
                         >
-                             <Dashboard />
+                            <Dashboard />
                         </ListItemIcon>
                         <ListItemText
                             primary={t("dashboard.title", "Dashboard")}
@@ -672,8 +672,10 @@ export const CustomSider: React.FC = () => {
 :::
 
 :::tip
+
 You can further customize the `<Sider>` and its appearance.  
-[Refer to Ant Design docs for more detailed information about Sider. &#8594](https://ant.design/components/layout/#Layout.Sider)
+Refer to Material UI docs for more detailed information about [Menu &#8594](https://mui.com/material-ui/react-menu) and [Drawer &#8594](https://mui.com/material-ui/react-drawer).
+
 :::
 
 [refine]: /core/components/refine-config.md

--- a/documentation/redirects.json
+++ b/documentation/redirects.json
@@ -1039,6 +1039,10 @@
         {
             "from": "/docs/examples/upload/multipartUpload/",
             "to": "/docs/examples/upload/antd/multipart/"
+        },
+        {
+            "from": "/docs/ui-frameworks/antd/hooks/resource/useMenu/",
+            "to": "/docs/core/hooks/ui/useMenu/"
         }
     ]
 }

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -230,11 +230,6 @@ module.exports = {
                                 },
                                 {
                                     type: "category",
-                                    label: "Resource",
-                                    items: ["core/hooks/ui/useMenu"],
-                                },
-                                {
-                                    type: "category",
                                     label: "Table",
                                     items: [
                                         "ui-frameworks/antd/hooks/table/useEditableTable",
@@ -323,11 +318,6 @@ module.exports = {
                             items: [
                                 "ui-frameworks/mui/hooks/useAutocomplete",
                                 "ui-frameworks/mui/hooks/useDataGrid",
-                                {
-                                    type: "category",
-                                    label: "Resource",
-                                    items: ["core/hooks/ui/useMenu"],
-                                },
                             ],
                         },
                         {


### PR DESCRIPTION
- Added `useMenu` redirect from `antd > hooks` to `core > hooks`
- Fixed wrong url in `material ui > customization > sider`