### PR TITLE
feat: add breadcrumb actions translate support

### DIFF
--- a/.changeset/serious-papayas-share.md
+++ b/.changeset/serious-papayas-share.md
@@ -2,4 +2,45 @@
 "@pankod/refine-core": patch
 ---
 
-Add translate support for `CRUD` components (`<List>`, `<Create>`, `<Edit>`, `<Show>`) actions in [`useBreadcrumb`](https://refine.dev/docs/core/hooks/useBreadcrumb/) hook.
+Added `actions` translate support for CRUD operations (`list`,`create`,`edit`,`show`) in the `useBreadcrumb` [`useBreadcrumb`](https://refine.dev/docs/core/hooks/useBreadcrumb/#translate) hook.
+
+#️⃣ First, We need to add the `actions` key to the translation file.
+
+```json
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
+```
+
+#️⃣ If you don't provide the `actions` key, `useBreadcrumb` will try to find the `buttons` key in the `translate` file for backward compatibility.
+
+```json
+    "buttons": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
+```
+
+🎉 You can check the code part of this pull request to see how it works [here👇🏼](https://github.com/pankod/refine/pull/2069)
+
+```tsx
+const key = `actions.${action}`;
+const actionLabel = translate(key);
+if (actionLabel === key) {
+    console.warn(
+        `Breadcrumb missing translate key for the "${action}" action. Please add "actions.${action}" key to your translation file. For more information, see https://refine.dev/docs/core/hooks/useBreadcrumb/#translate`,
+    );
+    breadcrumbs.push({
+        label: translate(`buttons.${action}`, humanizeString(action)),
+    });
+} else {
+    breadcrumbs.push({
+        label: translate(key, humanizeString(action)),
+    });
+}
+```

--- a/.changeset/serious-papayas-share.md
+++ b/.changeset/serious-papayas-share.md
@@ -2,7 +2,7 @@
 "@pankod/refine-core": patch
 ---
 
-Added `actions` translate support for CRUD operations (`list`,`create`,`edit`,`show`) in the `useBreadcrumb` [`useBreadcrumb`](https://refine.dev/docs/core/hooks/useBreadcrumb/#translate) hook.
+Added `actions` translate support for CRUD operations (`list`,`create`,`edit`,`show`) in the `useBreadcrumb` [`useBreadcrumb`](https://refine.dev/docs/core/hooks/useBreadcrumb/#i18n-support) hook.
 
 #️⃣ First, We need to add the `actions` key to the translation file.
 
@@ -15,7 +15,7 @@ Added `actions` translate support for CRUD operations (`list`,`create`,`edit`,`s
     },
 ```
 
-#️⃣ If you don't provide the `actions` key, `useBreadcrumb` will try to find the `buttons` key in the `translate` file for backward compatibility.
+#️⃣ If you don't provide the `actions` key, `useBreadcrumb` will try to find the `buttons` key in the `translation` file for backward compatibility.
 
 ```json
     "buttons": {
@@ -33,7 +33,7 @@ const key = `actions.${action}`;
 const actionLabel = translate(key);
 if (actionLabel === key) {
     console.warn(
-        `Breadcrumb missing translate key for the "${action}" action. Please add "actions.${action}" key to your translation file. For more information, see https://refine.dev/docs/core/hooks/useBreadcrumb/#translate`,
+        `Breadcrumb missing translate key for the "${action}" action. Please add "actions.${action}" key to your translation file. For more information, see https://refine.dev/docs/core/hooks/useBreadcrumb/#i18n-support`,
     );
     breadcrumbs.push({
         label: translate(`buttons.${action}`, humanizeString(action)),

--- a/.changeset/serious-papayas-share.md
+++ b/.changeset/serious-papayas-share.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Add translate support for `CRUD` components (`<List>`, `<Create>`, `<Edit>`, `<Show>`) actions in [`useBreadcrumb`](https://refine.dev/docs/core/hooks/useBreadcrumb/) hook.

--- a/documentation/docs/core/hooks/useBreadcrumb.md
+++ b/documentation/docs/core/hooks/useBreadcrumb.md
@@ -54,16 +54,6 @@ The `breadcrumbs` are created with your resource definitions. For example, if yo
 ];
 ```
 
-:::info
-If label is not provided in your `posts` resource `useBreadcrumb` uses the [`useTranslate`](/core/hooks/translate/useTranslate.md) hook to translate the names.
-
-For Crud operations (`list`,`create`,`edit`,`show`) the `useBreadcrumb` uses:
-
-1. The `actions` key to translate key `` translate(`actions.create`) ``
-2. If there are no actions key the `buttons` key uses to translate key `` translate(`buttons.create`) ``
-
-:::
-
 -   On the `list` page of the `posts` resource, the breadcrumbs look like this:
 
     ```tsx
@@ -91,10 +81,6 @@ For Crud operations (`list`,`create`,`edit`,`show`) the `useBreadcrumb` uses:
 
 :::info
 If resource has no `icon` property, the `icon` property of the breadcrumbs is `undefined`. Likewise, if the resource's list page is not found, the `href` property of the breadcrumbs is `undefined`.
-:::
-
-:::tip
-If resource definition has `label` property, `useBreadcrumbs` uses the `label` property. Otherwise, the `name` property of the resource is used. Likewise, if resource definition has `route` property, `useBreadcrumbs` uses the `route` property. Otherwise, the `name` property of the resource is used.
 :::
 
 If you have a nested resource definition as below:
@@ -137,6 +123,19 @@ If you have a nested resource definition as below:
         { label: "Create" },
     ];
     ```
+
+### Translate
+
+If resource definition has `label` property, `useBreadcrumbs` uses the `label` property. Otherwise, the `name` property of the resource is used. Likewise, if resource definition has `route` property, `useBreadcrumbs` uses the `route` property. Otherwise, the `name` property of the resource is used.
+
+:::info
+If label is not provided in your `posts` resource `useBreadcrumb` uses the [`useTranslate`](/core/hooks/translate/useTranslate.md) hook to translate the names.
+
+For CRUD operations (`list`,`create`,`edit`,`show`) the `useBreadcrumb` uses the `actions` key to translate key `` translate(`actions.${action}`) ``.
+
+For example; `create` action should look like : `` translate(`actions.create`) ``
+
+:::
 
 ## API Reference
 

--- a/documentation/docs/core/hooks/useBreadcrumb.md
+++ b/documentation/docs/core/hooks/useBreadcrumb.md
@@ -15,6 +15,12 @@ Congratulations [@salihozdemir](https://github.com/salihozdemir)! It was great s
 -   `href`: the route of the resource.
 -   `icon`: the icon of the resource.
 
+:::tip
+You can refer to the [source-code][source-code] of the `useBreadcrumb` hook to see how it is built.
+:::
+
+## Basic Usage
+
 ```tsx
 import React from "react";
 import { useBreadcrumb } from "@pankod/refine-core";
@@ -47,6 +53,16 @@ The `breadcrumbs` are created with your resource definitions. For example, if yo
     },
 ];
 ```
+
+:::info
+If label is not provided in your `posts` resource `useBreadcrumb` uses the [`useTranslate`](/core/hooks/translate/useTranslate.md) hook to translate the names.
+
+For Crud operations (`list`,`create`,`edit`,`show`) the `useBreadcrumb` uses:
+
+1. The `actions` key to translate key `` translate(`actions.create`) ``
+2. The `buttons` key to translate key `` translate(`buttons.create`) ``
+
+:::
 
 -   On the `list` page of the `posts` resource, the breadcrumbs look like this:
 
@@ -139,3 +155,5 @@ If you have a nested resource definition as below:
 >     icon?: React.ReactNode;
 > };
 > ```
+>
+> [source-code]: https://github.com/pankod/refine/blob/master/packages/core/src/hooks/breadcrumb/index.ts

--- a/documentation/docs/core/hooks/useBreadcrumb.md
+++ b/documentation/docs/core/hooks/useBreadcrumb.md
@@ -124,7 +124,7 @@ If you have a nested resource definition as below:
     ];
     ```
 
-### Translate
+### i18n support
 
 If resource definition has `label` property, `useBreadcrumbs` uses the `label` property. Otherwise, the `name` property of the resource is used. Likewise, if resource definition has `route` property, `useBreadcrumbs` uses the `route` property. Otherwise, the `name` property of the resource is used.
 

--- a/documentation/docs/core/hooks/useBreadcrumb.md
+++ b/documentation/docs/core/hooks/useBreadcrumb.md
@@ -60,7 +60,7 @@ If label is not provided in your `posts` resource `useBreadcrumb` uses the [`use
 For Crud operations (`list`,`create`,`edit`,`show`) the `useBreadcrumb` uses:
 
 1. The `actions` key to translate key `` translate(`actions.create`) ``
