### PR TITLE
feat: ability to enable/disable pagination in `useTable` hooks

### DIFF
--- a/.changeset/chatty-peaches-cheer.md
+++ b/.changeset/chatty-peaches-cheer.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": minor
+---
+
+Updated `useDataGrid` hook with `hasPagination` to enable/disable pagination.

--- a/.changeset/chatty-peaches-cheer.md
+++ b/.changeset/chatty-peaches-cheer.md
@@ -3,3 +3,11 @@
 ---
 
 Updated `useDataGrid` hook with `hasPagination` to enable/disable pagination.
+
+**Implementation**
+
+Updated the `useDataGrid` accordingly to the changes in the `useTable` of `@pankod/refine-core`. `hasPagination` property is being send directly to the `useTable` of `@pankod/refine-core` to disable pagination.
+
+**Use Cases**
+
+In some data providers, some of the resources might not support pagination which was not supported prior to these changes. To handle the pagination on the client-side or to disable completely, users can set `hasPagination` to `false`.

--- a/.changeset/four-lions-leave.md
+++ b/.changeset/four-lions-leave.md
@@ -13,4 +13,12 @@
 "@pankod/refine-supabase": patch
 ---
 
-Updated pagination parameters as nullable by handling the default value in function implementation.
+Updated pagination parameters default values and added `hasPagination` property to `getList` method of the data providers.
+
+**Implementation**
+
+Updated the `getList` method accordingly to the changes in the `useTable` and `useList` of `@pankod/refine-core`. `hasPagination` is used to disable pagination (defaults to `true`)
+
+**Use Cases**
+
+For some resources, there might be no support for pagination or users might want to see all of the data without any pagination, prior to these changes this was not supported in **refine** data providers.

--- a/.changeset/four-lions-leave.md
+++ b/.changeset/four-lions-leave.md
@@ -1,0 +1,16 @@
+---
+"@pankod/refine-airtable": patch
+"@pankod/refine-altogic": patch
+"@pankod/refine-appwrite": patch
+"@pankod/refine-graphql": patch
+"@pankod/refine-hasura": patch
+"@pankod/refine-nestjsx-crud": patch
+"@pankod/refine-nhost": patch
+"@pankod/refine-simple-rest": patch
+"@pankod/refine-strapi": patch
+"@pankod/refine-strapi-graphql": patch
+"@pankod/refine-strapi-v4": patch
+"@pankod/refine-supabase": patch
+---
+
+Updated pagination parameters as nullable by handling the default value in function implementation.

--- a/.changeset/green-poems-grab.md
+++ b/.changeset/green-poems-grab.md
@@ -2,4 +2,4 @@
 "@pankod/refine-strapi-v4": patch
 ---
 
