### PR TITLE
chore: add PR checklist to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**
 
-*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*
+_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._
 
 Please provide enough information so that others can review your pull request:
 
@@ -10,12 +10,23 @@ Explain the **details** for making this change. What existing problem does the p
 
 <!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
 
-**Test plan (required)**
+### Test plan (required)
 
 Demonstrate the code is solid. If not, please add `WIP:` in its title.
 
 <!-- Make sure tests pass. -->
 
-**Closing issues**
+### Closing issues
 
 Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
+
+### Self Check before Merge
+
+Please check all items below before review.
+
+-   [ ] Corresponding issues are created/updated or not needed
+-   [ ] Docs are updated/provided or not needed
+-   [ ] Examples are updated/provided or not needed
+-   [ ] TypeScript definitions are updated/provided or not needed
+-   [ ] Tests are updated/provided or not needed
+-   [ ] Changesets are provided or not needed


### PR DESCRIPTION
Updated PR Template with a simple checklist to make sure we don't skip any steps before merge.