### PR TITLE
fix: remove `useDataGrid` `columns` dependency

### DIFF
--- a/examples/base/mui/src/pages/posts/list.tsx
+++ b/examples/base/mui/src/pages/posts/list.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useOne } from "@pankod/refine-core";
+import { useMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
@@ -11,6 +11,17 @@ import {
 import { ICategory, IPost } from "interfaces";
 
 export const PostsList: React.FC = () => {
+    const { dataGridProps } = useDataGrid<IPost>();
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
     const columns = React.useMemo<GridColumns<IPost>>(
         () => [
             {
@@ -28,12 +39,15 @@ export const PostsList: React.FC = () => {
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
-                valueGetter: ({ row }) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: row.category.id,
-                    });
-                    return data?.data.title;
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
                 },
             },
             { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
@@ -48,16 +62,12 @@ export const PostsList: React.FC = () => {
                 minWidth: 80,
             },
         ],
-        [],
+        [categoriesData, isLoading],
     );
-
-    const { dataGridProps } = useDataGrid<IPost>({
-        columns,
-    });
 
     return (
         <List>
-            <DataGrid {...dataGridProps} autoHeight />
+            <DataGrid {...dataGridProps} columns={columns} autoHeight />
         </List>
     );
 };

--- a/examples/customization/customTheme/mui/src/pages/posts/list.tsx
+++ b/examples/customization/customTheme/mui/src/pages/posts/list.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useOne } from "@pankod/refine-core";
+import { useMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
@@ -11,6 +11,17 @@ import {
 import { ICategory, IPost } from "interfaces";
 
 export const PostsList: React.FC = () => {
+    const { dataGridProps } = useDataGrid<IPost>();
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
     const columns = React.useMemo<GridColumns<IPost>>(
         () => [
             {
@@ -28,12 +39,15 @@ export const PostsList: React.FC = () => {
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
-                valueGetter: ({ row }) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: row.category.id,
-                    });
-                    return data?.data.title;
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
                 },
             },
             { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
@@ -48,16 +62,12 @@ export const PostsList: React.FC = () => {
                 minWidth: 80,
             },
         ],
-        [],
+        [categoriesData, isLoading],
     );
-
-    const { dataGridProps } = useDataGrid<IPost>({
-        columns,
-    });
 
     return (
         <List>
-            <DataGrid {...dataGridProps} autoHeight />
+            <DataGrid {...dataGridProps} columns={columns} autoHeight />
         </List>
     );
 };

--- a/examples/field/useSelect/mui/src/pages/posts/list.tsx
+++ b/examples/field/useSelect/mui/src/pages/posts/list.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+import { useMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
@@ -6,40 +8,66 @@ import {
     EditButton,
 } from "@pankod/refine-mui";
 
-import { IPost } from "interfaces";
-
-const columns: GridColumns = [
-    {
-        field: "id",
-        headerName: "ID",
-        type: "number",
-    },
-    { field: "title", headerName: "Title", minWidth: 500, flex: 1 },
-    { field: "status", headerName: "Status", minWidth: 120, flex: 0.5 },
-    {
-        field: "actions",
-        headerName: "Actions",
-        renderCell: function render({ row }) {
-            return <EditButton hideText recordItemId={row.id} />;
-        },
-        align: "center",
-        headerAlign: "center",
-        minWidth: 80,
-    },
-];
+import { ICategory, IPost } from "interfaces";
 
 export const PostsList: React.FC = () => {
-    const { dataGridProps } = useDataGrid<IPost>({
-        columns,
+    const { dataGridProps } = useDataGrid<IPost>();
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
     });
+
+    const columns = React.useMemo<GridColumns<IPost>>(
+        () => [
+            {
+                field: "id",
+                headerName: "ID",
+                type: "number",
+                width: 50,
+            },
+            { field: "title", headerName: "Title", minWidth: 400, flex: 1 },
+            {
+                field: "category.id",
+                headerName: "Category",
+                type: "number",
+                headerAlign: "left",
+                align: "left",
+                minWidth: 250,
+                flex: 0.5,
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
+                },
+            },
+            { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
+            {
+                field: "actions",
+                headerName: "Actions",
+                renderCell: function render({ row }) {
+                    return <EditButton hideText recordItemId={row.id} />;
+                },
+                align: "center",
+                headerAlign: "center",
+                minWidth: 80,
+            },
+        ],
+        [categoriesData, isLoading],
+    );
 
     return (
         <List>
-            <DataGrid
-                {...dataGridProps}
-                autoHeight
-                rowsPerPageOptions={[10, 20, 30, 50, 100]}
-            />
+            <DataGrid {...dataGridProps} columns={columns} autoHeight />
         </List>
     );
 };

--- a/examples/fineFoods/admin/mui/src/components/dashboard/recentOrders/index.tsx
+++ b/examples/fineFoods/admin/mui/src/components/dashboard/recentOrders/index.tsx
@@ -21,6 +21,25 @@ export const RecentOrders: React.FC = () => {
     const { show } = useNavigation();
     const { mutate } = useUpdate();
 
+    const { dataGridProps } = useDataGrid<IOrder>({
+        resource: "orders",
+        initialSorter: [
+            {
+                field: "createdAt",
+                order: "desc",
+            },
+        ],
+        initialPageSize: 4,
+        permanentFilter: [
+            {
+                field: "status.text",
+                operator: "eq",
+                value: "Pending",
+            },
+        ],
+        syncWithLocation: false,
+    });
+
     const columns = React.useMemo<GridColumns<IOrder>>(
         () => [
             {
@@ -181,29 +200,10 @@ export const RecentOrders: React.FC = () => {
         [t],
     );
 
-    const { dataGridProps } = useDataGrid<IOrder>({
-        columns,
-        resource: "orders",
-        initialSorter: [
-            {
-                field: "createdAt",
-                order: "desc",
-            },
-        ],
-        initialPageSize: 4,
-        permanentFilter: [
-            {
-                field: "status.text",
-                operator: "eq",
-                value: "Pending",
-            },
-        ],
-        syncWithLocation: false,
-    });
-
     return (
         <DataGrid
             {...dataGridProps}
+            columns={columns}
             autoHeight
             headerHeight={0}
             rowHeight={200}

--- a/examples/fineFoods/admin/mui/src/pages/categories/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/categories/list.tsx
@@ -59,6 +59,7 @@ export const CategoryList: React.FC<IResourceComponentsProps> = () => {
     });
 
     const t = useTranslate();
+
     const columns: Array<Column> = React.useMemo(
         () => [
             {
@@ -338,6 +339,19 @@ export const CategoryList: React.FC<IResourceComponentsProps> = () => {
 const CategoryProductsTable: React.FC<{ record: ICategory }> = ({ record }) => {
     const t = useTranslate();
 
+    const { dataGridProps } = useDataGrid<IProduct>({
+        resource: "products",
+        initialPageSize: 5,
+        permanentFilter: [
+            {
+                field: "category.id",
+                operator: "eq",
+                value: record.id,
+            },
+        ],
+        syncWithLocation: false,
+    });
+
     const columns = React.useMemo<GridColumns<IProduct>>(
         () => [
             {
@@ -427,20 +441,6 @@ const CategoryProductsTable: React.FC<{ record: ICategory }> = ({ record }) => {
         [t],
     );
 
-    const { dataGridProps } = useDataGrid<IProduct>({
-        columns,
-        resource: "products",
-        initialPageSize: 5,
-        permanentFilter: [
-            {
-                field: "category.id",
-                operator: "eq",
-                value: record.id,
-            },
-        ],
-        syncWithLocation: false,
-    });
-
     const editDrawerFormProps = useModalForm<IProduct>({
         refineCoreProps: {
             action: "edit",
@@ -461,6 +461,7 @@ const CategoryProductsTable: React.FC<{ record: ICategory }> = ({ record }) => {
         >
             <DataGrid
                 {...dataGridProps}
+                columns={columns}
                 rowHeight={80}
                 autoHeight
                 density="comfortable"

--- a/examples/fineFoods/admin/mui/src/pages/couriers/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/couriers/list.tsx
@@ -25,6 +25,16 @@ export const CourierList: React.FC<IResourceComponentsProps> = () => {
     const t = useTranslate();
     const { mutate: mutateDelete } = useDelete();
 
+    const { dataGridProps } = useDataGrid<ICourier>({
+        initialPageSize: 10,
+        initialSorter: [
+            {
+                field: "id",
+                order: "desc",
+            },
+        ],
+    });
+
     const columns = React.useMemo<GridColumns<ICourier>>(
         () => [
             {
@@ -112,21 +122,11 @@ export const CourierList: React.FC<IResourceComponentsProps> = () => {
         [t],
     );
 
-    const { dataGridProps } = useDataGrid<ICourier>({
-        columns,
-        initialPageSize: 10,
-        initialSorter: [
-            {
-                field: "id",
-                order: "desc",
-            },
-        ],
-    });
-
     return (
         <List cardProps={{ sx: { paddingX: { xs: 2, md: 0 } } }}>
             <DataGrid
                 {...dataGridProps}
+                columns={columns}
                 autoHeight
                 rowsPerPageOptions={[10, 20, 50, 100]}
                 density="comfortable"

--- a/examples/fineFoods/admin/mui/src/pages/couriers/show.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/couriers/show.tsx
@@ -32,6 +32,26 @@ import {
 
 import { ICourier, IReview } from "interfaces";
 
+type CourierInfoTextProps = {
+    icon: React.ReactNode;
+    text?: string;
+};
+
+const CourierInfoText: React.FC<CourierInfoTextProps> = ({ icon, text }) => (
+    <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent={{
+            sm: "center",
+            lg: "flex-start",
+        }}
+        gap={1}
+    >
+        {icon}
+        <Typography variant="body1">{text}</Typography>
+    </Stack>
+);
+
 export const CourierShow: React.FC<IResourceComponentsProps> = () => {
     const t = useTranslate();
     const { show } = useNavigation();
@@ -41,28 +61,27 @@ export const CourierShow: React.FC<IResourceComponentsProps> = () => {
     } = useShow<ICourier>();
     const courier = data?.data;
 
-    type CourierInfoTextProps = {
-        icon: React.ReactNode;
-        text?: string;
-    };
-
-    const CourierInfoText: React.FC<CourierInfoTextProps> = ({
-        icon,
-        text,
-    }) => (
-        <Stack
-            direction="row"
-            alignItems="center"
-            justifyContent={{
-                sm: "center",
-                lg: "flex-start",
-            }}
-            gap={1}
-        >
-            {icon}
-            <Typography variant="body1">{text}</Typography>
-        </Stack>
-    );
+    const { dataGridProps } = useDataGrid<IReview, HttpError>({
+        resource: "reviews",
+        initialSorter: [
+            {
+                field: "id",
+                order: "desc",
+            },
+        ],
+        permanentFilter: [
+            {
+                field: "order.courier.id",
+                operator: "eq",
+                value: courier?.id,
+            },
+        ],
+        initialPageSize: 4,
+        queryOptions: {
+            enabled: courier !== undefined,
+        },
+        syncWithLocation: false,
+    });
 
     const columns = React.useMemo<GridColumns<IReview>>(
         () => [
@@ -127,29 +146,6 @@ export const CourierShow: React.FC<IResourceComponentsProps> = () => {
         [t],
     );
 
-    const { dataGridProps } = useDataGrid<IReview, HttpError>({
-        columns,
-        resource: "reviews",
-        initialSorter: [
-            {
-                field: "id",
-                order: "desc",
-            },
-        ],
-        permanentFilter: [
-            {
-                field: "order.courier.id",
-                operator: "eq",
-                value: courier?.id,
-            },
-        ],
-        initialPageSize: 4,
-        queryOptions: {
-            enabled: courier !== undefined,
-        },
-        syncWithLocation: false,
-    });
-
     return (
         <Grid container spacing={2}>
             <Grid item xs={12} lg={3}>
@@ -200,6 +196,7 @@ export const CourierShow: React.FC<IResourceComponentsProps> = () => {
                     >
                         <DataGrid
                             {...dataGridProps}
+                            columns={columns}
                             autoHeight
                             rowHeight={80}
                             rowsPerPageOptions={[4, 10, 20, 100]}

--- a/examples/fineFoods/admin/mui/src/pages/orders/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/orders/list.tsx
@@ -42,6 +42,44 @@ export const OrderList: React.FC<IResourceComponentsProps> = () => {
     const t = useTranslate();
     const { mutate } = useUpdate();
 
+    const { dataGridProps, search, filters, sorter } = useDataGrid<
+        IOrder,
+        HttpError,
+        IOrderFilterVariables
+    >({
+        initialPageSize: 10,
+        onSearch: (params) => {
+            const filters: CrudFilters = [];
+            const { q, store, user, status } = params;
+
+            filters.push({
+                field: "q",
+                operator: "eq",
+                value: q !== "" ? q : undefined,
+            });
+
+            filters.push({
+                field: "store.id",
+                operator: "eq",
+                value: (store ?? [].length) > 0 ? store : undefined,
+            });
+
+            filters.push({
+                field: "user.id",
+                operator: "eq",
+                value: user,
+            });
+
+            filters.push({
+                field: "status.text",
+                operator: "in",
+                value: (status ?? []).length > 0 ? status : undefined,
+            });
+
+            return filters;
+        },
+    });
+
     const columns = React.useMemo<GridColumns<IOrder>>(
         () => [
             {
@@ -196,45 +234,6 @@ export const OrderList: React.FC<IResourceComponentsProps> = () => {
         ],
         [t],
     );
-
-    const { dataGridProps, search, filters, sorter } = useDataGrid<
-        IOrder,
-        HttpError,
-        IOrderFilterVariables
-    >({
-        columns,
-        initialPageSize: 10,
-        onSearch: (params) => {
-            const filters: CrudFilters = [];
-            const { q, store, user, status } = params;
-
-            filters.push({
-                field: "q",
-                operator: "eq",
-                value: q !== "" ? q : undefined,
-            });
-
-            filters.push({
-                field: "store.id",
-                operator: "eq",
-                value: (store ?? [].length) > 0 ? store : undefined,
-            });
-
-            filters.push({
-                field: "user.id",
-                operator: "eq",
-                value: user,
-            });
-
-            filters.push({
-                field: "status.text",
-                operator: "in",
-                value: (status ?? []).length > 0 ? status : undefined,
-            });
-
-            return filters;
-        },
-    });
 
     const { show } = useNavigation();
 
@@ -465,6 +464,7 @@ export const OrderList: React.FC<IResourceComponentsProps> = () => {
                 >
                     <DataGrid
                         {...dataGridProps}
+                        columns={columns}
                         filterModel={undefined}
                         autoHeight
                         onRowClick={({ id }) => {

--- a/examples/fineFoods/admin/mui/src/pages/reviews/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/reviews/list.tsx
@@ -35,6 +35,17 @@ export const ReviewsList: React.FC<IResourceComponentsProps> = () => {
 
     const { mutate } = useUpdateMany<IReview>();
 
+    const { dataGridProps } = useDataGrid<IReview>({
+        initialPageSize: 10,
+        permanentFilter: [
+            {
+                field: "status",
+                operator: "eq",
+                value: "pending",
+            },
+        ],
+    });
+
     const handleUpdate = (id: BaseKey, status: IReview["status"]) => {
         mutate({
             resource: "reviews",
@@ -167,18 +178,6 @@ export const ReviewsList: React.FC<IResourceComponentsProps> = () => {
         [t],
     );
 
-    const { dataGridProps } = useDataGrid<IReview>({
-        columns,
-        initialPageSize: 10,
-        permanentFilter: [
-            {
-                field: "status",
-                operator: "eq",
-                value: "pending",
-            },
-        ],
-    });
-
     return (
         <List
             cardProps={{ sx: { paddingX: { xs: 2, md: 0 } } }}
@@ -203,6 +202,7 @@ export const ReviewsList: React.FC<IResourceComponentsProps> = () => {
         >
             <DataGrid
                 {...dataGridProps}
+                columns={columns}
                 autoHeight
                 checkboxSelection
                 density="comfortable"

--- a/examples/fineFoods/admin/mui/src/pages/stores/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/stores/list.tsx
@@ -34,6 +34,10 @@ export const StoreList: React.FC<IResourceComponentsProps> = () => {
     const { data: showQueryResult } = queryResult;
     const record = showQueryResult?.data;
 
+    const { dataGridProps } = useDataGrid<IStore>({
+        initialPageSize: 10,
+    });
+
     const columns = React.useMemo<GridColumns<IStore>>(
         () => [
             {
@@ -136,16 +140,12 @@ export const StoreList: React.FC<IResourceComponentsProps> = () => {
         [t],
     );
 
-    const { dataGridProps } = useDataGrid<IStore>({
-        initialPageSize: 10,
-        columns,
-    });
-
     return (
         <Paper>
             <List canCreate cardProps={{ sx: { paddingX: { xs: 2, md: 0 } } }}>
                 <DataGrid
                     {...dataGridProps}
+                    columns={columns}
                     rowHeight={80}
                     autoHeight
                     density="comfortable"

--- a/examples/fineFoods/admin/mui/src/pages/users/list.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/users/list.tsx
@@ -36,6 +36,38 @@ import { IUser, IUserFilterVariables } from "interfaces";
 export const UserList: React.FC<IResourceComponentsProps> = () => {
     const t = useTranslate();
 
+    const { dataGridProps, search, filters } = useDataGrid<
+        IUser,
+        HttpError,
+        IUserFilterVariables
+    >({
+        initialPageSize: 10,
+        onSearch: (params) => {
+            const filters: CrudFilters = [];
+            const { q, gender, isActive } = params;
+
+            filters.push({
+                field: "q",
+                operator: "eq",
+                value: q !== "" ? q : undefined,
+            });
+
+            filters.push({
+                field: "gender",
+                operator: "eq",
+                value: gender !== "" ? gender : undefined,
+            });
+
+            filters.push({
+                field: "isActive",
+                operator: "eq",
+                value: isActive !== "" ? isActive : undefined,
+            });
+
+            return filters;
+        },
+    });
+
     const columns = React.useMemo<GridColumns<IUser>>(
         () => [
             {
@@ -119,39 +151,6 @@ export const UserList: React.FC<IResourceComponentsProps> = () => {
         ],
         [t],
     );
-
-    const { dataGridProps, search, filters } = useDataGrid<
-        IUser,
-        HttpError,
-        IUserFilterVariables
-    >({
-        columns,
-        initialPageSize: 10,
-        onSearch: (params) => {
-            const filters: CrudFilters = [];
-            const { q, gender, isActive } = params;
-
-            filters.push({
-                field: "q",
-                operator: "eq",
-                value: q !== "" ? q : undefined,
-            });
-
-            filters.push({
-                field: "gender",
-                operator: "eq",
-                value: gender !== "" ? gender : undefined,
-            });
-
-            filters.push({
-                field: "isActive",
-                operator: "eq",
-                value: isActive !== "" ? isActive : undefined,
-            });
-
-            return filters;
-        },
-    });
 
     const { register, handleSubmit, control } = useForm<
         IUser,
@@ -270,6 +269,7 @@ export const UserList: React.FC<IResourceComponentsProps> = () => {
                 <List cardProps={{ sx: { paddingX: { xs: 2, md: 0 } } }}>
                     <DataGrid
                         {...dataGridProps}
+                        columns={columns}
                         filterModel={undefined}
                         autoHeight
                         rowsPerPageOptions={[10, 20, 50, 100]}

--- a/examples/fineFoods/admin/mui/src/pages/users/show.tsx
+++ b/examples/fineFoods/admin/mui/src/pages/users/show.tsx
@@ -34,11 +34,51 @@ import { CustomTooltip, OrderStatus } from "components";
 
 import { IOrder, IOrderFilterVariables, IUser } from "interfaces";
 
+const UserInfoText: React.FC = ({ children }) => (
+    <Stack
+        direction="row"
+        alignItems="center"
+        justifyContent={{
+            sm: "center",
+            lg: "flex-start",
+        }}
+        gap={1}
+    >
+        {children}
+    </Stack>
+);
+
 export const UserShow: React.FC<IResourceComponentsProps> = () => {
     const t = useTranslate();
 
     const { queryResult } = useShow<IUser>();
     const user = queryResult.data?.data;
+
+    const { dataGridProps } = useDataGrid<
+        IOrder,
+        HttpError,
+        IOrderFilterVariables
+    >({
+        resource: "orders",
+        initialSorter: [
+            {
+                field: "createdAt",
+                order: "desc",
+            },
+        ],
+        permanentFilter: [
+            {
+                field: "user.id",
+                operator: "eq",
+                value: user?.id,
+            },
+        ],
+        initialPageSize: 4,
+        queryOptions: {
+            enabled: user !== undefined,
+        },
+        syncWithLocation: false,
+    });
 
     const columns = React.useMemo<GridColumns<IOrder>>(
         () => [
@@ -134,47 +174,6 @@ export const UserShow: React.FC<IResourceComponentsProps> = () => {
         [t],
     );
 
-    const { dataGridProps } = useDataGrid<
-        IOrder,
-        HttpError,
-        IOrderFilterVariables
-    >({
-        columns,
-        resource: "orders",
-        initialSorter: [
-            {
-                field: "createdAt",
-                order: "desc",
-            },
-        ],
-        permanentFilter: [
-            {
-                field: "user.id",
-                operator: "eq",
-                value: user?.id,
-            },
-        ],
-        initialPageSize: 4,
-        queryOptions: {
-            enabled: user !== undefined,
-        },
-        syncWithLocation: false,
-    });
-
-    const UserInfoText: React.FC = ({ children }) => (
-        <Stack
-            direction="row"
-            alignItems="center"
-            justifyContent={{
-                sm: "center",
-                lg: "flex-start",
-            }}
-            gap={1}
-        >
-            {children}
-        </Stack>
-    );
-
     return (
         <Grid container spacing={2}>
             <Grid item xs={12} lg={3}>
@@ -225,6 +224,7 @@ export const UserShow: React.FC<IResourceComponentsProps> = () => {
                     >
                         <DataGrid
                             {...dataGridProps}
+                            columns={columns}
                             autoHeight
                             rowsPerPageOptions={[4, 10, 20, 100]}
                         />

--- a/examples/form/mui/useDrawerForm/src/pages/posts/list.tsx
+++ b/examples/form/mui/useDrawerForm/src/pages/posts/list.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useOne } from "@pankod/refine-core";
+import { useMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
@@ -13,6 +13,17 @@ import { CreatePostDrawer, EditPostDrawer } from "components";
 import { ICategory, IPost } from "interfaces";
 
 export const PostsList: React.FC = () => {
+    const { dataGridProps } = useDataGrid<IPost>();
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
     const createDrawerFormProps = useModalForm<IPost>({
         refineCoreProps: { action: "create" },
     });
@@ -44,12 +55,15 @@ export const PostsList: React.FC = () => {
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
-                valueGetter: ({ row }) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: row.category.id,
-                    });
-                    return data?.data.title;
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
                 },
             },
             { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
@@ -69,17 +83,13 @@ export const PostsList: React.FC = () => {
                 minWidth: 80,
             },
         ],
-        [t],
+        [categoriesData, isLoading],
     );
-
-    const { dataGridProps } = useDataGrid<IPost>({
-        columns,
-    });
 
     return (
         <>
             <List createButtonProps={{ onClick: () => showCreateDrawer() }}>
-                <DataGrid {...dataGridProps} autoHeight />
+                <DataGrid {...dataGridProps} columns={columns} autoHeight />
             </List>
             <CreatePostDrawer {...createDrawerFormProps} />
             <EditPostDrawer {...editDrawerFormProps} />

--- a/examples/form/mui/useForm/src/pages/posts/list.tsx
+++ b/examples/form/mui/useForm/src/pages/posts/list.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useOne } from "@pankod/refine-core";
+import { useMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
@@ -11,6 +11,17 @@ import {
 import { ICategory, IPost } from "interfaces";
 
 export const PostsList: React.FC = () => {
+    const { dataGridProps } = useDataGrid<IPost>();
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
     const columns = React.useMemo<GridColumns<IPost>>(
         () => [
             {
@@ -28,12 +39,15 @@ export const PostsList: React.FC = () => {
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
-                valueGetter: ({ row }) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: row.category.id,
-                    });
-                    return data?.data.title;
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
                 },
             },
             { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
@@ -48,16 +62,12 @@ export const PostsList: React.FC = () => {
                 minWidth: 80,
             },
         ],
-        [],
+        [categoriesData, isLoading],
     );
-
-    const { dataGridProps } = useDataGrid<IPost>({
-        columns,
-    });
 
     return (
         <List>
-            <DataGrid {...dataGridProps} autoHeight />
+            <DataGrid {...dataGridProps} columns={columns} autoHeight />
         </List>
     );
 };

--- a/examples/form/mui/useModalForm/src/pages/posts/list.tsx
+++ b/examples/form/mui/useModalForm/src/pages/posts/list.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useOne } from "@pankod/refine-core";
+import { useMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
@@ -13,6 +13,17 @@ import { CreatePostModal, EditPostModal } from "components";
 import { ICategory, IPost } from "interfaces";
 
 export const PostsList: React.FC = () => {
+    const { dataGridProps } = useDataGrid<IPost>();
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
     const createModalFormProps = useModalForm<IPost>({
         refineCoreProps: { action: "create" },
     });
@@ -44,12 +55,15 @@ export const PostsList: React.FC = () => {
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
-                valueGetter: ({ row }) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: row.category.id,
-                    });
-                    return data?.data.title;
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
                 },
             },
             { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
@@ -72,14 +86,10 @@ export const PostsList: React.FC = () => {
         [],
     );
 
-    const { dataGridProps } = useDataGrid<IPost>({
-        columns,
-    });
-
     return (
         <>
             <List createButtonProps={{ onClick: () => showCreateModal() }}>
-                <DataGrid {...dataGridProps} autoHeight />
+                <DataGrid {...dataGridProps} columns={columns} autoHeight />
             </List>
             <CreatePostModal {...createModalFormProps} />
             <EditPostModal {...editModalFormProps} />

--- a/examples/form/mui/useStepsForm/src/pages/posts/list.tsx
+++ b/examples/form/mui/useStepsForm/src/pages/posts/list.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useOne } from "@pankod/refine-core";
+import { useMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
@@ -11,6 +11,17 @@ import {
 import { ICategory, IPost } from "interfaces";
 
 export const PostsList: React.FC = () => {
+    const { dataGridProps } = useDataGrid<IPost>();
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
     const columns = React.useMemo<GridColumns<IPost>>(
         () => [
             {
@@ -28,12 +39,15 @@ export const PostsList: React.FC = () => {
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
-                valueGetter: ({ row }) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: row.category.id,
-                    });
-                    return data?.data.title;
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
                 },
             },
             { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
@@ -51,13 +65,9 @@ export const PostsList: React.FC = () => {
         [],
     );
 
-    const { dataGridProps } = useDataGrid<IPost>({
-        columns,
-    });
-
     return (
         <List>
-            <DataGrid {...dataGridProps} autoHeight />
+            <DataGrid {...dataGridProps} columns={columns} autoHeight />
         </List>
     );
 };

--- a/examples/importExport/mui/src/pages/list.tsx
+++ b/examples/importExport/mui/src/pages/list.tsx
@@ -40,9 +40,7 @@ const columns: GridColumns = [
 ];
 
 export const ImportList: React.FC = () => {
-    const { dataGridProps } = useDataGrid({
-        columns,
-    });
+    const { dataGridProps } = useDataGrid();
 
     const { open } = useNotification();
 
@@ -85,7 +83,7 @@ export const ImportList: React.FC = () => {
             }}
         >
             <div style={{ height: 700, width: "100%" }}>
-                <DataGrid {...dataGridProps} />
+                <DataGrid {...dataGridProps} columns={columns} />
             </div>
         </List>
     );

--- a/examples/storybook/mui/src/stories/dataGrid/basic.stories.tsx
+++ b/examples/storybook/mui/src/stories/dataGrid/basic.stories.tsx
@@ -1,8 +1,10 @@
+import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { DataGrid, GridColumns, useDataGrid } from "@pankod/refine-mui";
-import { useOne } from "@pankod/refine-core";
+import { useMany } from "@pankod/refine-core";
 
 import { RefineWithoutLayout } from "../../../.storybook/preview";
+import { ICategory, IPost } from "interfaces";
 
 export default {
     title: "Hooks / DataGrid",
@@ -10,37 +12,54 @@ export default {
     decorators: [(Story) => RefineWithoutLayout(Story)],
 } as ComponentMeta<typeof DataGrid>;
 
-const columns: GridColumns = [
-    {
-        field: "id",
-        headerName: "ID",
-        type: "number",
-    },
-    { field: "title", headerName: "Title", flex: 1, minWidth: 350 },
-    {
-        field: "category.id",
-        headerName: "Category",
-        flex: 1,
-        align: "left",
-        headerAlign: "left",
-        type: "number",
-        valueGetter: (params) => {
-            const { data } = useOne({
-                resource: "categories",
-                id: params.row.category.id,
-            });
-            return data?.data.title;
-        },
-    },
-    { field: "status", headerName: "Status", flex: 1 },
-];
-
 export const Basic: ComponentStory<typeof DataGrid> = () => {
-    const { dataGridProps } = useDataGrid({ columns });
+    const { dataGridProps } = useDataGrid<IPost>();
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
+    const columns = React.useMemo<GridColumns<IPost>>(
+        () => [
+            {
+                field: "id",
+                headerName: "ID",
+                type: "number",
+                width: 50,
+            },
+            { field: "title", headerName: "Title", minWidth: 400, flex: 1 },
+            {
+                field: "category.id",
+                headerName: "Category",
+                type: "number",
+                headerAlign: "left",
+                align: "left",
+                minWidth: 250,
+                flex: 0.5,
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
+                },
+            },
+            { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
+        ],
+        [categoriesData, isLoading],
+    );
 
     return (
         <div style={{ height: 700, width: "100%" }}>
-            <DataGrid {...dataGridProps} />
+            <DataGrid {...dataGridProps} columns={columns} />
         </div>
     );
 };

--- a/examples/storybook/mui/src/stories/dataGrid/editable.stories.tsx
+++ b/examples/storybook/mui/src/stories/dataGrid/editable.stories.tsx
@@ -34,7 +34,7 @@ const columns: GridColumns = [
 ];
 
 export const Editable: ComponentStory<typeof DataGrid> = (args) => {
-    const { dataGridProps } = useDataGrid({ columns });
+    const { dataGridProps } = useDataGrid();
     const { mutate } = useUpdate();
 
     return (
@@ -51,6 +51,7 @@ export const Editable: ComponentStory<typeof DataGrid> = (args) => {
                     return newRow;
                 }}
                 {...args}
+                columns={columns}
             />
         </div>
     );

--- a/examples/storybook/mui/src/stories/dataGrid/selection/deleteMany.stories.tsx
+++ b/examples/storybook/mui/src/stories/dataGrid/selection/deleteMany.stories.tsx
@@ -61,7 +61,7 @@ const CustomToolbar: React.FC<CustomToolbarProps> = ({ selectedRowIds }) => {
 };
 
 export const DeleteMany: ComponentStory<typeof DataGrid> = () => {
-    const { dataGridProps } = useDataGrid({ columns });
+    const { dataGridProps } = useDataGrid();
 
     const [selectedRowIds, setSelectedRowIds] = useState<GridSelectionModel>(
         [],
@@ -71,6 +71,7 @@ export const DeleteMany: ComponentStory<typeof DataGrid> = () => {
         <div style={{ height: 700, width: "100%" }}>
             <DataGrid
                 {...dataGridProps}
+                columns={columns}
                 checkboxSelection
                 disableSelectionOnClick
                 onSelectionModelChange={(newSelectionModel) => {

--- a/examples/storybook/mui/src/stories/dataGrid/selection/updateMany.stories.tsx
+++ b/examples/storybook/mui/src/stories/dataGrid/selection/updateMany.stories.tsx
@@ -62,7 +62,7 @@ const CustomToolbar: React.FC<CustomToolbarProps> = ({ selectedRowIds }) => {
 };
 
 export const UpdateMany: ComponentStory<typeof DataGrid> = () => {
-    const { dataGridProps } = useDataGrid({ columns });
+    const { dataGridProps } = useDataGrid();
 
     const [selectedRowIds, setSelectedRowIds] = useState<GridSelectionModel>(
         [],
@@ -72,6 +72,7 @@ export const UpdateMany: ComponentStory<typeof DataGrid> = () => {
         <div style={{ height: 700, width: "100%" }}>
             <DataGrid
                 {...dataGridProps}
+                columns={columns}
                 checkboxSelection
                 disableSelectionOnClick
                 onSelectionModelChange={(newSelectionModel) => {

--- a/examples/table/mui/advancedTable/src/pages/dataGrid/index.tsx
+++ b/examples/table/mui/advancedTable/src/pages/dataGrid/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useOne } from "@pankod/refine-core";
+import { useMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
@@ -8,9 +8,20 @@ import {
     GridActionsCellItem,
 } from "@pankod/refine-mui";
 
-import { IPost } from "interfaces";
+import { ICategory, IPost } from "interfaces";
 
 export const BasicDataGrid: React.FC = () => {
+    const { dataGridProps } = useDataGrid<IPost>();
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
     const columns = React.useMemo<GridColumns<IPost>>(
         () => [
             {
@@ -25,12 +36,15 @@ export const BasicDataGrid: React.FC = () => {
                 headerName: "Category",
                 flex: 1,
                 type: "number",
-                valueGetter: (params) => {
-                    const { data } = useOne({
-                        resource: "categories",
-                        id: params.row.category.id,
-                    });
-                    return data?.data.title;
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
                 },
             },
             { field: "status", headerName: "Status", flex: 1 },
@@ -46,13 +60,11 @@ export const BasicDataGrid: React.FC = () => {
         ],
         [],
     );
-    const { dataGridProps } = useDataGrid({
-        columns,
-    });
 
     return (
         <DataGrid
             {...dataGridProps}
+            columns={columns}
             components={{
                 Toolbar: GridToolbar,
             }}

--- a/examples/table/mui/dataGridPro/src/pages/posts/list.tsx
+++ b/examples/table/mui/dataGridPro/src/pages/posts/list.tsx
@@ -1,42 +1,12 @@
 import React from "react";
-import { useOne } from "@pankod/refine-core";
+import { useMany } from "@pankod/refine-core";
 import { useDataGrid, List } from "@pankod/refine-mui";
 import { DataGridPro, GridColumns } from "@mui/x-data-grid-pro";
 
 import { ICategory, IPost } from "interfaces";
 
 export const PostsList: React.FC = () => {
-    const columns = React.useMemo<GridColumns<IPost>>(
-        () => [
-            {
-                field: "id",
-                headerName: "ID",
-                type: "number",
-            },
-            { field: "title", headerName: "Title", minWidth: 400, flex: 1 },
-            {
-                field: "category.id",
-                headerName: "Category",
-                type: "number",
-                headerAlign: "left",
-                align: "left",
-                minWidth: 250,
-                flex: 0.5,
-                valueGetter: ({ row }) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: row.category.id,
-                    });
-                    return data?.data.title;
-                },
-            },
-            { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
-        ],
-        [],
-    );
-
     const { dataGridProps } = useDataGrid<IPost>({
-        columns,
         initialCurrent: 2,
         initialPageSize: 10,
         initialSorter: [
@@ -64,10 +34,52 @@ export const PostsList: React.FC = () => {
         syncWithLocation: true,
     });
 
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
+    const columns = React.useMemo<GridColumns<IPost>>(
+        () => [
+            {
+                field: "id",
+                headerName: "ID",
+                type: "number",
+            },
+            { field: "title", headerName: "Title", minWidth: 400, flex: 1 },
+            {
+                field: "category.id",
+                headerName: "Category",
+                type: "number",
+                headerAlign: "left",
+                align: "left",
+                minWidth: 250,
+                flex: 0.5,
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
+                },
+            },
+            { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
+        ],
+        [categoriesData, isLoading],
+    );
+
     return (
         <List>
             <DataGridPro
                 {...dataGridProps}
+                columns={columns}
                 autoHeight
                 rowsPerPageOptions={[10, 20, 30, 50, 100]}
             />

--- a/examples/table/mui/tableFilter/src/pages/posts/list.tsx
+++ b/examples/table/mui/tableFilter/src/pages/posts/list.tsx
@@ -1,6 +1,6 @@
 import React, { ComponentProps, useMemo } from "react";
 import {
-    useOne,
+    useMany,
     HttpError,
     CrudFilters,
     getDefaultFilter,
@@ -28,6 +28,47 @@ import { Controller, useForm } from "@pankod/refine-react-hook-form";
 import { ICategory, IPost, IPostFilterVariables } from "interfaces";
 
 export const PostsList: React.FC = () => {
+    const { dataGridProps, filters, search } = useDataGrid<
+        IPost,
+        HttpError,
+        IPostFilterVariables
+    >({
+        initialPageSize: 10,
+        onSearch: (params) => {
+            const filters: CrudFilters = [];
+            const { q, category, status } = params;
+
+            filters.push(
+                {
+                    field: "q",
+                    operator: "eq",
+                    value: q !== "" ? q : undefined,
+                },
+                {
+                    field: "category.id",
+                    operator: "eq",
+                    value: category !== "" ? category : undefined,
+                },
+                {
+                    field: "status",
+                    operator: "eq",
+                    value: status !== "" ? status : undefined,
+                },
+            );
+
+            return filters;
+        },
+    });
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
     const columns = useMemo<GridColumns<IPost>>(
         () => [
             {
@@ -69,50 +110,20 @@ export const PostsList: React.FC = () => {
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
-                valueGetter: ({ row }) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: row.category.id,
-                    });
-                    return data?.data.title;
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
                 },
             },
         ],
-        [],
+        [categoriesData, isLoading],
     );
-
-    const { dataGridProps, filters, search } = useDataGrid<
-        IPost,
-        HttpError,
-        IPostFilterVariables
-    >({
-        columns,
-        initialPageSize: 10,
-        onSearch: (params) => {
-            const filters: CrudFilters = [];
-            const { q, category, status } = params;
-
-            filters.push(
-                {
-                    field: "q",
-                    operator: "eq",
-                    value: q !== "" ? q : undefined,
-                },
-                {
-                    field: "category.id",
-                    operator: "eq",
-                    value: category !== "" ? category : undefined,
-                },
-                {
-                    field: "status",
-                    operator: "eq",
-                    value: status !== "" ? status : undefined,
-                },
-            );
-
-            return filters;
-        },
-    });
 
     const { control, register, handleSubmit } = useForm<
         IPost,
@@ -239,6 +250,7 @@ export const PostsList: React.FC = () => {
                 <List>
                     <DataGrid
                         {...dataGridProps}
+                        columns={columns}
                         filterModel={undefined}
                         autoHeight
                         rowsPerPageOptions={[10, 20, 50, 100]}

--- a/examples/table/mui/useDataGrid/src/pages/posts/list.tsx
+++ b/examples/table/mui/useDataGrid/src/pages/posts/list.tsx
@@ -1,42 +1,11 @@
 import React from "react";
-import { useOne } from "@pankod/refine-core";
+import { useMany } from "@pankod/refine-core";
 import { useDataGrid, DataGrid, GridColumns, List } from "@pankod/refine-mui";
 
 import { ICategory, IPost } from "interfaces";
 
 export const PostsList: React.FC = () => {
-    const columns = React.useMemo<GridColumns<IPost>>(
-        () => [
-            {
-                field: "id",
-                headerName: "ID",
-                type: "number",
-                width: 50,
-            },
-            { field: "title", headerName: "Title", minWidth: 400, flex: 1 },
-            {
-                field: "category.id",
-                headerName: "Category",
-                type: "number",
-                headerAlign: "left",
-                align: "left",
-                minWidth: 250,
-                flex: 0.5,
-                valueGetter: ({ row }) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: row.category.id,
-                    });
-                    return data?.data.title;
-                },
-            },
-            { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
-        ],
-        [],
-    );
-
     const { dataGridProps } = useDataGrid<IPost>({
-        columns,
         initialCurrent: 2,
         initialPageSize: 10,
         initialSorter: [
@@ -55,10 +24,53 @@ export const PostsList: React.FC = () => {
         syncWithLocation: true,
     });
 
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
+    const columns = React.useMemo<GridColumns<IPost>>(
+        () => [
+            {
+                field: "id",
+                headerName: "ID",
+                type: "number",
+                width: 50,
+            },
+            { field: "title", headerName: "Title", minWidth: 400, flex: 1 },
+            {
+                field: "category.id",
+                headerName: "Category",
+                type: "number",
+                headerAlign: "left",
+                align: "left",
+                minWidth: 250,
+                flex: 0.5,
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
+                },
+            },
+            { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
+        ],
+        [categoriesData, isLoading],
+    );
+
     return (
         <List>
             <DataGrid
                 {...dataGridProps}
+                columns={columns}
                 autoHeight
                 rowsPerPageOptions={[10, 20, 30, 50, 100]}
             />

--- a/examples/table/mui/useDeleteMany/src/pages/posts/list.tsx
+++ b/examples/table/mui/useDeleteMany/src/pages/posts/list.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useOne, useDeleteMany } from "@pankod/refine-core";
+import { useMany, useDeleteMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
@@ -32,6 +32,19 @@ export const PostsList: React.FC = () => {
         );
     };
 
+    const { dataGridProps } = useDataGrid<IPost>({
+        initialPageSize: 10,
+    });
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
     const columns = React.useMemo<GridColumns<IPost>>(
         () => [
             {
@@ -49,23 +62,21 @@ export const PostsList: React.FC = () => {
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
-                valueGetter: ({ row }) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: row.category.id,
-                    });
-                    return data?.data.title;
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
                 },
             },
             { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
         ],
-        [],
+        [categoriesData, isLoading],
     );
-
-    const { dataGridProps } = useDataGrid<IPost>({
-        columns,
-        initialPageSize: 10,
-    });
 
     return (
         <List
@@ -85,6 +96,7 @@ export const PostsList: React.FC = () => {
         >
             <DataGrid
                 {...dataGridProps}
+                columns={columns}
                 autoHeight
                 checkboxSelection
                 onSelectionModelChange={(newSelectionModel) => {

--- a/examples/table/mui/useUpdateMany/src/pages/posts/list.tsx
+++ b/examples/table/mui/useUpdateMany/src/pages/posts/list.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useOne, useUpdateMany } from "@pankod/refine-core";
+import { useMany, useUpdateMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
@@ -35,6 +35,19 @@ export const PostsList: React.FC = () => {
         );
     };
 
+    const { dataGridProps } = useDataGrid<IPost>({
+        initialPFageSize: 10,
+    });
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
     const columns = React.useMemo<GridColumns<IPost>>(
         () => [
             {
@@ -52,23 +65,21 @@ export const PostsList: React.FC = () => {
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
-                valueGetter: ({ row }) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: row.category.id,
-                    });
-                    return data?.data.title;
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
                 },
             },
             { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
         ],
-        [],
+        [categoriesData, isLoading],
     );
-
-    const { dataGridProps } = useDataGrid<IPost>({
-        columns,
-        initialPageSize: 10,
-    });
 
     return (
         <List
@@ -88,6 +99,7 @@ export const PostsList: React.FC = () => {
         >
             <DataGrid
                 {...dataGridProps}
+                columns={columns}
                 autoHeight
                 checkboxSelection
                 onSelectionModelChange={(newSelectionModel) => {

--- a/examples/tutorial/mui/src/pages/posts/list.tsx
+++ b/examples/tutorial/mui/src/pages/posts/list.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useOne } from "@pankod/refine-core";
+import { useMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
@@ -16,6 +16,17 @@ import {
 import { IPost, ICategory } from "interfaces";
 
 export const PostList: React.FC = () => {
+    const { dataGridProps } = useDataGrid<IPost>();
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
     const columns = React.useMemo<GridColumns<IPost>>(
         () => [
             { field: "title", headerName: "Title", flex: 1, minWidth: 350 },
@@ -24,12 +35,15 @@ export const PostList: React.FC = () => {
                 headerName: "Category",
                 minWidth: 250,
                 flex: 1,
-                valueGetter: (params) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: params.row.category.id,
-                    });
-                    return data?.data.title;
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
                 },
             },
             {
@@ -84,13 +98,9 @@ export const PostList: React.FC = () => {
         [],
     );
 
-    const { dataGridProps } = useDataGrid<IPost>({
-        columns,
-    });
-
     return (
         <List>
-            <DataGrid {...dataGridProps} autoHeight />
+            <DataGrid {...dataGridProps} columns={columns} autoHeight />
         </List>
     );
 };

--- a/examples/upload/mui/base64/src/pages/posts/list.tsx
+++ b/examples/upload/mui/base64/src/pages/posts/list.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useOne } from "@pankod/refine-core";
+import { useMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
@@ -11,6 +11,17 @@ import {
 import { ICategory, IPost } from "interfaces";
 
 export const PostsList: React.FC = () => {
+    const { dataGridProps } = useDataGrid<IPost>();
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
     const columns = React.useMemo<GridColumns<IPost>>(
         () => [
             {
@@ -28,12 +39,15 @@ export const PostsList: React.FC = () => {
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
-                valueGetter: ({ row }) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: row.category.id,
-                    });
-                    return data?.data.title;
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
                 },
             },
             { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
@@ -51,13 +65,9 @@ export const PostsList: React.FC = () => {
         [],
     );
 
-    const { dataGridProps } = useDataGrid<IPost>({
-        columns,
-    });
-
     return (
         <List>
-            <DataGrid {...dataGridProps} autoHeight />
+            <DataGrid {...dataGridProps} columns={columns} autoHeight />
         </List>
     );
 };

--- a/examples/upload/mui/multipart/src/pages/posts/list.tsx
+++ b/examples/upload/mui/multipart/src/pages/posts/list.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useOne } from "@pankod/refine-core";
+import { useMany } from "@pankod/refine-core";
 import {
     useDataGrid,
     DataGrid,
@@ -11,6 +11,17 @@ import {
 import { ICategory, IPost } from "interfaces";
 
 export const PostsList: React.FC = () => {
+    const { dataGridProps } = useDataGrid<IPost>();
+
+    const categoryIds = dataGridProps.rows.map((item) => item.category.id);
+    const { data: categoriesData, isLoading } = useMany<ICategory>({
+        resource: "categories",
+        ids: categoryIds,
+        queryOptions: {
+            enabled: categoryIds.length > 0,
+        },
+    });
+
     const columns = React.useMemo<GridColumns<IPost>>(
         () => [
             {
@@ -28,12 +39,15 @@ export const PostsList: React.FC = () => {
                 align: "left",
                 minWidth: 250,
                 flex: 0.5,
-                valueGetter: ({ row }) => {
-                    const { data } = useOne<ICategory>({
-                        resource: "categories",
-                        id: row.category.id,
-                    });
-                    return data?.data.title;
+                renderCell: ({ row }) => {
+                    if (isLoading) {
+                        return "Loading...";
+                    }
+
+                    const category = categoriesData?.data.find(
+                        (item) => item.id === row.category.id,
+                    );
+                    return category?.title;
                 },
             },
             { field: "status", headerName: "Status", minWidth: 120, flex: 0.3 },
@@ -51,13 +65,9 @@ export const PostsList: React.FC = () => {
         [],
     );
 
-    const { dataGridProps } = useDataGrid<IPost>({
-        columns,
-    });
-
     return (
         <List>
-            <DataGrid {...dataGridProps} autoHeight />
+            <DataGrid {...dataGridProps} columns={columns} autoHeight />
         </List>
     );
 };

--- a/packages/mui/src/definitions/dataGrid/index.ts
+++ b/packages/mui/src/definitions/dataGrid/index.ts
@@ -3,7 +3,6 @@ import {
     GridFilterModel,
     GridLinkOperator,
     GridFilterItem,
-    DataGridProps,
 } from "@mui/x-data-grid";
 import {
     CrudFilters,
@@ -11,6 +10,8 @@ import {
     CrudSorting,
     LogicalFilter,
 } from "@pankod/refine-core";
+
+import { ColumnsLookupType } from "@hooks/useDataGrid";
 
 export const transformSortModelToCrudSorting = (
     sortModel: GridSortModel,
@@ -161,7 +162,7 @@ export const transformCrudOperatorToMuiOperator = (
 
 export const transformCrudFiltersToFilterModel = (
     crudFilters: CrudFilters,
-    columns: DataGridProps["columns"],
+    columns?: ColumnsLookupType,
 ): GridFilterModel | undefined => {
     const gridFilterItems: GridFilterItem[] = [];
 
@@ -169,38 +170,42 @@ export const transformCrudFiltersToFilterModel = (
         (filter) => filter.operator === "or",
     );
 
-    if (isExistOrFilter) {
-        const orLogicalFilters = crudFilters.find(
-            (filter) => filter.operator === "or",
-        )?.value as LogicalFilter[];
+    if (columns) {
+        if (isExistOrFilter) {
+            const orLogicalFilters = crudFilters.find(
+                (filter) => filter.operator === "or",
+            )?.value as LogicalFilter[];
 
-        orLogicalFilters.map(({ field, value, operator }) => {
-            const column = columns.find((col) => col.field === field);
+            orLogicalFilters.map(({ field, value, operator }) => {
+                const columnType = columns[field]?.type;
 
-            gridFilterItems.push({
-                columnField: field,
-                operatorValue: transformCrudOperatorToMuiOperator(
-                    operator,
-                    column?.type,
-                ),
-                value: value === "" ? undefined : value,
-                id: field + operator,
+                gridFilterItems.push({
+                    columnField: field,
+                    operatorValue: transformCrudOperatorToMuiOperator(
+                        operator,
+                        columnType,
+                    ),
+                    value: value === "" ? undefined : value,
+                    id: field + operator,
+                });
             });
-        });
-    } else {
-        (crudFilters as LogicalFilter[]).map(({ field, value, operator }) => {
-            const column = columns.find((col) => col.field === field);
+        } else {
+            (crudFilters as LogicalFilter[]).map(
+                ({ field, value, operator }) => {
+                    const columnType = columns[field]?.type;
 
-            gridFilterItems.push({
-                columnField: field,
-                operatorValue: transformCrudOperatorToMuiOperator(
-                    operator,
-                    column?.type,
-                ),
-                value: value === "" ? undefined : value,
-                id: field + operator,
-            });
-        });
+                    gridFilterItems.push({
+                        columnField: field,
+                        operatorValue: transformCrudOperatorToMuiOperator(
+                            operator,
+                            columnType,
+                        ),
+                        value: value === "" ? undefined : value,
+                        id: field + operator,
+                    });
+                },
+            );
+        }
     }
 
     return {

--- a/packages/mui/src/hooks/index.ts
+++ b/packages/mui/src/hooks/index.ts
@@ -1,3 +1,7 @@
 export * from "./useAutocomplete";
-export * from "./useDataGrid";
+export {
+    UseDataGridProps,
+    UseDataGridReturnType,
+    useDataGrid,
+} from "./useDataGrid";
 export * from "./useMenu";

--- a/packages/mui/src/hooks/useDataGrid/index.ts
+++ b/packages/mui/src/hooks/useDataGrid/index.ts
@@ -94,10 +94,11 @@ export const useDataGrid = <
     liveParams,
     metaData,
     dataProviderName,
-}: UseDataGridProps<TData, TError, TSearchVariables>): UseDataGridReturnType<
+}: UseDataGridProps<
     TData,
+    TError,
     TSearchVariables
-> => {
+> = {}): UseDataGridReturnType<TData, TSearchVariables> => {
     const [columnsLookup, setColumnsLookup] = useState<ColumnsLookupType>();
 
     const {


### PR DESCRIPTION
The `useDataGrid` hook required the `columns` property. Since this situation gives us some difficulties, we will remove the column dependency.