### PR TITLE
fix: `antd` type error for `useFileUploadState`

### DIFF
--- a/.changeset/clever-tomatoes-shake.md
+++ b/.changeset/clever-tomatoes-shake.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": patch
+---
+
+Removed unused cases in `useFileUploadState` and fixed conflicting type in `antd#UploadFileStatus` interface.

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ example/.cache
 examples/**/*/package-lock.json
 !examples/fineFoods/package-lock.json
 .next
+
+# cli tool
+/refine

--- a/packages/antd/src/hooks/useFileUploadState/index.ts
+++ b/packages/antd/src/hooks/useFileUploadState/index.ts
@@ -27,10 +27,6 @@ const mapStatusToLoading = (files: UploadChangeParam["fileList"]) => {
         switch (file.status) {
             case "uploading":
                 return true;
-            case "error":
-            case "done":
-            case "removed":
-            case "success":
             default:
                 return false;
         }


### PR DESCRIPTION
Updated `useFileUploadState` in `@pankod/refine-antd` to fix #2134. [antd@4.21.6](https://github.com/ant-design/ant-design/tree/4.21.6) updates the type `UploadFileStatus` and removes `removed` from the union which breaks the `@pankod/refine-antd` because of the unused cases in the switch block.