### PR TITLE
fix: add dataProviderName support for edit and show crud components

### DIFF
--- a/.changeset/hot-apples-complain.md
+++ b/.changeset/hot-apples-complain.md
@@ -1,0 +1,6 @@
+---
+"@pankod/refine-antd": patch
+"@pankod/refine-mui": patch
+---
+
+Add `dataProviderName` property for `<RefreshButton>` and `<DeleteButton>` in `<Edit>` and `<Show>` CRUD components - #2096

--- a/packages/antd/src/components/crud/edit/index.tsx
+++ b/packages/antd/src/components/crud/edit/index.tsx
@@ -40,6 +40,7 @@ export interface EditProps {
     deleteButtonProps?: DeleteButtonProps;
     resource?: string;
     isLoading?: boolean;
+    dataProviderName?: string;
 }
 
 /**
@@ -60,6 +61,7 @@ export const Edit: React.FC<EditProps> = ({
     canDelete,
     resource: resourceFromProps,
     isLoading = false,
+    dataProviderName,
 }) => {
     const translate = useTranslate();
     const { goBack, list } = useNavigation();
@@ -108,6 +110,7 @@ export const Edit: React.FC<EditProps> = ({
                     <RefreshButton
                         resourceNameOrRouteName={resource.route}
                         recordItemId={id}
+                        dataProviderName={dataProviderName}
                     />
                 </Space>
             }
@@ -134,6 +137,7 @@ export const Edit: React.FC<EditProps> = ({
                                                         resource.name,
                                                 );
                                             }}
+                                            dataProviderName={dataProviderName}
                                             {...deleteButtonProps}
                                         />
                                     )}

--- a/packages/antd/src/components/crud/show/index.tsx
+++ b/packages/antd/src/components/crud/show/index.tsx
@@ -27,6 +27,7 @@ export interface ShowProps {
     pageHeaderProps?: PageHeaderProps;
     resource?: string;
     recordItemId?: BaseKey;
+    dataProviderName?: string;
 }
 
 /**
@@ -45,6 +46,7 @@ export const Show: React.FC<ShowProps> = ({
     pageHeaderProps,
     resource: resourceFromProps,
     recordItemId,
+    dataProviderName,
 }) => {
     const translate = useTranslate();
 
@@ -105,11 +107,13 @@ export const Show: React.FC<ShowProps> = ({
                             onSuccess={() =>
                                 list(resource.route ?? resource.name)
                             }
+                            dataProviderName={dataProviderName}
                         />
                     )}
                     <RefreshButton
                         resourceNameOrRouteName={resource.route}
                         recordItemId={id}
+                        dataProviderName={dataProviderName}
                     />
                 </Space>
             }

--- a/packages/mui/src/components/crud/edit/index.tsx
+++ b/packages/mui/src/components/crud/edit/index.tsx
@@ -51,6 +51,7 @@ export interface EditProps {
     cardContentProps?: CardContentProps;
     cardActionsProps?: CardActionsProps;
     breadcrumb?: React.ReactNode;
+    dataProviderName?: string;
 }
 
 /**
@@ -74,6 +75,7 @@ export const Edit: React.FC<EditProps> = ({
     cardContentProps,
     cardActionsProps,
     breadcrumb = <Breadcrumb />,
+    dataProviderName,
 }) => {
     const translate = useTranslate();
 
@@ -132,6 +134,7 @@ export const Edit: React.FC<EditProps> = ({
                         <RefreshButton
                             resourceNameOrRouteName={resource.route}
                             recordItemId={id}
+                            dataProviderName={dataProviderName}
                         />
                     </Box>
                 }
@@ -157,6 +160,7 @@ export const Edit: React.FC<EditProps> = ({
                                 onSuccess={() => {
                                     list(resource.route ?? resource.name);
                                 }}
+                                dataProviderName={dataProviderName}
                                 {...deleteButtonProps}
                             />
                         )}

--- a/packages/mui/src/components/crud/show/index.tsx
+++ b/packages/mui/src/components/crud/show/index.tsx
@@ -44,6 +44,7 @@ export interface ShowProps {
     cardContentProps?: CardContentProps;
     cardActionsProps?: CardActionsProps;
     breadcrumb?: React.ReactNode;
+    dataProviderName?: string;
 }
 
 /**
@@ -65,6 +66,7 @@ export const Show: React.FC<ShowProps> = ({
     cardContentProps,
     cardActionsProps,
     breadcrumb = <Breadcrumb />,
+    dataProviderName,
 }) => {
     const translate = useTranslate();
 
@@ -133,11 +135,13 @@ export const Show: React.FC<ShowProps> = ({
                                 onSuccess={() =>
                                     list(resource.route ?? resource.name)
                                 }
+                                dataProviderName={dataProviderName}
                             />
                         )}
                         <RefreshButton
                             resourceNameOrRouteName={resource.route}
                             recordItemId={id}
+                            dataProviderName={dataProviderName}
                         />
                     </Box>
                 }


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Added `dataProviderName` for `<RefreshButton>` and `<DeleteButton>` in `<Edit>` and `<Show>` CRUD components

**Closing issues**

- #2096