### PR TITLE
docs(getting-started): add overview example missing type and CLI option information

### DIFF
--- a/documentation/docs/getting-started/overview.md
+++ b/documentation/docs/getting-started/overview.md
@@ -128,7 +128,7 @@ Follow the _CLI wizard_ to select options and start creating your project.
 </p>
 </details>
 
-<br>
+<br/>
 
 After setup is complete, navigate to the project folder and start your project with:
 

--- a/documentation/docs/getting-started/overview.md
+++ b/documentation/docs/getting-started/overview.md
@@ -92,6 +92,8 @@ npx superplate-cli -p refine-react tutorial
 
 Follow the _CLI wizard_ to select options and start creating your project.
 
+For this example, select Ant Design as a UI Framework option in the creation phase.
+
 After setup is complete, navigate to the project folder and start your project with:
 
 ```

--- a/documentation/docs/getting-started/overview.md
+++ b/documentation/docs/getting-started/overview.md
@@ -92,7 +92,43 @@ npx superplate-cli -p refine-react tutorial
 
 Follow the _CLI wizard_ to select options and start creating your project.
 
-For this example, select Ant Design as a UI Framework option in the creation phase.
+
+<details><summary>Select the following options to complete the _CLI wizard_:</summary>
+<p>
+
+```bash title="CLI options selection"
+? What will be the name of your app:
+> tutorial
+
+? Do you want to use a UI Framework?:
+❯ Ant Design
+
+? Do you want a customized theme?:
+❯ Default theme
+
+? Router Provider:
+❯ React Router v6
+
+? Data Provider:
+❯ REST API
+
+? Auth Provider:
+❯ None
+
+? Do you want to add example pages?:
+❯ No
+
+? Do you want a customized layout?:
+❯ No
+
+? i18n - Internationalization:
+❯ No
+```
+
+</p>
+</details>
+
+<br>
 
 After setup is complete, navigate to the project folder and start your project with:
 

--- a/documentation/docs/getting-started/overview.md
+++ b/documentation/docs/getting-started/overview.md
@@ -154,7 +154,7 @@ export const PostList: React.FC = () => {
                 <Table.Column
                     dataIndex="createdAt"
                     title="createdAt"
-                    render={(value) => <DateField format="LLL" value={value} />}
+                    render={(value: string) => <DateField format="LLL" value={value} />}
                 />
             </Table>
         </List>

--- a/documentation/docs/ui-frameworks/antd/tutorial.md
+++ b/documentation/docs/ui-frameworks/antd/tutorial.md
@@ -88,9 +88,6 @@ npx superplate-cli -p refine-react tutorial
 Select the following options to complete the _CLI wizard_:
 
 ```
-? Select your project type:
-❯ refine-react
-
 ? What will be the name of your app:
 > tutorial
 


### PR DESCRIPTION
The missing `value` argument type on `createdAt` column was throwing a typeError during compiling phase. So I added proper type to doc example.

In addition, selecting the UI Framework option as an `Ant Design` during the CLI creation phase needed to be mentioned in the doc since the overview example uses the Ant Design feature.

