### PR TITLE
feat(supabase-dataProvider): add relational order for getList hook

### DIFF
--- a/.changeset/lemon-moose-matter.md
+++ b/.changeset/lemon-moose-matter.md
@@ -1,0 +1,27 @@
+---
+"@pankod/refine-supabase": minor
+---
+
+Add `foreignTable` propery to the **supabase** order statement to access relational data. For more information, you can check the 🔗[documentation](https://supabase.com/docs/reference/javascript/order).
+
+What we added to the [`getlist`](https://github.com/pankod/refine/blob/master/packages/supabase/src/index.ts) hook is the following:
+
+```tsx
+...
+sort?.map((item) => {
+    const [foreignTable, field] = item.field.split(/\.(.*)/);
+
+    if (foreignTable && field) {
+        query
+            .select(metaData?.select ?? `*, ${foreignTable}(${field})`)
+            .order(field, {
+                ascending: item.order === "asc",
+                foreignTable: foreignTable,
+            });
+    } else {
+        query.order(item.field, {
+            ascending: item.order === "asc",
+        });
+    }
+});
+```

--- a/.changeset/lemon-moose-matter.md
+++ b/.changeset/lemon-moose-matter.md
@@ -23,7 +23,7 @@ const { tableProps } = useTable({
 
 📢 `field: "categories.title"` means in the `posts` table `categories` is the foreign table, `title` is the field in the foreign table, and `asc` is the order.
 
-🚨 Don't forget to pass the `sorter` and `dataIndex` property to the your `Columm` component:
+🚨 If you are using **Ant Design** don't forget to pass the `sorter` and `dataIndex` property to the your `Columm` component:
 
 ```tsx
 ...

--- a/.changeset/lemon-moose-matter.md
+++ b/.changeset/lemon-moose-matter.md
@@ -6,22 +6,35 @@ Add `foreignTable` propery to the **supabase** order statement to access relatio
 
 What we added to the [`getlist`](https://github.com/pankod/refine/blob/master/packages/supabase/src/index.ts) hook is the following:
 
+💡 How use the `foreignTable` property?
+
 ```tsx
 ...
-sort?.map((item) => {
-    const [foreignTable, field] = item.field.split(/\.(.*)/);
-
-    if (foreignTable && field) {
-        query
-            .select(metaData?.select ?? `*, ${foreignTable}(${field})`)
-            .order(field, {
-                ascending: item.order === "asc",
-                foreignTable: foreignTable,
-            });
-    } else {
-        query.order(item.field, {
-            ascending: item.order === "asc",
-        });
-    }
+const { tableProps } = useTable({
+    resource: "posts",
+    initialSorter: [
+        {
+            field: "categories.title",
+            order: "asc",
+        },
+    ],
 });
 ```
+
+📢 `field: "categories.title"` means in the `posts` table `categories` is the foreign table, `title` is the field in the foreign table, and `asc` is the order.
+
+🚨 Don't forget to pass the `sorter` and `dataIndex` property to the your `Columm` component:
+
+```tsx
+...
+<Table.Column
+    dataIndex={["categories", "title"]}
+    title="Categories"
+    sorter
+```
+
+> **Warning**
+> We have developed this feature due to an [issue here](https://github.com/pankod/refine/issues/2066) but currently, **supabase** doesn't support it. You can follow the progress here 👇
+
+-   [https://github.com/supabase/supabase/discussions/4255](https://github.com/supabase/supabase/discussions/4255)
+-   [https://github.com/supabase/postgrest-js/issues/198](https://github.com/supabase/postgrest-js/issues/198)

--- a/examples/dataProvider/supabase/src/pages/posts/list.tsx
+++ b/examples/dataProvider/supabase/src/pages/posts/list.tsx
@@ -1,9 +1,8 @@
-import { IResourceComponentsProps, useMany } from "@pankod/refine-core";
+import { IResourceComponentsProps } from "@pankod/refine-core";
 
 import {
     List,
     Table,
-    TextField,
     useTable,
     Space,
     EditButton,
@@ -24,16 +23,8 @@ export const PostList: React.FC<IResourceComponentsProps> = () => {
                 order: "asc",
             },
         ],
-    });
-
-    const categoryIds =
-        tableProps?.dataSource?.map((item) => item.categoryId) ?? [];
-
-    const { data, isLoading } = useMany<ICategory>({
-        resource: "categories",
-        ids: categoryIds,
-        queryOptions: {
-            enabled: categoryIds.length > 0,
+        metaData: {
+            select: "*, categories(title)",
         },
     });
 
@@ -58,8 +49,13 @@ export const PostList: React.FC<IResourceComponentsProps> = () => {
                     sorter
                 />
                 <Table.Column
-                    dataIndex="categoryId"
+                    key="categoryId"
+                    dataIndex={["categories", "title"]}
                     title="Category"
+                    defaultSortOrder={getDefaultSortOrder(
+                        "categories.title",
+                        sorter,
+                    )}
                     filterDropdown={(props) => (
                         <FilterDropdown {...props}>
                             <Select
@@ -70,20 +66,6 @@ export const PostList: React.FC<IResourceComponentsProps> = () => {
                             />
                         </FilterDropdown>
                     )}
-                    render={(value) => {
-                        if (isLoading) {
-                            return <TextField value="Loading..." />;
-                        }
-
-                        return (
-                            <TextField
-                                value={
-                                    data?.data.find((item) => item.id === value)
-                                        ?.title
-                                }
-                            />
-                        );
-                    }}
                 />
                 <Table.Column<IPost>
                     title="Actions"

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -116,7 +116,22 @@ const dataProvider = (supabaseClient: SupabaseClient): DataProvider => {
                 .range((current - 1) * pageSize, current * pageSize - 1);
 
             sort?.map((item) => {
-                query.order(item.field, { ascending: item.order === "asc" });
+                const [foreignTable, field] = item.field.split(/\.(.*)/);
+
+                if (foreignTable && field) {
+                    query
+                        .select(
+                            metaData?.select ?? `*, ${foreignTable}(${field})`,
+                        )
+                        .order(field, {
+                            ascending: item.order === "asc",
+                            foreignTable: foreignTable,
+                        });
+                } else {
+                    query.order(item.field, {
+                        ascending: item.order === "asc",
+                    });
+                }
             });
 
             filters?.map((item) => {


### PR DESCRIPTION
In this PR, Add `foreignTable` propery to the **supabase** order statement to access relational data. For more information, you can check the 🔗[documentation](https://supabase.com/docs/reference/javascript/order).