### PR TITLE
fix: material UI exported types

### DIFF
--- a/.changeset/dry-weeks-trade.md
+++ b/.changeset/dry-weeks-trade.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": patch
+---
+
+Fixed missing imports (`DefaultColorScheme`, `ExtendedColorScheme` and `ThemeInput`) in `@mui/material/styles` in `@pankod/refine-mui` package.

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -42,7 +42,7 @@
         "@emotion/styled": "^11.8.1",
         "@mui/icons-material": "^5.8.3",
         "@mui/lab": "^5.0.0-alpha.85",
-        "@mui/material": "^5.8.3",
+        "@mui/material": "^5.8.6",
         "@mui/x-data-grid": "^5.12.1",
         "@pankod/refine-core": "^3.34.0",
         "@pankod/refine-react-hook-form": "^3.27.1",

--- a/packages/mui/src/index.tsx
+++ b/packages/mui/src/index.tsx
@@ -56,13 +56,13 @@ export type {
     ComponentsPropsList,
     ComponentsVariants,
     CreateMUIStyled,
-    DefaultColorScheme,
+    // DefaultColorScheme,
     DeprecatedThemeOptions,
     Direction,
     Duration,
     Easing,
     Experimental_CssVarsProvider,
-    ExtendedColorScheme,
+    // ExtendedColorScheme,
     Interpolation,
     Opacity,
     Palette,
@@ -74,7 +74,6 @@ export type {
     SupportedColorScheme,
     SxProps,
     Theme,
-    ThemeInput,
     ThemeOptions,
     ThemeProvider,
     ThemeWithProps,
@@ -89,6 +88,14 @@ export type {
     TypographyVariants,
     TypographyVariantsOptions,
 } from "@mui/material/styles";
+
+/** @deprecated not exists anymore - this type exists as a fallback for existing usages */
+export type ThemeInput = any;
+
+export {
+    DefaultColorScheme,
+    ExtendedColorScheme,
+} from "@mui/material/styles/experimental_extendTheme";
 
 export * from "@mui/material/utils";
 

--- a/packages/mui/src/index.tsx
+++ b/packages/mui/src/index.tsx
@@ -56,13 +56,11 @@ export type {
     ComponentsPropsList,
     ComponentsVariants,
     CreateMUIStyled,
-    // DefaultColorScheme,
     DeprecatedThemeOptions,
     Direction,
     Duration,
     Easing,
     Experimental_CssVarsProvider,
-    // ExtendedColorScheme,
     Interpolation,
     Opacity,
     Palette,
@@ -92,7 +90,7 @@ export type {
 /** @deprecated not exists anymore - this type exists as a fallback for existing usages */
 export type ThemeInput = any;
 
-export {
+export type {
     DefaultColorScheme,
     ExtendedColorScheme,
 } from "@mui/material/styles/experimental_extendTheme";


### PR DESCRIPTION
Updated missing exports from `@mui/material/styles` and replaced one deprecated one `ThemeInput` in `@pankod/refine-mui`