-2. The `buttons` key to translate key `` translate(`buttons.create`) ``
+2. If there are no actions key the `buttons` key uses to translate key `` translate(`buttons.create`) ``
 
 :::
 

--- a/documentation/docs/core/providers/i18n-provider.md
+++ b/documentation/docs/core/providers/i18n-provider.md
@@ -56,7 +56,7 @@ We recommend [**superplate**][superplate] to initialize your refine projects. It
 :::
 
 :::caution
-This example is for SPA react apps, for Next.js [refer to i18n Nextjs example ][i18nNextjs]
+This example is for SPA react apps, for Next.js [refer to i18n Nextjs example ][i18nnextjs]
 :::
 
 Let's add multi-language support using the `react-i18next` framework. At the end of our example, our application will support both German and English.
@@ -110,11 +110,11 @@ import "./i18n";
 
 ReactDOM.render(
     <React.StrictMode>
-// highlight-start
+        // highlight-start
         <React.Suspense fallback="loading">
             <App />
         </React.Suspense>
-// highlight-end
+        // highlight-end
     </React.StrictMode>,
     document.getElementById("root"),
 );
@@ -138,7 +138,7 @@ import { useTranslation } from "react-i18next";
 import { PostList } from "pages/posts";
 
 const App: React.FC = () => {
-// highlight-start
+    // highlight-start
     const { t, i18n } = useTranslation();
 
     const i18nProvider = {
@@ -146,13 +146,13 @@ const App: React.FC = () => {
         changeLocale: (lang: string) => i18n.changeLanguage(lang),
         getLocale: () => i18n.language,
     };
-// highlight-end
+    // highlight-end
 
     return (
         <Refine
             routerProvider={routerProvider}
             dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
-// highlight-next-line
+            // highlight-next-line
             i18nProvider={i18nProvider}
             resources={[{ name: "posts", list: PostList }]}
         />
@@ -186,6 +186,12 @@ Before we get started, let's look at the translations that refine uses in compon
             "backHome": "Back Home"
         }
     },
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
     "buttons": {
         "create": "Create",
         "save": "Save",
@@ -201,7 +207,7 @@ Before we get started, let's look at the translations that refine uses in compon
         "undo": "Undo",
         "import": "Import",
         "clone": "Clone",
-        "notAccessTitle": "You don't have permission to access",
+        "notAccessTitle": "You don't have permission to access"
     },
     "warnWhenUnsavedChanges": "Are you sure you want to leave? You have unsaved changes.",
     "notifications": {
@@ -267,6 +273,12 @@ values={[{ label: "English", value: "en" }, { label: "German", value: "de" }]}>
             "backHome": "Back Home"
         }
     },
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
     "buttons": {
         "create": "Create",
         "save": "Save",
@@ -282,7 +294,7 @@ values={[{ label: "English", value: "en" }, { label: "German", value: "de" }]}>
         "undo": "Undo",
         "import": "Import",
         "clone": "Clone",
-        "notAccessTitle": "You don't have permission to access",
+        "notAccessTitle": "You don't have permission to access"
     },
     "warnWhenUnsavedChanges": "Are you sure you want to leave? You have unsaved changes.",
     "notifications": {
@@ -355,6 +367,12 @@ values={[{ label: "English", value: "en" }, { label: "German", value: "de" }]}>
             "backHome": "Zurück"
         }
     },
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
     "buttons": {
         "create": "Erstellen",
         "save": "Speichern",
@@ -370,7 +388,7 @@ values={[{ label: "English", value: "en" }, { label: "German", value: "de" }]}>
         "undo": "Undo",
         "import": "Importieren",
         "clone": "Klon",
-        "notAccessTitle": "Sie haben keine zugriffsberechtigung",
+        "notAccessTitle": "Sie haben keine zugriffsberechtigung"
     },
     "warnWhenUnsavedChanges": "Nicht gespeicherte Änderungen werden nicht übernommen.",
     "notifications": {
@@ -532,7 +550,7 @@ const App: React.FC = () => {
             routerProvider={routerProvider}
             dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
             i18nProvider={i18nProvider}
-// highlight-next-line
+            // highlight-next-line
             Header={Header}
             resources={[{ name: "posts", list: PostList }]}
         />
@@ -545,11 +563,11 @@ const App: React.FC = () => {
 Finally, we will create the `<PostList>` page and then we will translate texts using `useTranslate`.
 
 ```tsx title="src/App.tsx"
-import { 
+import {
     // highlight-next-line
     useTranslate,
     useMany,
- } from "@pankod/refine-core";
+} from "@pankod/refine-core";
 import {
     List,
     Table,
@@ -563,7 +581,7 @@ import {
 import { IPost, ICategory } from "interfaces";
 
 export const PostList: React.FC = () => {
-// highlight-next-line
+    // highlight-next-line
     const translate = useTranslate();
     const { tableProps } = useTable<IPost>();
 
@@ -583,12 +601,12 @@ export const PostList: React.FC = () => {
                 <Table.Column dataIndex="id" title="ID" />
                 <Table.Column
                     dataIndex="title"
-// highlight-next-line
+                    // highlight-next-line
                     title={translate("posts.fields.title")}
                 />
                 <Table.Column
                     dataIndex={["category", "id"]}
-// highlight-next-line
+                    // highlight-next-line
                     title={translate("posts.fields.category")}
                     render={(value) => {
                         if (isLoading) {
@@ -606,7 +624,7 @@ export const PostList: React.FC = () => {
                     }}
                 />
                 <Table.Column<IPost>
-// highlight-next-line
+                    // highlight-next-line
                     title={translate("table.actions")}
                     dataIndex="actions"
                     key="actions"
@@ -658,5 +676,5 @@ export interface IPost {
      sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
    ></iframe>
 
-[i18nNextjs]: /examples/i18n/i18n-nextjs.md
+[i18nnextjs]: /examples/i18n/i18n-nextjs.md
 [superplate]: https://github.com/pankod/superplate

--- a/examples/fineFoods/admin/antd/public/locales/de.json
+++ b/examples/fineFoods/admin/antd/public/locales/de.json
@@ -1,339 +1,345 @@
 {
-  "pages": {
-    "login": {
-      "signin": "Einloggen",
-      "signup": "Anmelden",
-      "email": "Benutzername",
-      "password": "Passwort",
-      "remember": "Login speichern",
-      "forgotPassword": "Passwort Vergessen?",
-      "noAccount": "Noch kein Benutzerkonto?",
-      "message": "Einloggen"
+    "pages": {
+        "login": {
+            "signin": "Einloggen",
+            "signup": "Anmelden",
+            "email": "Benutzername",
+            "password": "Passwort",
+            "remember": "Login speichern",
+            "forgotPassword": "Passwort Vergessen?",
+            "noAccount": "Noch kein Benutzerkonto?",
+            "message": "Einloggen"
+        },
+        "error": {
+            "info": "Sie haben vergessen, {{action}} component zu {{resource}} hinzufügen.",
+            "404": "Leider existiert diese Seite nicht.",
+            "resource404": "Haben Sie die {{resource}} resource erstellt?",
+            "backHome": "Zurück"
+        }
     },
-    "error": {
-      "info": "Sie haben vergessen, {{action}} component zu {{resource}} hinzufügen.",
-      "404": "Leider existiert diese Seite nicht.",
-      "resource404": "Haben Sie die {{resource}} resource erstellt?",
-      "backHome": "Zurück"
-    }
-  },
-  "buttons": {
-  "create": "Erstellen",
-  "save": "Speichern",
-  "logout": "Abmelden",
-  "delete": "Löschen",
-  "edit": "Bearbeiten",
-  "cancel": "Abbrechen",
-  "confirm": "Sicher?",
-  "filter": "Filter",
-  "clear": "Löschen",
-  "refresh": "Erneuern",
-  "show": "Zeigen",
-  "undo": "Undo",
-  "import": "Importieren",
-    "export": "Exportieren",
-    "clone": "Klonen",
-    "accept": "Akzeptieren",
-    "acceptAll": "Alles akzeptieren",
-    "reject": "Abweisen",
-    "rejectAll": "Alles abweisen",
-    "nextStep": "Vorwärts",
-    "previousStep": "Zurück"
-  },
-  "loading": "Wird geladen",
-  "tags": {
-    "clone": "Klonen"
-  },
-  "table": {
-    "actions": "Aktionen"
-  },
-  "search": {
-    "placeholder": "Suchen mit Geschäfts-ID, E-mail oder Stichwort",
-    "more": "Noch mehr"
-  },
-  "status": {
-    "enable": "Aktiv",
-    "disable": "Passiv"
-  },
-  "warnWhenUnsavedChanges": "Nicht gespeicherte Änderungen werden nicht übernommen.",
-  "notifications": {
-      "success": "Erfolg",
-      "error": "Fehler (status code: {{statusCode}})",
-      "undoable": "Sie haben {{seconds}} Sekunden Zeit für Undo.",
-      "createSuccess": "{{resource}} erfolgreich erstellt.",
-      "createError": "Fehler beim Erstellen {{resource}} (status code: {{statusCode}})",
-      "deleteSuccess": "{{resource}} erfolgreich gelöscht.",
-      "deleteError": "Fehler beim Löschen {{resource}} (status code: {{statusCode}})",
-      "editSuccess": "{{resource}} erfolgreich bearbeitet.",
-    "importProgress": "{{processed}}/{{total}} importiert"
-  },
-  "categories": {
-    "categories": "Kategorien",
-    "titles": {
-      "list": "Kategorien"
-    },
-    "fields": {
-      "id": "ID",
-      "title": "Titel",
-      "isActive": "Aktiv"
-    }
-  },
-  "couriers": {
-    "couriers": "Kuriere",
-    "titles": {
-      "create": "Kurier erstellen",
-      "list": "Kuriere",
-      "edit": "Kurier bearbeiten"
-    },
-    "fields": {
-      "id": "ID",
-      "avatar": {
-        "label": "Avatar",
-        "description": "Ein Foto hochladen."
-      },
-      "name": "Vorname",
-      "surname": "Nachname",
-      "gender": {
-        "label": "Geschlecht",
-        "male": "Mann",
-        "female": "Frau"
-      },
-      "gsm": "Gsm",
-      "createdAt": "Erstellt am",
-      "isActive": "Aktiv",
-      "images": {
-        "label": "Foto",
-        "description": "Ein Foto hochladen.",
-        "validation": "Fotoauflösung: 480x480px"
-      },
-      "store": "Geschäft",
-      "vehicle": "Fahrzeug",
-      "accountNumber": "Kontonummer",
-      "address": "Adresse"
-    },
-    "steps": {
-      "content": "Inhalt",
-      "relations": "Beziehungen"
-    }
-  },
-  "dashboard": {
-    "title": "Panel",
-    "deliveryMap": {
-      "title": "Lieferkarte"
-    },
-    "orders": {
-      "title": "Bestellungen"
-    },
-    "totalSales": {
-      "title": "Gesamtumsatz"
-    },
-    "dailyRevenue": {
-      "title": "Tagesumsatz"
-    },
-    "dailyOrders": {
-      "title": "Tägliche Bestellungen"
-    },
-    "newCustomers": {
-      "title": "Neue Kunden"
-    },
-    "timeline": {
-      "title": "Aktualisierung",
-      "orderStatuses": {
-        "pending": "Wird vorbereiten.",
-        "ready": "Bereit",
-        "on the way": "Unterwegs",
-        "delivered": "Geliefert",
-        "cancelled": "Abgesagt"
-      }
-    },
-    "recentOrders": {
-      "title": "Letzte Bestellungen"
-    },
-    "trendingMenus": {
-      "title": "Täglich beliebte Menüs"
-    }
-  },
-  "enum": {
-    "orderStatuses": {
-      "pending": "Wird vorbereiten.",
-      "ready": "Bereit",
-      "on the way": "Unterwegs",
-      "delivered": "Geliefert",
-      "cancelled": "Abgesagt"
-    }
-  },
-  "orders": {
-    "orders": "Bestellungen",
-    "titles": {
-      "list": "Bestellungen",
-      "show": "Bestellung Info"
-    },
-    "fields": {
-      "orderNumber": "Bestellungsnummer",
-      "orderID": "Bestellung ID",
-      "status": "Bestellung Status",
-      "store": "Geschäfts",
-      "user": "Benutzer",
-      "products": "Produkte",
-      "createdAt": "Erstellt am",
-      "amount": "Betrag",
-      "itemsAmount": "{{amount}} Produkt"
-    },
-    "filter": {
-      "title": "Filter",
-      "search": {
-        "label": "Suche",
-        "placeholder": "Suchen mit Geschäfts-ID, E-mail oder Stichwort"
-      },
-      "status": {
-        "label": "Bestellung Status",
-        "placeholder": "Bestellung Status"
-      },
-      "store": {
-        "label": "Geschäft",
-        "placeholder": "Geschäft Suchen"
-      },
-      "user": {
-        "label": "Benutzer",
-        "placeholder": "Benutzer Suchen"
-      },
-      "createdAt": {
-        "label": "Erstellt am"
-      },
-      "submit": "Filter"
-    },
-    "courier": {
-      "deliveryTime": "Lieferzeit",
-      "phone": "Telefon"
-    },
-    "deliverables": {
-      "deliverables": "Wird geliefert",
-      "fields": {
-        "items": "Produkte",
-        "quantity": "Betrag",
-        "price": "Preis",
-        "total": "Gesamtpreis"
-      },
-      "mainTotal": "Gesamtpreis"
-    }
-  },
-  "products": {
-    "products": "Produkte",
-    "titles": {
-      "list": "Produkte",
-      "create": "Produkt erstellen",
-      "edit": "Prod Düzenle"
-    },
-    "fields": {
-      "id": "ID",
-      "name": "Titel",
-      "description": "Bezeichnung",
-      "isActive": "Aktiv",
-      "price": "Price",
-      "category": "Kategorie",
-      "images": {
-        "label": "Fotos",
-        "description": "Ein Foto hochladen.",
-        "validation": "Fotoauflösung: 1080x1080px."
-      },
-      "createdAt": "Erstellt am"
-    }
-  },
-  "reviews": {
-    "reviews": "Kommentare",
-    "titles": {
-      "list": "Kommentare"
-    },
-    "fields": {
-      "user": "Benutzer",
-      "orderId": "Bestellungsnummer",
-      "review": "Kommentar",
-      "rating": "Bewertung"
-    }
-  },
-  "stores": {
-    "stores": "Geschäfte",
-    "titles": {
-      "create": "Geschäft Erstellen",
-      "edit": "Geschäfts Bearbeiten",
-      "list": "Geschäfte",
-      "show": "Geschäft Zeigen"
-    },
-    "fields": {
-      "id": "Geschäfts-ID",
-      "title": "Titel",
-      "isActive": "Aktiv",
-      "createdAt": "Erstellt am",
-      "address": "Adresse",
-      "email": "Email",
-      "gsm": "Telefon"
+    "actions": {
+        "list": "Aufführen",
+        "create": "Erstellen",
+        "edit": "Bearbeiten",
+        "show": "Zeigen"
     },
     "buttons": {
-      "editProducts": "Produkte bearbeiten",
-      "addProduct": "Produkt erstellen",
-      "outOfStock": "Kein Bestand",
-      "edit": "Produkt bearbeiten"
+        "create": "Erstellen",
+        "save": "Speichern",
+        "logout": "Abmelden",
+        "delete": "Löschen",
+        "edit": "Bearbeiten",
+        "cancel": "Abbrechen",
+        "confirm": "Sicher?",
+        "filter": "Filter",
+        "clear": "Löschen",
+        "refresh": "Erneuern",
+        "show": "Zeigen",
+        "undo": "Undo",
+        "import": "Importieren",
+        "export": "Exportieren",
+        "clone": "Klonen",
+        "accept": "Akzeptieren",
+        "acceptAll": "Alles akzeptieren",
+        "reject": "Abweisen",
+        "rejectAll": "Alles abweisen",
+        "nextStep": "Vorwärts",
+        "previousStep": "Zurück"
     },
-    "selectLocation": "Wähle einen Ort",
-    "storeProducts": "Produkte des Geschäftes",
-    "tagFilterDescription": "Filter mit Etiketten",
-    "all": "Alles",
-    "productSearch": "Produkt suchen"
-  },
-  "users": {
-    "users": "Benutzern",
-    "titles": {
-      "edit": "Benutzer bearbeiten",
-      "list": "Benutzern",
-      "show": "Benutzer Information"
+    "loading": "Wird geladen",
+    "tags": {
+        "clone": "Klonen"
     },
-    "fields": {
-      "id": "ID",
-      "avatar": {
-        "label": "Avatar",
-        "description": "Ein Foto hochladen"
-      },
-      "firstName": "Vorname",
-      "lastName": "Nachname",
-      "gender": {
-        "label": "Geschlecht",
-        "Male": "Mann",
-        "Female": "Frau"
-      },
-      "gsm": "GSM",
-      "createdAt": "Erstellt am",
-      "isActive": {
-        "label": "Aktiv",
-        "true": "Ja",
-        "false": "Nein"
-      }
+    "table": {
+        "actions": "Aktionen"
     },
-    "filter": {
-      "title": "Filter",
-      "search": {
-        "label": "Suche",
-        "placeholder": "Vorname, Nachname, GSM..."
-      },
-      "createdAt": {
-        "label": "Erstellt am"
-      },
-      "gender": {
-        "label": "Geschlecht",
-        "placeholder": "Geschlecht",
-        "male": "Mann",
-        "female": "Frau"
-      },
-      "isActive": {
-        "label": "Ist aktiv?",
-        "placeholder": "Ist aktiv?",
-        "true": "Ja",
-        "false": "Nein"
-      },
-      "submit": "Filter"
+    "search": {
+        "placeholder": "Suchen mit Geschäfts-ID, E-mail oder Stichwort",
+        "more": "Noch mehr"
     },
-    "addresses": {
-      "addresses": "Adressen",
-      "address": "Adresse"
+    "status": {
+        "enable": "Aktiv",
+        "disable": "Passiv"
+    },
+    "warnWhenUnsavedChanges": "Nicht gespeicherte Änderungen werden nicht übernommen.",
+    "notifications": {
+        "success": "Erfolg",
+        "error": "Fehler (status code: {{statusCode}})",
+        "undoable": "Sie haben {{seconds}} Sekunden Zeit für Undo.",
+        "createSuccess": "{{resource}} erfolgreich erstellt.",
+        "createError": "Fehler beim Erstellen {{resource}} (status code: {{statusCode}})",
+        "deleteSuccess": "{{resource}} erfolgreich gelöscht.",
+        "deleteError": "Fehler beim Löschen {{resource}} (status code: {{statusCode}})",
+        "editSuccess": "{{resource}} erfolgreich bearbeitet.",
+        "importProgress": "{{processed}}/{{total}} importiert"
+    },
+    "categories": {
+        "categories": "Kategorien",
+        "titles": {
+            "list": "Kategorien"
+        },
+        "fields": {
+            "id": "ID",
+            "title": "Titel",
+            "isActive": "Aktiv"
+        }
+    },
+    "couriers": {
+        "couriers": "Kuriere",
+        "titles": {
+            "create": "Kurier erstellen",
+            "list": "Kuriere",
+            "edit": "Kurier bearbeiten"
+        },
+        "fields": {
+            "id": "ID",
+            "avatar": {
+                "label": "Avatar",
+                "description": "Ein Foto hochladen."
+            },
+            "name": "Vorname",
+            "surname": "Nachname",
+            "gender": {
+                "label": "Geschlecht",
+                "male": "Mann",
+                "female": "Frau"
+            },
+            "gsm": "Gsm",
+            "createdAt": "Erstellt am",
+            "isActive": "Aktiv",
+            "images": {
+                "label": "Foto",
+                "description": "Ein Foto hochladen.",
+                "validation": "Fotoauflösung: 480x480px"
+            },
+            "store": "Geschäft",
+            "vehicle": "Fahrzeug",
+            "accountNumber": "Kontonummer",
+            "address": "Adresse"
+        },
+        "steps": {
+            "content": "Inhalt",
+            "relations": "Beziehungen"
+        }
+    },
+    "dashboard": {
+        "title": "Panel",
+        "deliveryMap": {
+            "title": "Lieferkarte"
+        },
+        "orders": {
+            "title": "Bestellungen"
+        },
+        "totalSales": {
+            "title": "Gesamtumsatz"
+        },
+        "dailyRevenue": {
+            "title": "Tagesumsatz"
+        },
+        "dailyOrders": {
+            "title": "Tägliche Bestellungen"
+        },
+        "newCustomers": {
+            "title": "Neue Kunden"
+        },
+        "timeline": {
+            "title": "Aktualisierung",
+            "orderStatuses": {
+                "pending": "Wird vorbereiten.",
+                "ready": "Bereit",
+                "on the way": "Unterwegs",
+                "delivered": "Geliefert",
+                "cancelled": "Abgesagt"
+            }
+        },
+        "recentOrders": {
+            "title": "Letzte Bestellungen"
+        },
+        "trendingMenus": {
+            "title": "Täglich beliebte Menüs"
+        }
+    },
+    "enum": {
+        "orderStatuses": {
+            "pending": "Wird vorbereiten.",
+            "ready": "Bereit",
+            "on the way": "Unterwegs",
+            "delivered": "Geliefert",
+            "cancelled": "Abgesagt"
+        }
+    },
+    "orders": {
+        "orders": "Bestellungen",
+        "titles": {
+            "list": "Bestellungen",
+            "show": "Bestellung Info"
+        },
+        "fields": {
+            "orderNumber": "Bestellungsnummer",
+            "orderID": "Bestellung ID",
+            "status": "Bestellung Status",
+            "store": "Geschäfts",
+            "user": "Benutzer",
+            "products": "Produkte",
+            "createdAt": "Erstellt am",
+            "amount": "Betrag",
+            "itemsAmount": "{{amount}} Produkt"
+        },
+        "filter": {
+            "title": "Filter",
+            "search": {
+                "label": "Suche",
+                "placeholder": "Suchen mit Geschäfts-ID, E-mail oder Stichwort"
+            },
+            "status": {
+                "label": "Bestellung Status",
+                "placeholder": "Bestellung Status"
+            },
+            "store": {
+                "label": "Geschäft",
+                "placeholder": "Geschäft Suchen"
+            },
+            "user": {
+                "label": "Benutzer",
+                "placeholder": "Benutzer Suchen"
+            },
+            "createdAt": {
+                "label": "Erstellt am"
+            },
+            "submit": "Filter"
+        },
+        "courier": {
+            "deliveryTime": "Lieferzeit",
+            "phone": "Telefon"
+        },
+        "deliverables": {
+            "deliverables": "Wird geliefert",
+            "fields": {
+                "items": "Produkte",
+                "quantity": "Betrag",
+                "price": "Preis",
+                "total": "Gesamtpreis"
+            },
+            "mainTotal": "Gesamtpreis"
+        }
+    },
+    "products": {
+        "products": "Produkte",
+        "titles": {
+            "list": "Produkte",
+            "create": "Produkt erstellen",
+            "edit": "Prod Düzenle"
+        },
+        "fields": {
+            "id": "ID",
+            "name": "Titel",
+            "description": "Bezeichnung",
+            "isActive": "Aktiv",
+            "price": "Price",
+            "category": "Kategorie",
+            "images": {
+                "label": "Fotos",
+                "description": "Ein Foto hochladen.",
+                "validation": "Fotoauflösung: 1080x1080px."
+            },
+            "createdAt": "Erstellt am"
+        }
+    },
+    "reviews": {
+        "reviews": "Kommentare",
+        "titles": {
+            "list": "Kommentare"
+        },
+        "fields": {
+            "user": "Benutzer",
+            "orderId": "Bestellungsnummer",
+            "review": "Kommentar",
+            "rating": "Bewertung"
+        }
+    },
+    "stores": {
+        "stores": "Geschäfte",
+        "titles": {
+            "create": "Geschäft Erstellen",
+            "edit": "Geschäfts Bearbeiten",
+            "list": "Geschäfte",
+            "show": "Geschäft Zeigen"
+        },
+        "fields": {
+            "id": "Geschäfts-ID",
+            "title": "Titel",
+            "isActive": "Aktiv",
+            "createdAt": "Erstellt am",
+            "address": "Adresse",
+            "email": "Email",
+            "gsm": "Telefon"
+        },
+        "buttons": {
+            "editProducts": "Produkte bearbeiten",
+            "addProduct": "Produkt erstellen",
+            "outOfStock": "Kein Bestand",
+            "edit": "Produkt bearbeiten"
+        },
+        "selectLocation": "Wähle einen Ort",
+        "storeProducts": "Produkte des Geschäftes",
+        "tagFilterDescription": "Filter mit Etiketten",
+        "all": "Alles",
+        "productSearch": "Produkt suchen"
+    },
+    "users": {
+        "users": "Benutzern",
+        "titles": {
+            "edit": "Benutzer bearbeiten",
+            "list": "Benutzern",
+            "show": "Benutzer Information"
+        },
+        "fields": {
+            "id": "ID",
+            "avatar": {
+                "label": "Avatar",
+                "description": "Ein Foto hochladen"
+            },
+            "firstName": "Vorname",
+            "lastName": "Nachname",
+            "gender": {
+                "label": "Geschlecht",
+                "Male": "Mann",
+                "Female": "Frau"
+            },
+            "gsm": "GSM",
+            "createdAt": "Erstellt am",
+            "isActive": {
+                "label": "Aktiv",
+                "true": "Ja",
+                "false": "Nein"
+            }
+        },
+        "filter": {
+            "title": "Filter",
+            "search": {
+                "label": "Suche",
+                "placeholder": "Vorname, Nachname, GSM..."
+            },
+            "createdAt": {
+                "label": "Erstellt am"
+            },
+            "gender": {
+                "label": "Geschlecht",
+                "placeholder": "Geschlecht",
+                "male": "Mann",
+                "female": "Frau"
+            },
+            "isActive": {
+                "label": "Ist aktiv?",
+                "placeholder": "Ist aktiv?",
+                "true": "Ja",
+                "false": "Nein"
+            },
+            "submit": "Filter"
+        },
+        "addresses": {
+            "addresses": "Adressen",
+            "address": "Adresse"
+        }
     }
-  }
 }

--- a/examples/fineFoods/admin/antd/public/locales/en.json
+++ b/examples/fineFoods/admin/antd/public/locales/en.json
@@ -1,342 +1,348 @@
 {
-  "pages": {
-    "login": {
-      "signin": "Sign in",
-      "signup": "Sign up",
-      "email": "Username",
-      "password": "Password",
-      "remember": "Remember me",
-      "forgotPassword": "Forgot?",
-      "noAccount": "Don’t have an account?",
-      "message": "<0>Sign in</0> your account"
+    "pages": {
+        "login": {
+            "signin": "Sign in",
+            "signup": "Sign up",
+            "email": "Username",
+            "password": "Password",
+            "remember": "Remember me",
+            "forgotPassword": "Forgot?",
+            "noAccount": "Don’t have an account?",
+            "message": "<0>Sign in</0> your account"
+        },
+        "error": {
+            "info": "You may have forgotten to add the {{action}} component to {{resource}} resource.",
+            "404": "Sorry, the page you visited does not exist.",
+            "resource404": "Are you sure you have created the {{resource}} resource.",
+            "backHome": "Back Home"
+        }
     },
-    "error": {
-      "info": "You may have forgotten to add the {{action}} component to {{resource}} resource.",
-      "404": "Sorry, the page you visited does not exist.",
-      "resource404": "Are you sure you have created the {{resource}} resource.",
-      "backHome": "Back Home"
-    }
-  },
-  "buttons": {
-    "add": "Add",
-    "create": "Create",
-    "save": "Save",
-    "logout": "Logout",
-    "delete": "Delete",
-    "edit": "Edit",
-    "cancel": "Cancel",
-    "confirm": "Are you sure?",
-    "filter": "Filter",
-    "clear": "Clear",
-    "refresh": "Refresh",
-    "show": "Show",
-    "undo": "Undo",
-    "import": "Import",
-    "export": "Export",
-    "clone": "Clone",
-    "accept": "Accept",
-    "acceptAll": "Accept All",
-    "reject": "Reject",
-    "rejectAll": "Reject All",
-    "nextStep": "Next",
-    "previousStep": "Previous"
-  },
-  "loading": "Loading",
-  "tags": {
-    "clone": "Clone"
-  },
-  "table": {
-    "actions": "Actions"
-  },
-  "search": {
-    "placeholder": "Search by Store ID, E-mail, Keyword",
-    "more": "more"
-  },
-  "status": {
-    "enable": "Enable",
-    "disable": "Disable"
-  },
-  "warnWhenUnsavedChanges": "Are you sure you want to leave? You have unsaved changes.",
-  "notifications": {
-    "success": "Successful",
-    "error": "Error (status code: {{statusCode}})",
-    "undoable": "You have {{seconds}} seconds to undo",
-    "createSuccess": "Successfully created {{resource}}",
-    "createError": "There was an error creating {{resource}} (status code: {{statusCode}})",
-    "deleteSuccess": "Successfully deleted {{resource}}",
-    "deleteError": "Error when deleting {{resource}} (status code: {{statusCode}})",
-    "editSuccess": "Successfully edited {{resource}}",
-    "editError": "Error when editing {{resource}} (status code: {{statusCode}})",
-    "importProgress": "Importing: {{processed}}/{{total}}"
-  },
-  "categories": {
-    "categories": "Categories",
-    "titles": {
-      "list": "Categories"
-    },
-    "fields": {
-      "id": "ID",
-      "title": "Title",
-      "isActive": "Active"
-    }
-  },
-  "couriers": {
-    "couriers": "Couriers",
-    "titles": {
-      "create": "Create Courier",
-      "list": "Couriers",
-      "edit": "Edit Courier"
-    },
-    "fields": {
-      "id": "ID",
-      "avatar": {
-        "label": "Avatar",
-        "description": "Click or drag avatar image to this area to upload."
-      },
-      "name": "Name",
-      "surname": "Surname",
-      "gender": {
-        "label": "Gender",
-        "male": "Male",
-        "female": "Female"
-      },
-      "gsm": "Phone",
-      "email": "E-Mail",
-      "address": "Address",
-      "createdAt": "CreatedAt",
-      "isActive": "Is Active",
-      "images": {
-        "label": "Images",
-        "description": "Add user picture",
-        "validation": "must be 480x480 px"
-      },
-      "store": "Store",
-      "vehicle": "Vehicle",
-      "accountNumber": "Account Number"
-    },
-    "steps": {
-      "content": "Content",
-      "relations": "Relations"
-    }
-  },
-  "dashboard": {
-    "title": "Dashboard",
-    "deliveryMap": {
-      "title": "Delivery Map"
-    },
-    "orders": {
-      "title": "Orders"
-    },
-    "totalSales": {
-      "title": "Total Sales"
-    },
-    "dailyRevenue": {
-      "title": "Daily Revenue"
-    },
-    "dailyOrders": {
-      "title": "Daily Orders"
-    },
-    "newCustomers": {
-      "title": "New Customers"
-    },
-    "timeline": {
-      "title": "Timeline",
-      "orderStatuses": {
-        "pending": "Preparing order",
-        "ready": "Order is ready",
-        "on the way": "Order is on the way",
-        "delivered": "Order is delivered",
-        "cancelled": "Order is cancelled"
-      }
-    },
-    "recentOrders": {
-      "title": "Recent Orders"
-    },
-    "trendingMenus": {
-      "title": "Daily Trending Menus"
-    }
-  },
-  "enum": {
-    "orderStatuses": {
-      "Pending": "Pending",
-      "Ready": "Ready",
-      "On The Way": "On the way",
-      "Delivered": "Delivered",
-      "Cancelled": "Cancelled"
-    }
-  },
-  "orders": {
-    "orders": "Orders",
-    "titles": {
-      "list": "Orders",
-      "show": "Show Order"
-    },
-    "fields": {
-      "orderNumber": "Order Number",
-      "orderID": "Order ID",
-      "status": "Status",
-      "store": "Store",
-      "user": "User",
-      "products": "Products",
-      "createdAt": "CreatedAt",
-      "amount": "Amount",
-      "itemsAmount": "{{amount}} items"
-    },
-    "filter": {
-      "title": "Filters",
-      "search": {
-        "label": "Search",
-        "placeholder": "Order Number, User, etc."
-      },
-      "status": {
-        "label": "Status",
-        "placeholder": "Order Status"
-      },
-      "store": {
-        "label": "Store",
-        "placeholder": "Search Stores"
-      },
-      "user": {
-        "label": "User",
-        "placeholder": "Search Users"
-      },
-      "createdAt": {
-        "label": "Created At"
-      },
-      "submit": "Filter"
-    },
-    "courier": {
-      "deliveryTime": "Delivery Time",
-      "phone": "Phone"
-    },
-    "deliverables": {
-      "deliverables": "Deliverables",
-      "fields": {
-        "items": "Items",
-        "quantity": "Quantity",
-        "price": "Price",
-        "total": "Total"
-      },
-      "mainTotal": "MAIN TOTAL"
-    }
-  },
-  "products": {
-    "products": "Products",
-    "titles": {
-      "list": "Products",
-      "create": "Create Product",
-      "edit": "Edit Product"
-    },
-    "fields": {
-      "id": "ID",
-      "name": "Name",
-      "description": "Description",
-      "isActive": "Active",
-      "price": "Price",
-      "category": "Category",
-      "images": {
-        "label": "Images",
-        "description": "Add product picture",
-        "validation": "must be 1080x1080 px"
-      },
-      "createdAt": "CreatedAt"
-    }
-  },
-  "reviews": {
-    "reviews": "Reviews",
-    "titles": {
-      "list": "Reviews"
-    },
-    "fields": {
-      "user": "User",
-      "orderId": "Order ID",
-      "review": "Review",
-      "rating": "Rating"
-    }
-  },
-  "stores": {
-    "stores": "Stores",
-    "titles": {
-      "create": "Create Store",
-      "edit": "Edit Store",
-      "list": "Stores",
-      "show": "Show Store"
-    },
-    "fields": {
-      "id": "Store ID",
-      "title": "Title",
-      "isActive": "Active",
-      "createdAt": "CreatedAt",
-      "address": "Address",
-      "email": "Email",
-      "gsm": "Phone"
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
     },
     "buttons": {
-      "editProducts": "Edit Products",
-      "addProduct": "Add Product",
-      "outOfStock": "Out Of Stock",
-      "edit": "Edit Product"
+        "add": "Add",
+        "create": "Create",
+        "save": "Save",
+        "logout": "Logout",
+        "delete": "Delete",
+        "edit": "Edit",
+        "cancel": "Cancel",
+        "confirm": "Are you sure?",
+        "filter": "Filter",
+        "clear": "Clear",
+        "refresh": "Refresh",
+        "show": "Show",
+        "undo": "Undo",
+        "import": "Import",
+        "export": "Export",
+        "clone": "Clone",
+        "accept": "Accept",
+        "acceptAll": "Accept All",
+        "reject": "Reject",
+        "rejectAll": "Reject All",
+        "nextStep": "Next",
+        "previousStep": "Previous"
     },
-    "selectLocation": "Choose store location on the map",
-    "storeProducts": "Store Products",
-    "tagFilterDescription": "Use tags to filter your search",
-    "all": "All",
-    "productSearch": "Product Search"
-  },
-  "users": {
-    "users": "Users",
-    "titles": {
-      "edit": "Edit User",
-      "list": "Users",
-      "show": "User Detail"
+    "loading": "Loading",
+    "tags": {
+        "clone": "Clone"
     },
-    "fields": {
-      "id": "ID",
-      "avatar": {
-        "label": "Avatar",
-        "description": "Click or drag avatar image to this area to upload."
-      },
-      "firstName": "First Name",
-      "lastName": "Last Name",
-      "gender": {
-        "label": "Gender",
-        "Male": "Male",
-        "Female": "Female"
-      },
-      "gsm": "Gsm Number",
-      "createdAt": "CreatedAt",
-      "isActive": {
-        "label": "Is Active",
-        "true": "Yes",
-        "false": "No"
-      }
+    "table": {
+        "actions": "Actions"
     },
-    "filter": {
-      "title": "Filters",
-      "search": {
-        "label": "Search",
-        "placeholder": "FirstName, lastName, gsm, etc."
-      },
-      "createdAt": {
-        "label": "Created At"
-      },
-      "gender": {
-        "label": "Gender",
-        "placeholder": "Gender",
-        "male": "Male",
-        "female": "Female"
-      },
-      "isActive": {
-        "label": "Active",
-        "placeholder": "Active status",
-        "true": "Yes",
-        "false": "No"
-      },
-      "submit": "Filter"
+    "search": {
+        "placeholder": "Search by Store ID, E-mail, Keyword",
+        "more": "more"
     },
-    "addresses": {
-      "addresses": "Addresses",
-      "address": "Address"
+    "status": {
+        "enable": "Enable",
+        "disable": "Disable"
+    },
+    "warnWhenUnsavedChanges": "Are you sure you want to leave? You have unsaved changes.",
+    "notifications": {
+        "success": "Successful",
+        "error": "Error (status code: {{statusCode}})",
+        "undoable": "You have {{seconds}} seconds to undo",
+        "createSuccess": "Successfully created {{resource}}",
+        "createError": "There was an error creating {{resource}} (status code: {{statusCode}})",
+        "deleteSuccess": "Successfully deleted {{resource}}",
+        "deleteError": "Error when deleting {{resource}} (status code: {{statusCode}})",
+        "editSuccess": "Successfully edited {{resource}}",
+        "editError": "Error when editing {{resource}} (status code: {{statusCode}})",
+        "importProgress": "Importing: {{processed}}/{{total}}"
+    },
+    "categories": {
+        "categories": "Categories",
+        "titles": {
+            "list": "Categories"
+        },
+        "fields": {
+            "id": "ID",
+            "title": "Title",
+            "isActive": "Active"
+        }
+    },
+    "couriers": {
+        "couriers": "Couriers",
+        "titles": {
+            "create": "Create Courier",
+            "list": "Couriers",
+            "edit": "Edit Courier"
+        },
+        "fields": {
+            "id": "ID",
+            "avatar": {
+                "label": "Avatar",
+                "description": "Click or drag avatar image to this area to upload."
+            },
+            "name": "Name",
+            "surname": "Surname",
+            "gender": {
+                "label": "Gender",
+                "male": "Male",
+                "female": "Female"
+            },
+            "gsm": "Phone",
+            "email": "E-Mail",
+            "address": "Address",
+            "createdAt": "CreatedAt",
+            "isActive": "Is Active",
+            "images": {
+                "label": "Images",
+                "description": "Add user picture",
+                "validation": "must be 480x480 px"
+            },
+            "store": "Store",
+            "vehicle": "Vehicle",
+            "accountNumber": "Account Number"
+        },
+        "steps": {
+            "content": "Content",
+            "relations": "Relations"
+        }
+    },
+    "dashboard": {
+        "title": "Dashboard",
+        "deliveryMap": {
+            "title": "Delivery Map"
+        },
+        "orders": {
+            "title": "Orders"
+        },
+        "totalSales": {
+            "title": "Total Sales"
+        },
+        "dailyRevenue": {
+            "title": "Daily Revenue"
+        },
+        "dailyOrders": {
+            "title": "Daily Orders"
+        },
+        "newCustomers": {
+            "title": "New Customers"
+        },
+        "timeline": {
+            "title": "Timeline",
+            "orderStatuses": {
+                "pending": "Preparing order",
+                "ready": "Order is ready",
+                "on the way": "Order is on the way",
+                "delivered": "Order is delivered",
+                "cancelled": "Order is cancelled"
+            }
+        },
+        "recentOrders": {
+            "title": "Recent Orders"
+        },
+        "trendingMenus": {
+            "title": "Daily Trending Menus"
+        }
+    },
+    "enum": {
+        "orderStatuses": {
+            "Pending": "Pending",
+            "Ready": "Ready",
+            "On The Way": "On the way",
+            "Delivered": "Delivered",
+            "Cancelled": "Cancelled"
+        }
+    },
+    "orders": {
+        "orders": "Orders",
+        "titles": {
+            "list": "Orders",
+            "show": "Show Order"
+        },
+        "fields": {
+            "orderNumber": "Order Number",
+            "orderID": "Order ID",
+            "status": "Status",
+            "store": "Store",
+            "user": "User",
+            "products": "Products",
+            "createdAt": "CreatedAt",
+            "amount": "Amount",
+            "itemsAmount": "{{amount}} items"
+        },
+        "filter": {
+            "title": "Filters",
+            "search": {
+                "label": "Search",
+                "placeholder": "Order Number, User, etc."
+            },
+            "status": {
+                "label": "Status",
+                "placeholder": "Order Status"
+            },
+            "store": {
+                "label": "Store",
+                "placeholder": "Search Stores"
+            },
+            "user": {
+                "label": "User",
+                "placeholder": "Search Users"
+            },
+            "createdAt": {
+                "label": "Created At"
+            },
+            "submit": "Filter"
+        },
+        "courier": {
+            "deliveryTime": "Delivery Time",
+            "phone": "Phone"
+        },
+        "deliverables": {
+            "deliverables": "Deliverables",
+            "fields": {
+                "items": "Items",
+                "quantity": "Quantity",
+                "price": "Price",
+                "total": "Total"
+            },
+            "mainTotal": "MAIN TOTAL"
+        }
+    },
+    "products": {
+        "products": "Products",
+        "titles": {
+            "list": "Products",
+            "create": "Create Product",
+            "edit": "Edit Product"
+        },
+        "fields": {
+            "id": "ID",
+            "name": "Name",
+            "description": "Description",
+            "isActive": "Active",
+            "price": "Price",
+            "category": "Category",
+            "images": {
+                "label": "Images",
+                "description": "Add product picture",
+                "validation": "must be 1080x1080 px"
+            },
+            "createdAt": "CreatedAt"
+        }
+    },
+    "reviews": {
+        "reviews": "Reviews",
+        "titles": {
+            "list": "Reviews"
+        },
+        "fields": {
+            "user": "User",
+            "orderId": "Order ID",
+            "review": "Review",
+            "rating": "Rating"
+        }
+    },
+    "stores": {
+        "stores": "Stores",
+        "titles": {
+            "create": "Create Store",
+            "edit": "Edit Store",
+            "list": "Stores",
+            "show": "Show Store"
+        },
+        "fields": {
+            "id": "Store ID",
+            "title": "Title",
+            "isActive": "Active",
+            "createdAt": "CreatedAt",
+            "address": "Address",
+            "email": "Email",
+            "gsm": "Phone"
+        },
+        "buttons": {
+            "editProducts": "Edit Products",
+            "addProduct": "Add Product",
+            "outOfStock": "Out Of Stock",
+            "edit": "Edit Product"
+        },
+        "selectLocation": "Choose store location on the map",
+        "storeProducts": "Store Products",
+        "tagFilterDescription": "Use tags to filter your search",
+        "all": "All",
+        "productSearch": "Product Search"
+    },
+    "users": {
+        "users": "Users",
+        "titles": {
+            "edit": "Edit User",
+            "list": "Users",
+            "show": "User Detail"
+        },
+        "fields": {
+            "id": "ID",
+            "avatar": {
+                "label": "Avatar",
+                "description": "Click or drag avatar image to this area to upload."
+            },
+            "firstName": "First Name",
+            "lastName": "Last Name",
+            "gender": {
+                "label": "Gender",
+                "Male": "Male",
+                "Female": "Female"
+            },
+            "gsm": "Gsm Number",
+            "createdAt": "CreatedAt",
+            "isActive": {
+                "label": "Is Active",
+                "true": "Yes",
+                "false": "No"
+            }
+        },
+        "filter": {
+            "title": "Filters",
+            "search": {
+                "label": "Search",
+                "placeholder": "FirstName, lastName, gsm, etc."
+            },
+            "createdAt": {
+                "label": "Created At"
+            },
+            "gender": {
+                "label": "Gender",
+                "placeholder": "Gender",
+                "male": "Male",
+                "female": "Female"
+            },
+            "isActive": {
+                "label": "Active",
+                "placeholder": "Active status",
+                "true": "Yes",
+                "false": "No"
+            },
+            "submit": "Filter"
+        },
+        "addresses": {
+            "addresses": "Addresses",
+            "address": "Address"
+        }
     }
-  }
 }

--- a/examples/fineFoods/admin/mui/public/locales/de.json
+++ b/examples/fineFoods/admin/mui/public/locales/de.json
@@ -17,6 +17,12 @@
             "backHome": "Zurück"
         }
     },
+    "actions": {
+        "list": "Aufführen",
+        "create": "Erstellen",
+        "edit": "Bearbeiten",
+        "show": "Zeigen"
+    },
     "buttons": {
         "create": "Erstellen",
         "save": "Speichern",

--- a/examples/fineFoods/admin/mui/public/locales/de.json
+++ b/examples/fineFoods/admin/mui/public/locales/de.json
@@ -20,7 +20,8 @@
     "actions": {
         "list": "Aufführen",
         "create": "Erstellen",
-        "edit": "Bearbeiten"
+        "edit": "Bearbeiten",
+        "show": "Zeigen"
     },
     "buttons": {
         "create": "Erstellen",

--- a/examples/fineFoods/admin/mui/public/locales/de.json
+++ b/examples/fineFoods/admin/mui/public/locales/de.json
@@ -20,8 +20,7 @@
     "actions": {
         "list": "Aufführen",
         "create": "Erstellen",
-        "edit": "Bearbeiten",
-        "show": "Zeigen"
+        "edit": "Bearbeiten"
     },
     "buttons": {
         "create": "Erstellen",

--- a/examples/fineFoods/admin/mui/public/locales/en.json
+++ b/examples/fineFoods/admin/mui/public/locales/en.json
@@ -35,6 +35,7 @@
         "filter": "Filter",
         "clear": "Clear",
         "refresh": "Refresh",
+        "show": "Show",
         "undo": "Undo",
         "import": "Import",
         "export": "Export",

--- a/examples/fineFoods/admin/mui/public/locales/en.json
+++ b/examples/fineFoods/admin/mui/public/locales/en.json
@@ -17,6 +17,12 @@
             "backHome": "Back Home"
         }
     },
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
     "buttons": {
         "add": "Add",
         "create": "Create",
@@ -29,7 +35,6 @@
         "filter": "Filter",
         "clear": "Clear",
         "refresh": "Refresh",
-        "show": "Show",
         "undo": "Undo",
         "import": "Import",
         "export": "Export",

--- a/examples/fineFoods/admin/mui/public/locales/en.json
+++ b/examples/fineFoods/admin/mui/public/locales/en.json
@@ -20,7 +20,8 @@
     "actions": {
         "list": "List",
         "create": "Create",
-        "edit": "Edit"
+        "edit": "Edit",
+        "show": "Show"
     },
     "buttons": {
         "add": "Add",

--- a/examples/fineFoods/admin/mui/public/locales/en.json
+++ b/examples/fineFoods/admin/mui/public/locales/en.json
@@ -20,8 +20,7 @@
     "actions": {
         "list": "List",
         "create": "Create",
-        "edit": "Edit",
-        "show": "Show"
+        "edit": "Edit"
     },
     "buttons": {
         "add": "Add",

--- a/examples/i18n/nextjs/public/locales/en/common.json
+++ b/examples/i18n/nextjs/public/locales/en/common.json
@@ -17,6 +17,12 @@
             "backHome": "Back Home"
         }
     },
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
     "buttons": {
         "create": "Create",
         "save": "Save",

--- a/examples/i18n/react/public/locales/de/common.json
+++ b/examples/i18n/react/public/locales/de/common.json
@@ -17,6 +17,12 @@
             "backHome": "Zurück"
         }
     },
+    "actions": {
+        "list": "Aufführen",
+        "create": "Erstellen",
+        "edit": "Bearbeiten",
+        "show": "Zeigen"
+    },
     "buttons": {
         "create": "Erstellen",
         "save": "Speichern",

--- a/examples/i18n/react/public/locales/en/common.json
+++ b/examples/i18n/react/public/locales/en/common.json
@@ -17,6 +17,12 @@
             "backHome": "Back Home"
         }
     },
+    "actions": {
+        "list": "List",
+        "create": "Create",
+        "edit": "Edit",
+        "show": "Show"
+    },
     "buttons": {
         "create": "Create",
         "save": "Save",

--- a/examples/i18n/react/public/locales/en/common.json
+++ b/examples/i18n/react/public/locales/en/common.json
@@ -42,7 +42,7 @@
     },
     "warnWhenUnsavedChanges": "Are you sure you want to leave? You have unsaved changes.",
     "notifications": {
-        "success": "Successful ",
+        "success": "Successful",
         "error": "Error (status code: {{statusCode}})",
         "undoable": "You have {{seconds}} seconds to undo",
         "createSuccess": "Successfully created {{resource}}",

--- a/packages/core/src/hooks/breadcrumb/index.ts
+++ b/packages/core/src/hooks/breadcrumb/index.ts
@@ -73,7 +73,7 @@ export const useBreadcrumb = (): UseBreadcrumbReturnType => {
         const actionLabel = translate(key);
         if (actionLabel === key) {
             console.warn(
-                `Breadcrumb missing translate key for the "${action}" action. Please add "actions.${action}" key to your translation file. For more information, see https://refine.dev/docs/core/hooks/useBreadcrumb/#translate`,
+                `Breadcrumb missing translate key for the "${action}" action. Please add "actions.${action}" key to your translation file. For more information, see https://refine.dev/docs/core/hooks/useBreadcrumb/#i18n-support`,
             );
             breadcrumbs.push({
                 label: translate(`buttons.${action}`, humanizeString(action)),

--- a/packages/core/src/hooks/breadcrumb/index.ts
+++ b/packages/core/src/hooks/breadcrumb/index.ts
@@ -37,7 +37,6 @@ export const useBreadcrumb = (): UseBreadcrumbReturnType => {
             if (parentResource.parentName) {
                 addBreadcrumb(parentResource.parentName);
             }
-
             breadcrumbs.push({
                 label:
                     parentResource.label ??
@@ -70,9 +69,20 @@ export const useBreadcrumb = (): UseBreadcrumbReturnType => {
     });
 
     if (action) {
-        breadcrumbs.push({
-            label: humanizeString(action),
-        });
+        const key = `actions.${action}`;
+        const actionLabel = translate(key);
+        if (actionLabel === key) {
+            console.warn(
+                `Breadcrumb missing translate key for action "${action}". Please add "actions.${action}" key to your translation file. For more information, see https://refine.dev/docs/core/hooks/useBreadcrumb/`,
+            );
+            breadcrumbs.push({
+                label: translate(`buttons.${action}`, humanizeString(action)),
+            });
+        } else {
+            breadcrumbs.push({
+                label: translate(key, humanizeString(action)),
+            });
+        }
     }
 
     return {

--- a/packages/core/src/hooks/breadcrumb/index.ts
+++ b/packages/core/src/hooks/breadcrumb/index.ts
@@ -73,7 +73,7 @@ export const useBreadcrumb = (): UseBreadcrumbReturnType => {
         const actionLabel = translate(key);
         if (actionLabel === key) {
             console.warn(
-                `Breadcrumb missing translate key for action "${action}". Please add "actions.${action}" key to your translation file. For more information, see https://refine.dev/docs/core/hooks/useBreadcrumb/`,
+                `Breadcrumb missing translate key for the "${action}" action. Please add "actions.${action}" key to your translation file. For more information, see https://refine.dev/docs/core/hooks/useBreadcrumb/#translate`,
             );
             breadcrumbs.push({
                 label: translate(`buttons.${action}`, humanizeString(action)),


### PR DESCRIPTION
Add translate support for `CRUD` components (`<List>`, `<Create>`, `<Edit>`, `<Show>`) actions in [`useBreadcrumb`](https://refine.dev/docs/core/hooks/useBreadcrumb/) hook.
