### PR TITLE
fix: update casbin example

### DIFF
--- a/documentation/docs/guides-and-concepts/access-control.md
+++ b/documentation/docs/guides-and-concepts/access-control.md
@@ -25,7 +25,7 @@ We will be using **[Casbin](https://casbin.org/)** in this guide for users with 
 We need to install Casbin.
 
 ```bash
-npm install casbin.js --save
+npm install casbin
 ```
 :::caution
 To make this example more visual, we used the [`@pankod/refine-antd`](https://github.com/pankod/refine/tree/master/packages/refine-antd) package. If you are using Refine headless, you need to provide the components, hooks or helpers imported from the [`@pankod/refine-antd`](https://github.com/pankod/refine/tree/master/packages/refine-antd) package.
@@ -104,7 +104,7 @@ The way **[Casbin](https://casbin.org/)** works is that access rights are checke
 Let's add a model and a policy for a role **editor** that have **list** access for **posts** resource.
 
 ```ts title="src/accessControl.ts"
-import { newModel, MemoryAdapter } from "casbin.js";
+import { newModel, StringAdapter } from "casbin";
 
 export const model = newModel(`
 [request_definition]
@@ -139,7 +139,7 @@ Now we will implement the `can` method for `accessControlProvider` to integrate 
 ```tsx title="src/App.tsx"
 // ...
 // highlight-next-line
-import { newEnforcer } from "casbin.js";
+import { newEnforcer } from "casbin";
 
 // highlight-next-line
 import { model, adapter } from "./accessControl";

--- a/examples/accessControl/casbin/package.json
+++ b/examples/accessControl/casbin/package.json
@@ -10,12 +10,12 @@
     "@types/node": "^12.20.11",
     "@types/react": "^17.0.4",
     "@types/react-dom": "^17.0.4",
-    "casbin.js": "^1.0.1",
+    "casbin": "^5.15.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
-    "react-scripts": "^5.0.0",
+    "react-scripts": "^4.0.0",
     "typescript": "^4.4.3"
   },
   "scripts": {

--- a/examples/accessControl/casbin/src/App.tsx
+++ b/examples/accessControl/casbin/src/App.tsx
@@ -6,7 +6,7 @@ import {
 } from "@pankod/refine-antd";
 import dataProvider from "@pankod/refine-simple-rest";
 import routerProvider from "@pankod/refine-react-router-v6";
-import { newEnforcer } from "casbin.js";
+import { newEnforcer } from "casbin";
 import "@pankod/refine-antd/dist/styles.min.css";
 
 import { model, adapter } from "accessControl";

--- a/examples/accessControl/casbin/src/accessControl.ts
+++ b/examples/accessControl/casbin/src/accessControl.ts
@@ -1,4 +1,4 @@
-import { newModel, MemoryAdapter } from "casbin.js";
+import { newModel, StringAdapter } from "casbin";
 
 export const model = newModel(`
 [request_definition]
@@ -17,7 +17,7 @@ e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 m = g(r.sub, p.sub) && keyMatch(r.obj, p.obj) && regexMatch(r.act, p.act)
 `);
 
-export const adapter = new MemoryAdapter(`
+export const adapter = new StringAdapter(`
 p, admin, posts, (list)|(create)
 p, admin, posts/*, (edit)|(show)|(delete)
 p, admin, posts/*, field


### PR DESCRIPTION
Update casbin example with up to date casbin package. Used [`node-casbin`](https://github.com/casbin/node-casbin) instead of [`casbin.js`](https://github.com/casbin/casbin.js).

> **Note**
> `casbin` packages doesn't support react-script 5 so we downgraded react-script for this example.

closes #2140 