### PR TITLE
fix: console.warn even if i18n provider is not used

### DIFF
--- a/.changeset/nine-chefs-camp.md
+++ b/.changeset/nine-chefs-camp.md
@@ -1,0 +1,6 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fixed `useBreadcrumb` hook throws `console.warn` even if i18nProvider is not used - #2103
+

--- a/packages/core/src/hooks/breadcrumb/index.ts
+++ b/packages/core/src/hooks/breadcrumb/index.ts
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useContext } from "react";
 import humanizeString from "humanize-string";
 
 import { useResource, useRouterContext, useTranslate } from "@hooks";
-import { ResourceRouterParams } from "src/interfaces";
+import { TranslationContext } from "@contexts/translation";
+
+import { ResourceRouterParams } from "../../interfaces";
 
 export type BreadcrumbsType = {
     label: string;
@@ -16,6 +18,8 @@ type UseBreadcrumbReturnType = {
 
 export const useBreadcrumb = (): UseBreadcrumbReturnType => {
     const { useParams } = useRouterContext();
+    const { i18nProvider } = useContext(TranslationContext);
+
     const translate = useTranslate();
 
     const { resources, resource } = useResource();
@@ -71,7 +75,7 @@ export const useBreadcrumb = (): UseBreadcrumbReturnType => {
     if (action) {
         const key = `actions.${action}`;
         const actionLabel = translate(key);
-        if (actionLabel === key) {
+        if (typeof i18nProvider !== "undefined" && actionLabel === key) {
             console.warn(
                 `Breadcrumb missing translate key for the "${action}" action. Please add "actions.${action}" key to your translation file. For more information, see https://refine.dev/docs/core/hooks/useBreadcrumb/#i18n-support`,
             );


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

`useBreadcrumb` hook throws `console.warn` even if `i18nProvider` is not used

**Closing issues**

- #2103