### PR TITLE
Fix: prevent add permanent filters and permanent sorters in URL via `syncWithLocation`

### DIFF
--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -1,5 +1,7 @@
 import { useState, useEffect } from "react";
 import { QueryObserverResult, UseQueryOptions } from "react-query";
+import differenceWith from "lodash/differenceWith";
+import isEqual from "lodash/isEqual";
 
 import {
     useRouterContext,
@@ -175,8 +177,8 @@ export const useTable = <
                     pageSize,
                     current,
                 },
-                sorter,
-                filters,
+                sorter: differenceWith(sorter, permanentSorter, isEqual),
+                filters: differenceWith(filters, permanentFilter, isEqual),
             });
 
             // Careful! This triggers render

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -13,6 +13,8 @@ import {
     GridSortModel,
 } from "@mui/x-data-grid";
 import { useTheme, darken } from "@mui/material";
+import differenceWith from "lodash/differenceWith";
+import isEqual from "lodash/isEqual";
 
 import {
     transformCrudSortingToSortModel,
@@ -166,10 +168,15 @@ export const useDataGrid = <
             pageSize: pageSize,
             onPageSizeChange: handlePageSizeChange,
             sortingMode: "server",
-            sortModel: transformCrudSortingToSortModel(sorter),
+            sortModel: transformCrudSortingToSortModel(
+                differenceWith(sorter, permanentSorter ?? [], isEqual),
+            ),
             onSortModelChange: handleSortModelChange,
             filterMode: "server",
-            filterModel: transformCrudFiltersToFilterModel(filters, columns),
+            filterModel: transformCrudFiltersToFilterModel(
+                differenceWith(filters, permanentFilter ?? [], isEqual),
+                columns,
+            ),
             onFilterModelChange: handleFilterModelChange,
             sx: {
                 border: "none",


### PR DESCRIPTION
Prevented add permanent filters and permanent sorters in URL via `syncWithLocation`