-The data length added to `total` return value of `@refine/strapi-v4` dataProvider `getList` method.
+Resolves [#2028](https://github.com/pankod/refine/issues/2028)

--- a/.changeset/green-poems-grab.md
+++ b/.changeset/green-poems-grab.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-strapi-v4": patch
+---
+
+The data length added to `total` return value of `@refine/strapi-v4` dataProvider `getList` method.

--- a/.changeset/green-poems-grab.md
+++ b/.changeset/green-poems-grab.md
@@ -2,4 +2,4 @@
 "@pankod/refine-strapi-v4": patch
 ---
 
-Resolves [#2028](https://github.com/pankod/refine/issues/2028)
+Fix pagination issue on `users` endpoint - [#2028](https://github.com/pankod/refine/issues/2028)

--- a/.changeset/silly-garlics-listen.md
+++ b/.changeset/silly-garlics-listen.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": minor
+---
+
+Updated `useTable` hook with `hasPagination` to enable/disable pagination.

--- a/.changeset/silly-garlics-listen.md
+++ b/.changeset/silly-garlics-listen.md
@@ -3,3 +3,11 @@
 ---
 
 Updated `useTable` hook with `hasPagination` to enable/disable pagination.
+
+**Implementation**
+
+Updated the `useTable` accordingly to the changes in the `useTable` of `@pankod/refine-core`. `hasPagination` property is being send directly to the `useTable` of `@pankod/refine-core` to disable pagination.
+
+**Use Cases**
+
+In some data providers, some of the resources might not support pagination which was not supported prior to these changes. To handle the pagination on the client-side or to disable completely, users can set `hasPagination` to `false`.

--- a/.changeset/small-eggs-wash.md
+++ b/.changeset/small-eggs-wash.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-react-table": minor
+---
+
+s

--- a/.changeset/small-eggs-wash.md
+++ b/.changeset/small-eggs-wash.md
@@ -3,3 +3,11 @@
 ---
 
 Add `hasPagination` property to `useTable` hook to enable/disable pagination.
+
+**Implementation**
+
+Updated the `useTable` hook accordingly to the changes in the `useTable` of `@pankod/refine-core`. `hasPagination` property is being send directly to the `useTable` of `@pankod/refine-core` to disable pagination.
+
+**Use Cases**
+
+In some data providers, some of the resources might not support pagination which was not supported prior to these changes. To handle the pagination on the client-side or to disable completely, users can set `hasPagination` to `false`.

--- a/.changeset/small-eggs-wash.md
+++ b/.changeset/small-eggs-wash.md
@@ -2,4 +2,4 @@
 "@pankod/refine-react-table": minor
 ---
 
-s
+Add `hasPagination` property to `useTable` hook to enable/disable pagination.

--- a/.changeset/stupid-meals-yell.md
+++ b/.changeset/stupid-meals-yell.md
@@ -1,0 +1,6 @@
+---
+"@pankod/refine-core": minor
+---
+
+Added `hasPagination` property to `useTable` to enable/disable pagination.
+Updated `useList` config with no pagination option. Set `pagination` to `false` to disable pagination.

--- a/.changeset/stupid-meals-yell.md
+++ b/.changeset/stupid-meals-yell.md
@@ -2,5 +2,12 @@
 "@pankod/refine-core": minor
 ---
 
-Added `hasPagination` property to `useTable` to enable/disable pagination.
-Updated `useList` config with no pagination option. Set `pagination` to `false` to disable pagination.
+Ability to disable server-side pagination on `useTable` and `useList` hooks.
+
+**Implementation**
+
+Added `hasPagination` property to `useTable` to enable/disable pagination. Updated `useList` config with no pagination option. Set `hasPagination` to `false` to disable pagination. `useTable` hook uses the `useList` hook under the hood and propagates the `hasPagination` property to it. Also setting pagination related return values to `undefined` for better type check on the user side.
+
+**Use Cases**
+
+In some data providers, some of the resources might not support pagination which was not supported prior to these changes. To handle the pagination on the client-side or to disable completely, users can set `hasPagination` to `false`.

--- a/examples/dataProvider/strapi-v4/src/App.tsx
+++ b/examples/dataProvider/strapi-v4/src/App.tsx
@@ -13,6 +13,7 @@ import axios from "axios";
 import "@pankod/refine-antd/dist/styles.min.css";
 
 import { PostList, PostCreate, PostEdit } from "pages/posts";
+import { UsersList } from "pages/users";
 import { CategoryList, CategoryCreate, CategoryEdit } from "pages/categories";
 
 import { TOKEN_KEY, API_URL } from "./constants";
@@ -93,6 +94,10 @@ const App: React.FC = () => {
                     list: CategoryList,
                     create: CategoryCreate,
                     edit: CategoryEdit,
+                },
+                {
+                    name: "users",
+                    list: UsersList,
                 },
             ]}
             notificationProvider={notificationProvider}

--- a/examples/dataProvider/strapi-v4/src/pages/users/index.ts
+++ b/examples/dataProvider/strapi-v4/src/pages/users/index.ts
@@ -1,0 +1,1 @@
+export { UsersList } from "./list";

--- a/examples/dataProvider/strapi-v4/src/pages/users/list.tsx
+++ b/examples/dataProvider/strapi-v4/src/pages/users/list.tsx
@@ -1,0 +1,24 @@
+import { IResourceComponentsProps } from "@pankod/refine-core";
+
+import { List, Table, useTable } from "@pankod/refine-antd";
+
+export const UsersList: React.FC<IResourceComponentsProps> = () => {
+    const { tableProps, sorter } = useTable({
+        hasPagination: false,
+        syncWithLocation: true,
+    });
+
+    return (
+        <List>
+            <Table {...tableProps} rowKey="id">
+                <Table.Column dataIndex="id" key="id" title="ID" />
+                <Table.Column
+                    dataIndex="username"
+                    key="name"
+                    title="Username"
+                />
+                <Table.Column dataIndex="email" key="email" title="Email" />
+            </Table>
+        </List>
+    );
+};

--- a/examples/real-world-example/src/dataProvider.ts
+++ b/examples/real-world-example/src/dataProvider.ts
@@ -36,29 +36,25 @@ const generateFilter = (filters?: CrudFilters) => {
 export const dataProvider = (axios: AxiosInstance): DataProvider => {
     return {
         ...restDataProvider(API_URL, axios),
-        getList: async ({
-            resource,
-            pagination = { current: 1, pageSize: 10 },
-            filters,
-            metaData,
-        }) => {
+        getList: async ({ resource, pagination, filters, metaData }) => {
             const url = `${API_URL}/${resource}`;
 
             // pagination
-            const hasPagination = pagination !== false;
-            const { current = 1, pageSize = 10 } = pagination ? pagination : {};
+            const current = pagination?.current || 1;
+            const pageSize = pagination?.pageSize || 10;
 
             const queryFilters = generateFilter(filters);
 
-            const query = hasPagination
-                ? {
-                      offset: (current - 1) * pageSize,
-                      limit: pageSize,
-                  }
-                : {};
+            const query: {
+                limit: number;
+                offset: number;
+            } = {
+                offset: (current - 1) * pageSize,
+                limit: pageSize,
+            };
 
             const { data } = await axios.get(
-                `${url}?${stringify({ ...query, ...queryFilters })}`,
+                `${url}?${stringify(query)}&${stringify(queryFilters)}`,
             );
 
             return {

--- a/examples/real-world-example/src/dataProvider.ts
+++ b/examples/real-world-example/src/dataProvider.ts
@@ -36,25 +36,29 @@ const generateFilter = (filters?: CrudFilters) => {
 export const dataProvider = (axios: AxiosInstance): DataProvider => {
     return {
         ...restDataProvider(API_URL, axios),
-        getList: async ({ resource, pagination, filters, metaData }) => {
+        getList: async ({
+            resource,
+            pagination = { current: 1, pageSize: 10 },
+            filters,
+            metaData,
+        }) => {
             const url = `${API_URL}/${resource}`;
 
             // pagination
-            const current = pagination?.current || 1;
-            const pageSize = pagination?.pageSize || 10;
+            const hasPagination = pagination !== false;
+            const { current = 1, pageSize = 10 } = pagination ? pagination : {};
 
             const queryFilters = generateFilter(filters);
 
-            const query: {
-                limit: number;
-                offset: number;
-            } = {
-                offset: (current - 1) * pageSize,
-                limit: pageSize,
-            };
+            const query = hasPagination
+                ? {
+                      offset: (current - 1) * pageSize,
+                      limit: pageSize,
+                  }
+                : {};
 
             const { data } = await axios.get(
-                `${url}?${stringify(query)}&${stringify(queryFilters)}`,
+                `${url}?${stringify({ ...query, ...queryFilters })}`,
             );
 
             return {

--- a/packages/airtable/src/index.ts
+++ b/packages/airtable/src/index.ts
@@ -118,12 +118,12 @@ const AirtableDataProvider = (
     return {
         getList: async ({
             resource,
+            hasPagination = true,
             pagination = { current: 1, pageSize: 10 },
             sort,
             filters,
         }) => {
-            const hasPagination = pagination !== false;
-            const { current = 1, pageSize = 10 } = pagination ? pagination : {};
+            const { current = 1, pageSize = 10 } = pagination ?? {};
 
             const generetedSort = generateSort(sort) || [];
             const queryFilters = generateFilter(filters);

--- a/packages/airtable/src/index.ts
+++ b/packages/airtable/src/index.ts
@@ -118,10 +118,13 @@ const AirtableDataProvider = (
     return {
         getList: async ({
             resource,
-            pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+            pagination = { current: 1, pageSize: 10 },
             sort,
             filters,
         }) => {
+            const hasPagination = pagination !== false;
+            const { current = 1, pageSize = 10 } = pagination ? pagination : {};
+
             const generetedSort = generateSort(sort) || [];
             const queryFilters = generateFilter(filters);
 
@@ -136,14 +139,8 @@ const AirtableDataProvider = (
             return {
                 data: data
                     .slice(
-                        typeof current !== "undefined" &&
-                            typeof pageSize !== "undefined"
-                            ? (current - 1) * pageSize
-                            : undefined,
-                        typeof current !== "undefined" &&
-                            typeof pageSize !== "undefined"
-                            ? current * pageSize
-                            : undefined,
+                        hasPagination ? (current - 1) * pageSize : undefined,
+                        hasPagination ? current * pageSize : undefined,
                     )
                     .map((p) => ({
                         id: p.id,

--- a/packages/airtable/src/index.ts
+++ b/packages/airtable/src/index.ts
@@ -116,10 +116,12 @@ const AirtableDataProvider = (
         airtableClient || new Airtable({ apiKey: apiKey }).base(baseId);
 
     return {
-        getList: async ({ resource, pagination, sort, filters }) => {
-            const current = pagination?.current || 1;
-            const pageSize = pagination?.pageSize || 10;
-
+        getList: async ({
+            resource,
+            pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+            sort,
+            filters,
+        }) => {
             const generetedSort = generateSort(sort) || [];
             const queryFilters = generateFilter(filters);
 
@@ -133,7 +135,16 @@ const AirtableDataProvider = (
 
             return {
                 data: data
-                    .slice((current - 1) * pageSize, current * pageSize)
+                    .slice(
+                        typeof current !== "undefined" &&
+                            typeof pageSize !== "undefined"
+                            ? (current - 1) * pageSize
+                            : undefined,
+                        typeof current !== "undefined" &&
+                            typeof pageSize !== "undefined"
+                            ? current * pageSize
+                            : undefined,
+                    )
                     .map((p) => ({
                         id: p.id,
                         ...p.fields,

--- a/packages/altogic/src/index.ts
+++ b/packages/altogic/src/index.ts
@@ -100,23 +100,27 @@ const AltogicDataProvider = (
     apiUrl: string,
     httpClient: AxiosInstance = axiosInstance,
 ): DataProvider => ({
-    getList: async ({ resource, pagination, filters, sort }) => {
+    getList: async ({
+        resource,
+        pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+        filters,
+        sort,
+    }) => {
         const url = `${apiUrl}/${resource}`;
-
-        // pagination
-        const current = pagination?.current || 1;
-        const pageSize = pagination?.pageSize || 10;
 
         const queryFilters = generateFilter(filters);
 
         const query: {
-            page: number;
-            size: number;
+            page?: number;
+            size?: number;
             sort?: string;
-        } = {
-            page: current,
-            size: pageSize,
-        };
+        } =
+            typeof current !== "undefined" && typeof pageSize !== "undefined"
+                ? {
+                      page: current,
+                      size: pageSize,
+                  }
+                : {};
 
         const generatedSort = generateSort(sort);
         if (generatedSort) {

--- a/packages/altogic/src/index.ts
+++ b/packages/altogic/src/index.ts
@@ -102,14 +102,12 @@ const AltogicDataProvider = (
 ): DataProvider => ({
     getList: async ({
         resource,
+        hasPagination = true,
         pagination = { current: 1, pageSize: 10 },
         filters,
         sort,
     }) => {
-        const hasPagination = pagination !== false;
-        const { current: page = 1, pageSize: size = 10 } = pagination
-            ? pagination
-            : {};
+        const { current: page = 1, pageSize: size = 10 } = pagination ?? {};
 
         const url = `${apiUrl}/${resource}`;
 

--- a/packages/altogic/src/index.ts
+++ b/packages/altogic/src/index.ts
@@ -102,10 +102,15 @@ const AltogicDataProvider = (
 ): DataProvider => ({
     getList: async ({
         resource,
-        pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+        pagination = { current: 1, pageSize: 10 },
         filters,
         sort,
     }) => {
+        const hasPagination = pagination !== false;
+        const { current: page = 1, pageSize: size = 10 } = pagination
+            ? pagination
+            : {};
+
         const url = `${apiUrl}/${resource}`;
 
         const queryFilters = generateFilter(filters);
@@ -114,13 +119,7 @@ const AltogicDataProvider = (
             page?: number;
             size?: number;
             sort?: string;
-        } =
-            typeof current !== "undefined" && typeof pageSize !== "undefined"
-                ? {
-                      page: current,
-                      size: pageSize,
-                  }
-                : {};
+        } = hasPagination ? { page, size } : {};
 
         const generatedSort = generateSort(sort);
         if (generatedSort) {

--- a/packages/antd/src/hooks/table/useTable/useTable.spec.ts
+++ b/packages/antd/src/hooks/table/useTable/useTable.spec.ts
@@ -60,6 +60,28 @@ describe("useTable Hook", () => {
         expect(pagination).toEqual(expect.objectContaining(customPagination));
     });
 
+    it("with disabled pagination", async () => {
+        const { result, waitFor } = renderHook(
+            () =>
+                useTable({
+                    hasPagination: false,
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        await waitFor(() => {
+            return !result.current.tableProps.loading;
+        });
+
+        const {
+            tableProps: { pagination },
+        } = result.current;
+
+        expect(pagination).toBe(false);
+    });
+
     it("with custom resource", async () => {
         const { result, waitFor } = renderHook(
             () =>

--- a/packages/antd/src/hooks/table/useTable/useTable.ts
+++ b/packages/antd/src/hooks/table/useTable/useTable.ts
@@ -163,6 +163,62 @@ export const useTable = <
         }
     };
 
+    const antdPagination = (): false | TablePaginationConfig => {
+        if (hasPagination) {
+            return {
+                itemRender: (page, type, element) => {
+                    const link = createLinkForSyncWithLocation({
+                        pagination: {
+                            pageSize,
+                            current: page,
+                        },
+                        sorter,
+                        filters,
+                    });
+
+                    if (type === "page") {
+                        return createElement(PaginationLink, {
+                            to: link,
+                            element: `${page}`,
+                        });
+                    }
+                    if (type === "next" || type === "prev") {
+                        return createElement(PaginationLink, {
+                            to: link,
+                            element: element,
+                        });
+                    }
+
+                    if (type === "jump-next" || type === "jump-prev") {
+                        const elementChildren = (element as React.ReactElement)
+                            ?.props?.children;
+
+                        return createElement(PaginationLink, {
+                            to: link,
+                            element:
+                                Children.count(elementChildren) > 1
+                                    ? createElement(
+                                          Fragment,
+                                          {},
+                                          elementChildren,
+                                      )
+                                    : elementChildren,
+                        });
+                    }
+
+                    return element;
+                },
+                pageSize,
+                current,
+                simple: !breakpoint.sm,
+                position: !breakpoint.sm ? ["bottomCenter"] : ["bottomRight"],
+                total: data?.total,
+            };
+        }
+
+        return false;
+    };
+
     return {
         searchFormProps: {
             ...formSF.formProps,
@@ -172,60 +228,7 @@ export const useTable = <
             dataSource: data?.data,
             loading: liveMode === "auto" ? isLoading : !isFetched,
             onChange,
-            pagination: hasPagination
-                ? {
-                      itemRender: (page, type, element) => {
-                          const link = createLinkForSyncWithLocation({
-                              pagination: {
-                                  pageSize,
-                                  current: page,
-                              },
-                              sorter,
-                              filters,
-                          });
-
-                          if (type === "page") {
-                              return createElement(PaginationLink, {
-                                  to: link,
-                                  element: `${page}`,
-                              });
-                          }
-                          if (type === "next" || type === "prev") {
-                              return createElement(PaginationLink, {
-                                  to: link,
-                                  element: element,
-                              });
-                          }
-
-                          if (type === "jump-next" || type === "jump-prev") {
-                              const elementChildren = (
-                                  element as React.ReactElement
-                              )?.props?.children;
-
-                              return createElement(PaginationLink, {
-                                  to: link,
-                                  element:
-                                      Children.count(elementChildren) > 1
-                                          ? createElement(
-                                                Fragment,
-                                                {},
-                                                elementChildren,
-                                            )
-                                          : elementChildren,
-                              });
-                          }
-
-                          return element;
-                      },
-                      pageSize,
-                      current,
-                      simple: !breakpoint.sm,
-                      position: !breakpoint.sm
-                          ? ["bottomCenter"]
-                          : ["bottomRight"],
-                      total: data?.total,
-                  }
-                : false,
+            pagination: antdPagination(),
             scroll: { x: true },
         },
         tableQueryResult,

--- a/packages/appwrite/src/index.ts
+++ b/packages/appwrite/src/index.ts
@@ -100,9 +100,12 @@ export const getAppwriteSorting: GetAppwriteSortingType = (sort) => {
 export const dataProvider = (appwriteClient: Appwrite): DataProvider => {
     return {
         //TODO: Fix typing
-        getList: async ({ resource, pagination, filters, sort }) => {
-            const current = pagination?.current ?? 1;
-            const pageSize = pagination?.pageSize ?? 10;
+        getList: async ({
+            resource,
+            pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+            filters,
+            sort,
+        }) => {
             const appwriteFilters = getAppwriteFilters(filters);
             const { orderField, orderType } = getAppwriteSorting(sort);
 
@@ -111,7 +114,10 @@ export const dataProvider = (appwriteClient: Appwrite): DataProvider => {
                     resource,
                     appwriteFilters,
                     pageSize,
-                    (current - 1) * pageSize,
+                    typeof current !== "undefined" &&
+                        typeof pageSize !== "undefined"
+                        ? (current - 1) * pageSize
+                        : undefined,
                     undefined,
                     undefined,
                     orderField,

--- a/packages/appwrite/src/index.ts
+++ b/packages/appwrite/src/index.ts
@@ -102,10 +102,13 @@ export const dataProvider = (appwriteClient: Appwrite): DataProvider => {
         //TODO: Fix typing
         getList: async ({
             resource,
-            pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+            pagination = { current: 1, pageSize: 10 },
             filters,
             sort,
         }) => {
+            const hasPagination = pagination !== false;
+            const { current = 1, pageSize = 10 } = pagination ? pagination : {};
+
             const appwriteFilters = getAppwriteFilters(filters);
             const { orderField, orderType } = getAppwriteSorting(sort);
 
@@ -114,10 +117,7 @@ export const dataProvider = (appwriteClient: Appwrite): DataProvider => {
                     resource,
                     appwriteFilters,
                     pageSize,
-                    typeof current !== "undefined" &&
-                        typeof pageSize !== "undefined"
-                        ? (current - 1) * pageSize
-                        : undefined,
+                    hasPagination ? (current - 1) * pageSize : undefined,
                     undefined,
                     undefined,
                     orderField,

--- a/packages/appwrite/src/index.ts
+++ b/packages/appwrite/src/index.ts
@@ -102,12 +102,12 @@ export const dataProvider = (appwriteClient: Appwrite): DataProvider => {
         //TODO: Fix typing
         getList: async ({
             resource,
+            hasPagination = true,
             pagination = { current: 1, pageSize: 10 },
             filters,
             sort,
         }) => {
-            const hasPagination = pagination !== false;
-            const { current = 1, pageSize = 10 } = pagination ? pagination : {};
+            const { current = 1, pageSize = 10 } = pagination ?? {};
 
             const appwriteFilters = getAppwriteFilters(filters);
             const { orderField, orderType } = getAppwriteSorting(sort);

--- a/packages/core/src/contexts/data/IDataContext.ts
+++ b/packages/core/src/contexts/data/IDataContext.ts
@@ -107,7 +107,8 @@ export interface DeleteManyResponse<TData = BaseRecord> {
 export interface IDataContext {
     getList: <TData extends BaseRecord = BaseRecord>(params: {
         resource: string;
-        pagination?: Pagination | false;
+        pagination?: Pagination;
+        hasPagination?: boolean;
         sort?: CrudSorting;
         filters?: CrudFilters;
         metaData?: MetaDataQuery;
@@ -183,7 +184,8 @@ export interface IDataContext {
 export interface IDataContextProvider {
     getList: <TData extends BaseRecord = BaseRecord>(params: {
         resource: string;
-        pagination?: Pagination | false;
+        pagination?: Pagination;
+        hasPagination?: boolean;
         sort?: CrudSorting;
         filters?: CrudFilters;
         metaData?: MetaDataQuery;

--- a/packages/core/src/contexts/data/IDataContext.ts
+++ b/packages/core/src/contexts/data/IDataContext.ts
@@ -107,7 +107,7 @@ export interface DeleteManyResponse<TData = BaseRecord> {
 export interface IDataContext {
     getList: <TData extends BaseRecord = BaseRecord>(params: {
         resource: string;
-        pagination?: Pagination;
+        pagination?: Pagination | false;
         sort?: CrudSorting;
         filters?: CrudFilters;
         metaData?: MetaDataQuery;
@@ -183,7 +183,7 @@ export interface IDataContext {
 export interface IDataContextProvider {
     getList: <TData extends BaseRecord = BaseRecord>(params: {
         resource: string;
-        pagination?: Pagination;
+        pagination?: Pagination | false;
         sort?: CrudSorting;
         filters?: CrudFilters;
         metaData?: MetaDataQuery;

--- a/packages/core/src/definitions/table/index.ts
+++ b/packages/core/src/definitions/table/index.ts
@@ -30,7 +30,7 @@ export const parseTableParamsFromQuery = (params: any) => {
 };
 
 export const stringifyTableParams = (params: {
-    pagination: { current?: number; pageSize?: number };
+    pagination?: { current?: number; pageSize?: number };
     sorter: CrudSorting;
     filters: CrudFilters;
 }): string => {
@@ -41,7 +41,22 @@ export const stringifyTableParams = (params: {
     };
     const { pagination, sorter, filters } = params;
 
-    let queryString = `current=${pagination.current}&pageSize=${pagination.pageSize}`;
+    let queryString = pagination
+        ? `${
+              typeof pagination.current !== "undefined"
+                  ? `current=${pagination.current}`
+                  : ""
+          }${
+              typeof pagination.current !== "undefined" &&
+              typeof pagination.pageSize !== "undefined"
+                  ? "&"
+                  : ""
+          }${
+              typeof pagination.pageSize !== "undefined"
+                  ? `pageSize=${pagination.pageSize}`
+                  : ""
+          }`
+        : "";
 
     const qsSorters = qs.stringify({ sorter }, options);
     if (qsSorters) {

--- a/packages/core/src/definitions/table/index.ts
+++ b/packages/core/src/definitions/table/index.ts
@@ -41,32 +41,10 @@ export const stringifyTableParams = (params: {
     };
     const { pagination, sorter, filters } = params;
 
-    let queryString = pagination
-        ? `${
-              typeof pagination.current !== "undefined"
-                  ? `current=${pagination.current}`
-                  : ""
-          }${
-              typeof pagination.current !== "undefined" &&
-              typeof pagination.pageSize !== "undefined"
-                  ? "&"
-                  : ""
-          }${
-              typeof pagination.pageSize !== "undefined"
-                  ? `pageSize=${pagination.pageSize}`
-                  : ""
-          }`
-        : "";
-
-    const qsSorters = qs.stringify({ sorter }, options);
-    if (qsSorters) {
-        queryString += `&${qsSorters}`;
-    }
-
-    const qsFilters = qs.stringify({ filters }, options);
-    if (qsFilters) {
-        queryString += `&${qsFilters}`;
-    }
+    const queryString = qs.stringify(
+        { ...(pagination ? pagination : {}), sorter, filters },
+        options,
+    );
 
     return queryString;
 };

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -93,13 +93,7 @@ export const useList = <
             return getList<TData>({
                 resource,
                 ...restConfig,
-                pagination:
-                    pagination === false
-                        ? {
-                              current: undefined,
-                              pageSize: undefined,
-                          }
-                        : pagination,
+                pagination,
                 metaData,
             });
         },

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -21,7 +21,7 @@ import {
 import { queryKeys } from "@definitions/helpers";
 
 export interface UseListConfig {
-    pagination?: Pagination;
+    pagination?: Pagination | false;
     sort?: CrudSorting;
     filters?: CrudFilters;
 }
@@ -88,7 +88,21 @@ export const useList = <
 
     const queryResponse = useQuery<GetListResponse<TData>, TError>(
         queryKey.list(config),
-        () => getList<TData>({ resource, ...config, metaData }),
+        () => {
+            const { pagination, ...restConfig } = config || {};
+            return getList<TData>({
+                resource,
+                ...restConfig,
+                pagination:
+                    pagination === false
+                        ? {
+                              current: undefined,
+                              pageSize: undefined,
+                          }
+                        : pagination,
+                metaData,
+            });
+        },
         {
             ...queryOptions,
             onSuccess: (data) => {

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -21,7 +21,8 @@ import {
 import { queryKeys } from "@definitions/helpers";
 
 export interface UseListConfig {
-    pagination?: Pagination | false;
+    pagination?: Pagination;
+    hasPagination?: boolean;
     sort?: CrudSorting;
     filters?: CrudFilters;
 }
@@ -89,11 +90,11 @@ export const useList = <
     const queryResponse = useQuery<GetListResponse<TData>, TError>(
         queryKey.list(config),
         () => {
-            const { pagination, ...restConfig } = config || {};
+            const { hasPagination, ...restConfig } = config || {};
             return getList<TData>({
                 resource,
                 ...restConfig,
-                pagination,
+                hasPagination,
                 metaData,
             });
         },

--- a/packages/core/src/hooks/useTable/index.spec.ts
+++ b/packages/core/src/hooks/useTable/index.spec.ts
@@ -70,6 +70,31 @@ describe("useTable Hook", () => {
         expect(pageCount).toEqual(2);
     });
 
+    it("with disabled pagination", async () => {
+        const { result, waitFor } = renderHook(
+            () =>
+                useTable({
+                    hasPagination: false,
+                }),
+            {
+                wrapper: TestWrapper({
+                    dataProvider: MockJSONServer,
+                    resources: [{ name: "posts" }],
+                }),
+            },
+        );
+
+        await waitFor(() => {
+            return !result.current.tableQueryResult.isLoading;
+        });
+
+        const { pageSize, current, pageCount } = result.current;
+
+        expect(pageSize).toBeUndefined();
+        expect(current).toBeUndefined();
+        expect(pageCount).toBeUndefined();
+    });
+
     it("with custom resource", async () => {
         const { result, waitFor } = renderHook(
             () =>

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -281,7 +281,7 @@ export function useTable<
                 setPageSize,
                 pageCount: pageSize
                     ? Math.ceil((queryResult.data?.total ?? 0) / pageSize)
-                    : 0,
+                    : 1,
             };
         }
 
@@ -292,7 +292,7 @@ export function useTable<
             setPageSize: undefined,
             pageCount: undefined,
         };
-    }, [hasPagination, current, pageSize]);
+    }, [hasPagination, current, pageSize, queryResult.data?.total]);
 
     return {
         tableQueryResult: queryResult,

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -102,8 +102,8 @@ export function useTable<
     TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
 >(
-    props: useTableProps<TData, TError> & {
-        hasPagination: true;
+    props?: useTableProps<TData, TError> & {
+        hasPagination?: true;
     },
 ): useTableReturnType<TData>;
 // overload without pagination
@@ -111,7 +111,7 @@ export function useTable<
     TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
 >(
-    props: useTableProps<TData, TError> & {
+    props?: useTableProps<TData, TError> & {
         hasPagination: false;
     },
 ): useTableNoPaginationReturnType<TData>;

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -223,7 +223,8 @@ export function useTable<
     const queryResult = useList<TData, TError>({
         resource: resource.name,
         config: {
-            pagination: hasPagination ? { current, pageSize } : false,
+            hasPagination,
+            pagination: { current, pageSize },
             filters: unionFilters(permanentFilter, filters),
             sort: unionSorters(permanentSorter, sorter),
         },

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -51,13 +51,13 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
     return {
         getList: async ({
             resource,
+            hasPagination = true,
             pagination = { current: 1, pageSize: 10 },
             sort,
             filters,
             metaData,
         }) => {
-            const hasPagination = pagination !== false;
-            const { current = 1, pageSize = 10 } = pagination ? pagination : {};
+            const { current = 1, pageSize = 10 } = pagination ?? {};
 
             const sortBy = genereteSort(sort);
             const filterBy = generateFilter(filters);

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -49,9 +49,15 @@ const generateFilter = (filters?: CrudFilters) => {
 
 const dataProvider = (client: GraphQLClient): DataProvider => {
     return {
-        getList: async ({ resource, pagination, sort, filters, metaData }) => {
-            const current = pagination?.current || 1;
-            const pageSize = pagination?.pageSize || 10;
+        getList: async ({
+            resource,
+            pagination = { current: 1, pageSize: 10 },
+            sort,
+            filters,
+            metaData,
+        }) => {
+            const hasPagination = pagination !== false;
+            const { current = 1, pageSize = 10 } = pagination ? pagination : {};
 
             const sortBy = genereteSort(sort);
             const filterBy = generateFilter(filters);
@@ -66,8 +72,12 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
                     ...metaData?.variables,
                     sort: sortBy,
                     where: { value: filterBy, type: "JSON" },
-                    start: (current - 1) * pageSize,
-                    limit: pageSize,
+                    ...(hasPagination
+                        ? {
+                              start: (current - 1) * pageSize,
+                              limit: pageSize,
+                          }
+                        : {}),
                 },
                 fields: metaData?.fields,
             });

--- a/packages/hasura/src/index.ts
+++ b/packages/hasura/src/index.ts
@@ -152,11 +152,16 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
             };
         },
 
-        getList: async ({ resource, sort, filters, pagination, metaData }) => {
-            const current = pagination?.current ?? 1;
-            const limit = pagination?.pageSize || 10;
-            const offset = (current - 1) * limit;
-
+        getList: async ({
+            resource,
+            sort,
+            filters,
+            pagination: { current, pageSize: limit } = {
+                current: 1,
+                pageSize: 10,
+            },
+            metaData,
+        }) => {
             const hasuraSorting = generateSorting(sort);
             const hasuraFilters = generateFilters(filters);
 
@@ -172,8 +177,13 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
                     operation,
                     fields: metaData?.fields,
                     variables: {
-                        limit,
-                        offset,
+                        ...(typeof current !== "undefined" &&
+                        typeof limit !== "undefined"
+                            ? {
+                                  limit,
+                                  offset: (current - 1) * limit,
+                              }
+                            : {}),
                         ...(hasuraSorting && {
                             order_by: {
                                 value: hasuraSorting,

--- a/packages/hasura/src/index.ts
+++ b/packages/hasura/src/index.ts
@@ -156,13 +156,11 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
             resource,
             sort,
             filters,
+            hasPagination = true,
             pagination = { current: 1, pageSize: 10 },
             metaData,
         }) => {
-            const hasPagination = pagination !== false;
-            const { current = 1, pageSize: limit = 10 } = pagination
-                ? pagination
-                : {};
+            const { current = 1, pageSize: limit = 10 } = pagination ?? {};
 
             const hasuraSorting = generateSorting(sort);
             const hasuraFilters = generateFilters(filters);

--- a/packages/hasura/src/index.ts
+++ b/packages/hasura/src/index.ts
@@ -156,12 +156,14 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
             resource,
             sort,
             filters,
-            pagination: { current, pageSize: limit } = {
-                current: 1,
-                pageSize: 10,
-            },
+            pagination = { current: 1, pageSize: 10 },
             metaData,
         }) => {
+            const hasPagination = pagination !== false;
+            const { current = 1, pageSize: limit = 10 } = pagination
+                ? pagination
+                : {};
+
             const hasuraSorting = generateSorting(sort);
             const hasuraFilters = generateFilters(filters);
 
@@ -177,8 +179,7 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
                     operation,
                     fields: metaData?.fields,
                     variables: {
-                        ...(typeof current !== "undefined" &&
-                        typeof limit !== "undefined"
+                        ...(hasPagination
                             ? {
                                   limit,
                                   offset: (current - 1) * limit,

--- a/packages/mui/src/hooks/useDataGrid/index.spec.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.spec.ts
@@ -61,4 +61,26 @@ describe("useDataGrid Hook", () => {
         ]);
         expect(result.current.current).toEqual(1);
     });
+
+    it("with no pagination", async () => {
+        const { result, waitFor } = renderHook(
+            () =>
+                useDataGrid<any, any>({
+                    resource: "posts",
+                    columns: [{ field: "title" }, { field: "status" }],
+                    hasPagination: false,
+                }),
+            {
+                wrapper: TestWrapper({}),
+            },
+        );
+
+        await waitFor(() => {
+            return !result.current.tableQueryResult?.isLoading;
+        });
+
+        expect(result.current.current).toBeUndefined();
+        expect(result.current.pageSize).toBeUndefined();
+        expect(result.current.pageCount).toBeUndefined();
+    });
 });

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -5,6 +5,7 @@ import {
     useTable as useTableCore,
     useTableProps as useTablePropsCore,
     useTableReturnType as useTableReturnTypeCore,
+    useTableNoPaginationReturnType as useTableNoPaginationReturnTypeCore,
     useLiveMode,
 } from "@pankod/refine-core";
 import {
@@ -22,6 +23,7 @@ import {
     transformFilterModelToCrudFilters,
     transformCrudFiltersToFilterModel,
 } from "@definitions";
+import { useMemo } from "react";
 
 type DataGridPropsType = Pick<DataGridProps, "filterModel"> &
     Required<
@@ -30,12 +32,7 @@ type DataGridPropsType = Pick<DataGridProps, "filterModel"> &
             | "columns"
             | "rows"
             | "loading"
-            | "paginationMode"
             | "rowCount"
-            | "page"
-            | "onPageChange"
-            | "pageSize"
-            | "onPageSizeChange"
             | "sortingMode"
             | "sortModel"
             | "onSortModelChange"
@@ -44,6 +41,15 @@ type DataGridPropsType = Pick<DataGridProps, "filterModel"> &
             | "sx"
             | "disableSelectionOnClick"
         >
+    > &
+    Pick<
+        DataGridProps,
+        | "hideFooterPagination"
+        | "paginationMode"
+        | "page"
+        | "onPageChange"
+        | "pageSize"
+        | "onPageSizeChange"
     >;
 
 export type UseDataGridProps<TData, TError, TSearchVariables = unknown> =
@@ -62,7 +68,33 @@ export type UseDataGridReturnType<
     search: (value: TSearchVariables) => Promise<void>;
 };
 
-export const useDataGrid = <
+export type UseDataGridNoPaginationReturnType<
+    TData extends BaseRecord = BaseRecord,
+    TSearchVariables = unknown,
+> = useTableNoPaginationReturnTypeCore<TData> & {
+    dataGridProps: DataGridPropsType;
+    search: (value: TSearchVariables) => Promise<void>;
+};
+
+export function useDataGrid<
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+    TSearchVariables = unknown,
+>(
+    props: UseDataGridProps<TData, TError, TSearchVariables> & {
+        hasPagination?: true;
+    },
+): UseDataGridReturnType<TData, TSearchVariables>;
+export function useDataGrid<
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+    TSearchVariables = unknown,
+>(
+    props: UseDataGridProps<TData, TError, TSearchVariables> & {
+        hasPagination: false;
+    },
+): UseDataGridNoPaginationReturnType<TData, TSearchVariables>;
+export function useDataGrid<
     TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TSearchVariables = unknown,
@@ -71,6 +103,7 @@ export const useDataGrid = <
     onSearch: onSearchProp,
     initialCurrent,
     initialPageSize = 25,
+    hasPagination = true,
     initialSorter,
     permanentSorter,
     defaultSetFilterBehavior = "replace",
@@ -86,10 +119,9 @@ export const useDataGrid = <
     liveParams,
     metaData,
     dataProviderName,
-}: UseDataGridProps<TData, TError, TSearchVariables>): UseDataGridReturnType<
-    TData,
-    TSearchVariables
-> => {
+}: UseDataGridProps<TData, TError, TSearchVariables>):
+    | UseDataGridReturnType<TData, TSearchVariables>
+    | UseDataGridNoPaginationReturnType<TData, TSearchVariables> {
     const {
         tableQueryResult,
         current,
@@ -107,6 +139,8 @@ export const useDataGrid = <
         permanentFilter,
         initialCurrent,
         initialPageSize,
+        // @ts-expect-error currently boolean casting is not supported in overloaded types.
+        hasPagination: hasPagination,
         initialSorter,
         initialFilter,
         syncWithLocation: syncWithLocationProp,
@@ -129,10 +163,14 @@ export const useDataGrid = <
     const liveMode = useLiveMode(liveModeFromProp);
 
     const handlePageChange = (page: number) => {
-        setCurrent(page + 1);
+        if (hasPagination) {
+            setCurrent(page + 1);
+        }
     };
     const handlePageSizeChange = (pageSize: number) => {
-        setPageSize(pageSize);
+        if (hasPagination) {
+            setPageSize(pageSize);
+        }
     };
 
     const handleSortModelChange = (sortModel: GridSortModel) => {
@@ -143,16 +181,40 @@ export const useDataGrid = <
     const handleFilterModelChange = (filterModel: GridFilterModel) => {
         const crudFilters = transformFilterModelToCrudFilters(filterModel);
         setFilters(crudFilters);
-        setCurrent(1);
+        if (hasPagination) {
+            setCurrent(1);
+        }
     };
 
     const search = async (value: TSearchVariables) => {
         if (onSearchProp) {
             const searchFilters = await onSearchProp(value);
             setFilters(searchFilters);
-            setCurrent(1);
+            if (hasPagination) {
+                setCurrent(1);
+            }
         }
     };
+
+    const paginationValues = useMemo(() => {
+        if (hasPagination) {
+            return {
+                current,
+                setCurrent,
+                pageSize,
+                setPageSize,
+                pageCount,
+            };
+        }
+
+        return {
+            current: undefined,
+            setCurrent: undefined,
+            pageSize: undefined,
+            setPageSize: undefined,
+            pageCount: undefined,
+        };
+    }, [hasPagination, current, pageSize, pageCount]);
 
     return {
         tableQueryResult,
@@ -161,12 +223,18 @@ export const useDataGrid = <
             disableSelectionOnClick: true,
             rows: data?.data || [],
             loading: liveMode === "auto" ? isLoading : !isFetched,
-            paginationMode: "server",
             rowCount: data?.total || 0,
-            page: current - 1,
-            onPageChange: handlePageChange,
-            pageSize: pageSize,
-            onPageSizeChange: handlePageSizeChange,
+            ...(hasPagination
+                ? {
+                      paginationMode: "server",
+                      page: (current ?? 1) - 1,
+                      onPageChange: handlePageChange,
+                      pageSize: pageSize,
+                      onPageSizeChange: handlePageSizeChange,
+                  }
+                : {
+                      hideFooterPagination: true,
+                  }),
             sortingMode: "server",
             sortModel: transformCrudSortingToSortModel(
                 differenceWith(sorter, permanentSorter ?? [], isEqual),
@@ -195,16 +263,12 @@ export const useDataGrid = <
                 },
             },
         },
-        current,
-        setCurrent,
-        pageSize,
-        setPageSize,
+        ...paginationValues,
         sorter,
         setSorter,
         filters,
         setFilters,
         search,
-        pageCount,
         createLinkForSyncWithLocation,
     };
-};
+}

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -216,6 +216,22 @@ export function useDataGrid<
         };
     }, [hasPagination, current, pageSize, pageCount]);
 
+    const dataGridPaginationValues = () => {
+        if (hasPagination) {
+            return {
+                paginationMode: "server" as const,
+                page: (current ?? 1) - 1,
+                onPageChange: handlePageChange,
+                pageSize: pageSize,
+                onPageSizeChange: handlePageSizeChange,
+            };
+        }
+
+        return {
+            hideFooterPagination: true,
+        };
+    };
+
     return {
         tableQueryResult,
         dataGridProps: {
@@ -224,17 +240,7 @@ export function useDataGrid<
             rows: data?.data || [],
             loading: liveMode === "auto" ? isLoading : !isFetched,
             rowCount: data?.total || 0,
-            ...(hasPagination
-                ? {
-                      paginationMode: "server",
-                      page: (current ?? 1) - 1,
-                      onPageChange: handlePageChange,
-                      pageSize: pageSize,
-                      onPageSizeChange: handlePageSizeChange,
-                  }
-                : {
-                      hideFooterPagination: true,
-                  }),
+            ...dataGridPaginationValues(),
             sortingMode: "server",
             sortModel: transformCrudSortingToSortModel(
                 differenceWith(sorter, permanentSorter ?? [], isEqual),

--- a/packages/nestjsx-crud/src/index.ts
+++ b/packages/nestjsx-crud/src/index.ts
@@ -124,11 +124,14 @@ const NestsxCrud = (
 ): DataProvider => ({
     getList: async ({
         resource,
-        pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+        pagination = { current: 1, pageSize: 10 },
         filters,
         sort,
     }) => {
         const url = `${apiUrl}/${resource}`;
+
+        const hasPagination = pagination !== false;
+        const { current = 1, pageSize = 10 } = pagination ? pagination : {};
 
         const { crudFilters, orFilters } = generateFilter(filters);
 
@@ -136,7 +139,7 @@ const NestsxCrud = (
             .setFilter(crudFilters)
             .setOr(orFilters);
 
-        if (typeof current !== "undefined" && typeof pageSize !== "undefined") {
+        if (hasPagination) {
             query
                 .setLimit(pageSize)
                 .setPage(current)

--- a/packages/nestjsx-crud/src/index.ts
+++ b/packages/nestjsx-crud/src/index.ts
@@ -122,19 +122,26 @@ const NestsxCrud = (
     apiUrl: string,
     httpClient: AxiosInstance = axiosInstance,
 ): DataProvider => ({
-    getList: async ({ resource, pagination, filters, sort }) => {
+    getList: async ({
+        resource,
+        pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+        filters,
+        sort,
+    }) => {
         const url = `${apiUrl}/${resource}`;
-        const current = pagination?.current || 1;
-        const pageSize = pagination?.pageSize || 10;
 
         const { crudFilters, orFilters } = generateFilter(filters);
 
         const query = RequestQueryBuilder.create()
             .setFilter(crudFilters)
-            .setOr(orFilters)
-            .setLimit(pageSize)
-            .setPage(current)
-            .setOffset((current - 1) * pageSize);
+            .setOr(orFilters);
+
+        if (typeof current !== "undefined" && typeof pageSize !== "undefined") {
+            query
+                .setLimit(pageSize)
+                .setPage(current)
+                .setOffset((current - 1) * pageSize);
+        }
 
         const sortBy = generateSort(sort);
         if (sortBy) {

--- a/packages/nestjsx-crud/src/index.ts
+++ b/packages/nestjsx-crud/src/index.ts
@@ -124,14 +124,14 @@ const NestsxCrud = (
 ): DataProvider => ({
     getList: async ({
         resource,
+        hasPagination = true,
         pagination = { current: 1, pageSize: 10 },
         filters,
         sort,
     }) => {
         const url = `${apiUrl}/${resource}`;
 
-        const hasPagination = pagination !== false;
-        const { current = 1, pageSize = 10 } = pagination ? pagination : {};
+        const { current = 1, pageSize = 10 } = pagination ?? {};
 
         const { crudFilters, orFilters } = generateFilter(filters);
 

--- a/packages/nhost/src/index.ts
+++ b/packages/nhost/src/index.ts
@@ -184,12 +184,17 @@ const dataProvider = (client: NhostClient): DataProvider => {
             resource,
             sort,
             filters,
-            pagination: { current, pageSize: limit } = {
+            pagination = {
                 current: 1,
                 pageSize: 10,
             },
             metaData,
         }) => {
+            const hasPagination = pagination !== false;
+            const { current = 1, pageSize: limit = 10 } = pagination
+                ? pagination
+                : {};
+
             const hasuraSorting = generateSorting(sort);
             const hasuraFilters = generateFilters(filters);
 
@@ -205,8 +210,7 @@ const dataProvider = (client: NhostClient): DataProvider => {
                     operation,
                     fields: metaData?.fields,
                     variables: {
-                        ...(typeof current !== "undefined" &&
-                        typeof limit !== "undefined"
+                        ...(hasPagination
                             ? {
                                   limit,
                                   offset: (current - 1) * limit,

--- a/packages/nhost/src/index.ts
+++ b/packages/nhost/src/index.ts
@@ -180,11 +180,16 @@ const dataProvider = (client: NhostClient): DataProvider => {
             };
         },
 
-        getList: async ({ resource, sort, filters, pagination, metaData }) => {
-            const current = pagination?.current ?? 1;
-            const limit = pagination?.pageSize || 10;
-            const offset = (current - 1) * limit;
-
+        getList: async ({
+            resource,
+            sort,
+            filters,
+            pagination: { current, pageSize: limit } = {
+                current: 1,
+                pageSize: 10,
+            },
+            metaData,
+        }) => {
             const hasuraSorting = generateSorting(sort);
             const hasuraFilters = generateFilters(filters);
 
@@ -200,8 +205,13 @@ const dataProvider = (client: NhostClient): DataProvider => {
                     operation,
                     fields: metaData?.fields,
                     variables: {
-                        limit,
-                        offset,
+                        ...(typeof current !== "undefined" &&
+                        typeof limit !== "undefined"
+                            ? {
+                                  limit,
+                                  offset: (current - 1) * limit,
+                              }
+                            : {}),
                         ...(hasuraSorting && {
                             order_by: {
                                 value: hasuraSorting,

--- a/packages/nhost/src/index.ts
+++ b/packages/nhost/src/index.ts
@@ -184,16 +184,14 @@ const dataProvider = (client: NhostClient): DataProvider => {
             resource,
             sort,
             filters,
+            hasPagination = true,
             pagination = {
                 current: 1,
                 pageSize: 10,
             },
             metaData,
         }) => {
-            const hasPagination = pagination !== false;
-            const { current = 1, pageSize: limit = 10 } = pagination
-                ? pagination
-                : {};
+            const { current = 1, pageSize: limit = 10 } = pagination ?? {};
 
             const hasuraSorting = generateSorting(sort);
             const hasuraFilters = generateFilters(filters);

--- a/packages/react-table/src/useTable/index.ts
+++ b/packages/react-table/src/useTable/index.ts
@@ -49,6 +49,7 @@ export function useTable<
 >(
     {
         refineCoreProps: { hasPagination = true, ...refineCoreProps } = {},
+        initialState: reactTableInitialState = {},
         ...rest
     }: UseTableProps<TData, TError>,
     ...plugins: Array<PluginHook<{}>>
@@ -98,6 +99,7 @@ export function useTable<
                     id: filter.field,
                     value: filter.value,
                 })),
+                ...reactTableInitialState,
             },
             pageCount: hasPagination ? pageCount : 1,
             manualPagination: true,

--- a/packages/react-table/src/useTable/index.ts
+++ b/packages/react-table/src/useTable/index.ts
@@ -88,7 +88,6 @@ export function useTable<
                     ? {
                           pageIndex: (current ?? 1) - 1,
                           pageSize: pageSizeCore,
-                          pageCount,
                       }
                     : {}),
                 sortBy: sorter.map((sorting) => ({
@@ -100,6 +99,7 @@ export function useTable<
                     value: filter.value,
                 })),
             },
+            pageCount: hasPagination ? pageCount : 1,
             manualPagination: true,
             manualSortBy: true,
             manualFilters: true,

--- a/packages/react-table/src/useTable/index.ts
+++ b/packages/react-table/src/useTable/index.ts
@@ -6,14 +6,21 @@ import {
     LogicalFilter,
     useTable as useTableCore,
     useTableProps as useTablePropsCore,
-    useTableReturnType,
+    useTableReturnType as useTableReturnTypeCore,
+    useTableNoPaginationReturnType as useTableNoPaginationReturnTypeCore,
 } from "@pankod/refine-core";
 import { useTable as useTableRT, PluginHook, TableOptions } from "react-table";
 
 export type UseTableReturnType<TData extends BaseRecord = BaseRecord> =
     ReturnType<typeof useTableRT> & {
-        refineCore: useTableReturnType<TData>;
+        refineCore: useTableReturnTypeCore<TData>;
     };
+
+export type UseTableNoPaginationReturnType<
+    TData extends BaseRecord = BaseRecord,
+> = ReturnType<typeof useTableRT> & {
+    refineCore: useTableNoPaginationReturnTypeCore<TData>;
+};
 
 export type UseTableProps<
     TData extends BaseRecord = BaseRecord,
@@ -22,15 +29,34 @@ export type UseTableProps<
     refineCoreProps?: useTablePropsCore<TData, TError>;
 } & TableOptions<{}>;
 
-export const useTable = <
+export function useTable<
     TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
 >(
-    { refineCoreProps, ...rest }: UseTableProps<TData, TError>,
+    props: UseTableProps<TData, TError> & { hasPagination?: true },
     ...plugins: Array<PluginHook<{}>>
-): UseTableReturnType<TData> => {
+): UseTableReturnType<TData>;
+export function useTable<
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+>(
+    props: UseTableProps<TData, TError> & { hasPagination: false },
+    ...plugins: Array<PluginHook<{}>>
+): UseTableNoPaginationReturnType<TData>;
+export function useTable<
+    TData extends BaseRecord = BaseRecord,
+    TError extends HttpError = HttpError,
+>(
+    {
+        refineCoreProps: { hasPagination = true, ...refineCoreProps } = {},
+        ...rest
+    }: UseTableProps<TData, TError>,
+    ...plugins: Array<PluginHook<{}>>
+): UseTableReturnType<TData> | UseTableNoPaginationReturnType<TData> {
     const useTableResult = useTableCore<TData, TError>({
         ...refineCoreProps,
+        // @ts-expect-error currently boolean casting is not supported in overloaded types.
+        hasPagination,
     });
 
     const {
@@ -58,8 +84,13 @@ export const useTable = <
         {
             data: memoizedData,
             initialState: {
-                pageIndex: current - 1,
-                pageSize: pageSizeCore,
+                ...(hasPagination
+                    ? {
+                          pageIndex: (current ?? 1) - 1,
+                          pageSize: pageSizeCore,
+                          pageCount,
+                      }
+                    : {}),
                 sortBy: sorter.map((sorting) => ({
                     id: sorting.field,
                     desc: sorting.order === "desc",
@@ -69,7 +100,6 @@ export const useTable = <
                     value: filter.value,
                 })),
             },
-            pageCount: pageCount,
             manualPagination: true,
             manualSortBy: true,
             manualFilters: true,
@@ -79,12 +109,17 @@ export const useTable = <
     );
 
     const { pageIndex, pageSize, sortBy, filters } = reactTableResult.state;
+
     useEffect(() => {
-        setCurrent(pageIndex + 1);
+        if (hasPagination) {
+            setCurrent(pageIndex + 1);
+        }
     }, [pageIndex]);
 
     useEffect(() => {
-        setPageSizeCore(pageSize);
+        if (hasPagination) {
+            setPageSizeCore(pageSize);
+        }
     }, [pageSize]);
 
     useEffect(() => {
@@ -95,7 +130,9 @@ export const useTable = <
             })),
         );
         if (sortBy?.length) {
-            setCurrent(1);
+            if (hasPagination) {
+                setCurrent(1);
+            }
         }
     }, [sortBy]);
 
@@ -134,12 +171,28 @@ export const useTable = <
 
         setFilters(crudFilters);
         if (crudFilters.length > 0) {
-            setCurrent(1);
+            if (hasPagination) {
+                setCurrent(1);
+            }
         }
     }, [filters]);
 
+    if (hasPagination) {
+        return {
+            ...reactTableResult,
+            refineCore: useTableResult,
+        };
+    }
+
     return {
         ...reactTableResult,
-        refineCore: useTableResult,
+        refineCore: {
+            ...(useTableResult as unknown as useTableNoPaginationReturnTypeCore<TData>),
+            current: undefined,
+            setCurrent: undefined,
+            pageSize: undefined,
+            setPageSize: undefined,
+            pageCount: undefined,
+        },
     };
-};
+}

--- a/packages/simple-rest/src/index.ts
+++ b/packages/simple-rest/src/index.ts
@@ -85,14 +85,14 @@ const JsonServer = (
 ): DataProvider => ({
     getList: async ({
         resource,
+        hasPagination = true,
         pagination = { current: 1, pageSize: 10 },
         filters,
         sort,
     }) => {
         const url = `${apiUrl}/${resource}`;
 
-        const hasPagination = pagination !== false;
-        const { current = 1, pageSize = 10 } = pagination ? pagination : {};
+        const { current = 1, pageSize = 10 } = pagination ?? {};
 
         const queryFilters = generateFilter(filters);
 

--- a/packages/simple-rest/src/index.ts
+++ b/packages/simple-rest/src/index.ts
@@ -85,11 +85,14 @@ const JsonServer = (
 ): DataProvider => ({
     getList: async ({
         resource,
-        pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+        pagination = { current: 1, pageSize: 10 },
         filters,
         sort,
     }) => {
         const url = `${apiUrl}/${resource}`;
+
+        const hasPagination = pagination !== false;
+        const { current = 1, pageSize = 10 } = pagination ? pagination : {};
 
         const queryFilters = generateFilter(filters);
 
@@ -98,13 +101,12 @@ const JsonServer = (
             _end?: number;
             _sort?: string;
             _order?: string;
-        } =
-            typeof current !== "undefined" && typeof pageSize !== "undefined"
-                ? {
-                      _start: (current - 1) * pageSize,
-                      _end: current * pageSize,
-                  }
-                : {};
+        } = hasPagination
+            ? {
+                  _start: (current - 1) * pageSize,
+                  _end: current * pageSize,
+              }
+            : {};
 
         const generatedSort = generateSort(sort);
         if (generatedSort) {

--- a/packages/simple-rest/src/index.ts
+++ b/packages/simple-rest/src/index.ts
@@ -83,24 +83,28 @@ const JsonServer = (
     apiUrl: string,
     httpClient: AxiosInstance = axiosInstance,
 ): DataProvider => ({
-    getList: async ({ resource, pagination, filters, sort }) => {
+    getList: async ({
+        resource,
+        pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+        filters,
+        sort,
+    }) => {
         const url = `${apiUrl}/${resource}`;
-
-        // pagination
-        const current = pagination?.current || 1;
-        const pageSize = pagination?.pageSize || 10;
 
         const queryFilters = generateFilter(filters);
 
         const query: {
-            _start: number;
-            _end: number;
+            _start?: number;
+            _end?: number;
             _sort?: string;
             _order?: string;
-        } = {
-            _start: (current - 1) * pageSize,
-            _end: current * pageSize,
-        };
+        } =
+            typeof current !== "undefined" && typeof pageSize !== "undefined"
+                ? {
+                      _start: (current - 1) * pageSize,
+                      _end: current * pageSize,
+                  }
+                : {};
 
         const generatedSort = generateSort(sort);
         if (generatedSort) {

--- a/packages/strapi-graphql/src/index.ts
+++ b/packages/strapi-graphql/src/index.ts
@@ -51,11 +51,14 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
     return {
         getList: async ({
             resource,
-            pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+            pagination = { current: 1, pageSize: 10 },
             sort,
             filters,
             metaData,
         }) => {
+            const hasPagination = pagination !== false;
+            const { current = 1, pageSize = 10 } = pagination ? pagination : {};
+
             const sortBy = genereteSort(sort);
             const filterBy = generateFilter(filters);
 
@@ -80,8 +83,7 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
                         ...metaData?.variables,
                         sort: sortBy,
                         where: { value: filterBy, type: "JSON" },
-                        ...(typeof current !== "undefined" &&
-                        typeof pageSize !== "undefined"
+                        ...(hasPagination
                             ? {
                                   start: (current - 1) * pageSize,
                                   limit: pageSize,

--- a/packages/strapi-graphql/src/index.ts
+++ b/packages/strapi-graphql/src/index.ts
@@ -51,13 +51,13 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
     return {
         getList: async ({
             resource,
+            hasPagination = true,
             pagination = { current: 1, pageSize: 10 },
             sort,
             filters,
             metaData,
         }) => {
-            const hasPagination = pagination !== false;
-            const { current = 1, pageSize = 10 } = pagination ? pagination : {};
+            const { current = 1, pageSize = 10 } = pagination ?? {};
 
             const sortBy = genereteSort(sort);
             const filterBy = generateFilter(filters);

--- a/packages/strapi-graphql/src/index.ts
+++ b/packages/strapi-graphql/src/index.ts
@@ -49,10 +49,13 @@ const generateFilter = (filters?: CrudFilters) => {
 
 const dataProvider = (client: GraphQLClient): DataProvider => {
     return {
-        getList: async ({ resource, pagination, sort, filters, metaData }) => {
-            const current = pagination?.current || 1;
-            const pageSize = pagination?.pageSize || 10;
-
+        getList: async ({
+            resource,
+            pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+            sort,
+            filters,
+            metaData,
+        }) => {
             const sortBy = genereteSort(sort);
             const filterBy = generateFilter(filters);
 
@@ -77,8 +80,13 @@ const dataProvider = (client: GraphQLClient): DataProvider => {
                         ...metaData?.variables,
                         sort: sortBy,
                         where: { value: filterBy, type: "JSON" },
-                        start: (current - 1) * pageSize,
-                        limit: pageSize,
+                        ...(typeof current !== "undefined" &&
+                        typeof pageSize !== "undefined"
+                            ? {
+                                  start: (current - 1) * pageSize,
+                                  limit: pageSize,
+                              }
+                            : {}),
                     },
                     fields: metaData?.fields,
                 },

--- a/packages/strapi-v4/src/dataProvider.ts
+++ b/packages/strapi-v4/src/dataProvider.ts
@@ -136,12 +136,15 @@ export const DataProvider = (
 ): IDataProvider => ({
     getList: async ({
         resource,
-        pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+        pagination = { current: 1, pageSize: 10 },
         filters,
         sort,
         metaData,
     }) => {
         const url = `${apiUrl}/${resource}`;
+
+        const hasPagination = pagination !== false;
+        const { current = 1, pageSize = 10 } = pagination ? pagination : {};
 
         const locale = metaData?.locale;
         const fields = metaData?.fields;
@@ -152,8 +155,7 @@ export const DataProvider = (
         const queryFilters = generateFilter(filters);
 
         const query = {
-            ...(typeof current !== "undefined" &&
-            typeof pageSize !== "undefined"
+            ...(hasPagination
                 ? {
                       "pagination[page]": current,
                       "pagination[pageSize]": pageSize,

--- a/packages/strapi-v4/src/dataProvider.ts
+++ b/packages/strapi-v4/src/dataProvider.ts
@@ -165,6 +165,7 @@ export const DataProvider = (
 
         return {
             data: normalizeData(data),
+            // added to support pagination on client side when using endpoints that provide only data (see https://github.com/pankod/refine/issues/2028)
             total: data.meta?.pagination.total || data.data.length,
         };
     },

--- a/packages/strapi-v4/src/dataProvider.ts
+++ b/packages/strapi-v4/src/dataProvider.ts
@@ -136,6 +136,7 @@ export const DataProvider = (
 ): IDataProvider => ({
     getList: async ({
         resource,
+        hasPagination = true,
         pagination = { current: 1, pageSize: 10 },
         filters,
         sort,
@@ -143,8 +144,7 @@ export const DataProvider = (
     }) => {
         const url = `${apiUrl}/${resource}`;
 
-        const hasPagination = pagination !== false;
-        const { current = 1, pageSize = 10 } = pagination ? pagination : {};
+        const { current = 1, pageSize = 10 } = pagination ?? {};
 
         const locale = metaData?.locale;
         const fields = metaData?.fields;

--- a/packages/strapi-v4/src/dataProvider.ts
+++ b/packages/strapi-v4/src/dataProvider.ts
@@ -165,7 +165,7 @@ export const DataProvider = (
 
         return {
             data: normalizeData(data),
-            total: data.meta.pagination.total,
+            total: data.meta?.pagination.total || data.data.length,
         };
     },
 

--- a/packages/strapi-v4/src/dataProvider.ts
+++ b/packages/strapi-v4/src/dataProvider.ts
@@ -134,11 +134,15 @@ export const DataProvider = (
     apiUrl: string,
     httpClient: AxiosInstance = axiosInstance,
 ): IDataProvider => ({
-    getList: async ({ resource, pagination, filters, sort, metaData }) => {
+    getList: async ({
+        resource,
+        pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+        filters,
+        sort,
+        metaData,
+    }) => {
         const url = `${apiUrl}/${resource}`;
 
-        const current = pagination?.current || 1;
-        const pageSize = pagination?.pageSize || 10;
         const locale = metaData?.locale;
         const fields = metaData?.fields;
         const populate = metaData?.populate;
@@ -148,8 +152,13 @@ export const DataProvider = (
         const queryFilters = generateFilter(filters);
 
         const query = {
-            "pagination[page]": current,
-            "pagination[pageSize]": pageSize,
+            ...(typeof current !== "undefined" &&
+            typeof pageSize !== "undefined"
+                ? {
+                      "pagination[page]": current,
+                      "pagination[pageSize]": pageSize,
+                  }
+                : {}),
             locale,
             publicationState,
             fields,
@@ -166,7 +175,7 @@ export const DataProvider = (
         return {
             data: normalizeData(data),
             // added to support pagination on client side when using endpoints that provide only data (see https://github.com/pankod/refine/issues/2028)
-            total: data.meta?.pagination.total || data.data.length,
+            total: data.meta?.pagination?.total || normalizeData(data)?.length,
         };
     },
 

--- a/packages/strapi/src/dataProvider.ts
+++ b/packages/strapi/src/dataProvider.ts
@@ -79,6 +79,7 @@ export const DataProvider = (
 ): IDataProvider => ({
     getList: async ({
         resource,
+        hasPagination = true,
         pagination = {
             current: 1,
             pageSize: 10,
@@ -88,10 +89,7 @@ export const DataProvider = (
     }) => {
         const url = `${apiUrl}/${resource}`;
 
-        const hasPagination = pagination !== false;
-        const { current = 1, pageSize: _limit = 10 } = pagination
-            ? pagination
-            : {};
+        const { current = 1, pageSize: _limit = 10 } = pagination ?? {};
 
         const _sort = generateSort(sort);
         const queryFilters = generateFilter(filters);

--- a/packages/strapi/src/dataProvider.ts
+++ b/packages/strapi/src/dataProvider.ts
@@ -77,18 +77,27 @@ export const DataProvider = (
     apiUrl: string,
     httpClient: AxiosInstance = axiosInstance,
 ): IDataProvider => ({
-    getList: async ({ resource, pagination, filters, sort }) => {
+    getList: async ({
+        resource,
+        pagination: { current, pageSize: _limit } = {
+            current: 1,
+            pageSize: 10,
+        },
+        filters,
+        sort,
+    }) => {
         const url = `${apiUrl}/${resource}`;
-
-        const current = pagination?.current || 1;
-        const pageSize = pagination?.pageSize || 10;
 
         const _sort = generateSort(sort);
         const queryFilters = generateFilter(filters);
 
         const query = {
-            _start: (current - 1) * pageSize,
-            _limit: pageSize,
+            ...(typeof current !== "undefined" && typeof _limit !== "undefined"
+                ? {
+                      _start: (current - 1) * _limit,
+                      _limit,
+                  }
+                : {}),
             _sort: _sort.length > 0 ? _sort.join(",") : undefined,
         };
 

--- a/packages/strapi/src/dataProvider.ts
+++ b/packages/strapi/src/dataProvider.ts
@@ -79,7 +79,7 @@ export const DataProvider = (
 ): IDataProvider => ({
     getList: async ({
         resource,
-        pagination: { current, pageSize: _limit } = {
+        pagination = {
             current: 1,
             pageSize: 10,
         },
@@ -88,11 +88,16 @@ export const DataProvider = (
     }) => {
         const url = `${apiUrl}/${resource}`;
 
+        const hasPagination = pagination !== false;
+        const { current = 1, pageSize: _limit = 10 } = pagination
+            ? pagination
+            : {};
+
         const _sort = generateSort(sort);
         const queryFilters = generateFilter(filters);
 
         const query = {
-            ...(typeof current !== "undefined" && typeof _limit !== "undefined"
+            ...(hasPagination
                 ? {
                       _start: (current - 1) * _limit,
                       _limit,

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -106,20 +106,20 @@ const dataProvider = (supabaseClient: SupabaseClient): DataProvider => {
     return {
         getList: async ({
             resource,
-            pagination: { current, pageSize } = { current: 1, pageSize: 10 },
+            pagination = { current: 1, pageSize: 10 },
             filters,
             sort,
             metaData,
         }) => {
+            const hasPagination = pagination !== false;
+            const { current = 1, pageSize = 10 } = pagination ? pagination : {};
+
             const query = supabaseClient
                 .from(resource)
                 .select(metaData?.select ?? "*", {
                     count: "exact",
                 });
-            if (
-                typeof current !== "undefined" &&
-                typeof pageSize !== "undefined"
-            ) {
+            if (hasPagination) {
                 query.range((current - 1) * pageSize, current * pageSize - 1);
             }
 
@@ -139,7 +139,7 @@ const dataProvider = (supabaseClient: SupabaseClient): DataProvider => {
 
             return {
                 data: data || [],
-                total: count || data?.length || 0,
+                total: count || 0,
             };
         },
 

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -106,13 +106,13 @@ const dataProvider = (supabaseClient: SupabaseClient): DataProvider => {
     return {
         getList: async ({
             resource,
+            hasPagination = true,
             pagination = { current: 1, pageSize: 10 },
             filters,
             sort,
             metaData,
         }) => {
-            const hasPagination = pagination !== false;
-            const { current = 1, pageSize = 10 } = pagination ? pagination : {};
+            const { current = 1, pageSize = 10 } = pagination ?? {};
 
             const query = supabaseClient
                 .from(resource)


### PR DESCRIPTION
In this PR, 

- Add `hasPagination` to `useTable` and `useDataGrid` hooks.
- Add  `pagination=false` type to `useList`
- Update default value initialization of pagination in dataProviders' `getList` methods.
- Add `hasPagination` to React table's `useTable` hook.

Related to #2067 and #2028
