### PR TITLE
Disable telemetry on all examples.

### DIFF
--- a/examples/ably/src/App.tsx
+++ b/examples/ably/src/App.tsx
@@ -45,6 +45,7 @@ const App: React.FC = () => {
             Title={Title}
             notificationProvider={notificationProvider}
             Layout={Layout}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/accessControl/casbin/src/App.tsx
+++ b/examples/accessControl/casbin/src/App.tsx
@@ -87,6 +87,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/accessControl/cerbos/src/App.tsx
+++ b/examples/accessControl/cerbos/src/App.tsx
@@ -91,6 +91,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/antdAuditLog/src/App.tsx
+++ b/examples/antdAuditLog/src/App.tsx
@@ -110,6 +110,7 @@ const App: React.FC = () => {
                     });
                 },
             }}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/auditLogProvider/src/App.tsx
+++ b/examples/auditLogProvider/src/App.tsx
@@ -55,6 +55,7 @@ const App: React.FC = () => {
                     canDelete: true,
                 },
             ]}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/authProvider/auth0/src/App.tsx
+++ b/examples/authProvider/auth0/src/App.tsx
@@ -78,6 +78,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/authProvider/googleLogin/src/App.tsx
+++ b/examples/authProvider/googleLogin/src/App.tsx
@@ -84,6 +84,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/authProvider/otpLogin/src/App.tsx
+++ b/examples/authProvider/otpLogin/src/App.tsx
@@ -54,6 +54,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/authentication/src/App.tsx
+++ b/examples/authentication/src/App.tsx
@@ -61,6 +61,7 @@ const App: React.FC = () => {
             LoginPage={LoginPage}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/authorization/src/App.tsx
+++ b/examples/authorization/src/App.tsx
@@ -87,6 +87,7 @@ const App: React.FC = () => {
             LoginPage={LoginPage}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/base/antd/src/App.tsx
+++ b/examples/base/antd/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/base/headless/src/App.tsx
+++ b/examples/base/headless/src/App.tsx
@@ -18,6 +18,7 @@ const App: React.FC = () => {
                     edit: PostEdit,
                 },
             ]}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/base/mui/src/App.tsx
+++ b/examples/base/mui/src/App.tsx
@@ -40,6 +40,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/blog/ecommerce/pages/_app.tsx
+++ b/examples/blog/ecommerce/pages/_app.tsx
@@ -34,6 +34,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
                 reactQueryDevtoolConfig={{
                     position: "bottom-left",
                 }}
+                disableTelemetry={true}
             >
                 <ChakraProvider>
                     <Component {...pageProps} />

--- a/examples/blog/hackathonize/src/App.tsx
+++ b/examples/blog/hackathonize/src/App.tsx
@@ -82,6 +82,7 @@ function App() {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 }

--- a/examples/blog/invoiceGenerator/src/App.tsx
+++ b/examples/blog/invoiceGenerator/src/App.tsx
@@ -68,6 +68,7 @@ function App() {
                     icon: <FileAddOutlined />,
                 },
             ]}
+            disableTelemetry={true}
         />
     );
 }

--- a/examples/blog/issueTracker/src/App.tsx
+++ b/examples/blog/issueTracker/src/App.tsx
@@ -49,6 +49,7 @@ function App() {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 }

--- a/examples/blog/jobPosting/src/App.tsx
+++ b/examples/blog/jobPosting/src/App.tsx
@@ -50,6 +50,7 @@ function App() {
                     show: CompanyShow,
                 },
             ]}
+            disableTelemetry={true}
         />
     );
 }

--- a/examples/blog/mailSubscription/src/App.tsx
+++ b/examples/blog/mailSubscription/src/App.tsx
@@ -43,6 +43,7 @@ function App() {
             notificationProvider={notificationProvider}
             LoginPage={LoginPage}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 }

--- a/examples/blog/refeedback/src/App.tsx
+++ b/examples/blog/refeedback/src/App.tsx
@@ -39,6 +39,7 @@ function App() {
             notificationProvider={notificationProvider}
             LoginPage={LoginPage}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 }

--- a/examples/blog/refineflix/src/App.tsx
+++ b/examples/blog/refineflix/src/App.tsx
@@ -57,6 +57,7 @@ function App() {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 }

--- a/examples/blog/win95/src/App.tsx
+++ b/examples/blog/win95/src/App.tsx
@@ -46,6 +46,7 @@ function App() {
                         edit: CategoryEdit,
                     },
                 ]}
+                disableTelemetry={true}
             />
         </ThemeProvider>
     );

--- a/examples/calendar/src/App.tsx
+++ b/examples/calendar/src/App.tsx
@@ -20,6 +20,7 @@ const App: React.FC = () => {
                 },
             ]}
             Layout={Layout}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/cloud/src/App.tsx
+++ b/examples/cloud/src/App.tsx
@@ -45,6 +45,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/core/useImport/src/App.tsx
+++ b/examples/core/useImport/src/App.tsx
@@ -10,6 +10,7 @@ const App: React.FC = () => {
             dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
             routerProvider={routerProvider}
             resources={[{ name: "posts", list: DummyList }]}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/core/useModal/src/App.tsx
+++ b/examples/core/useModal/src/App.tsx
@@ -10,6 +10,7 @@ const App: React.FC = () => {
             dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
             routerProvider={routerProvider}
             resources={[{ name: "posts", list: DummyList }]}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/core/useSelect/src/App.tsx
+++ b/examples/core/useSelect/src/App.tsx
@@ -10,6 +10,7 @@ const App: React.FC = () => {
             dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
             routerProvider={routerProvider}
             resources={[{ name: "posts", list: DummyList }]}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/customPages/src/App.tsx
+++ b/examples/customPages/src/App.tsx
@@ -76,6 +76,7 @@ const App: React.FC = () => {
             LoginPage={LoginPage}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/customization/customFooter/src/App.tsx
+++ b/examples/customization/customFooter/src/App.tsx
@@ -40,6 +40,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/customization/customLogin/src/App.tsx
+++ b/examples/customization/customLogin/src/App.tsx
@@ -54,6 +54,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/customization/customSider/src/App.tsx
+++ b/examples/customization/customSider/src/App.tsx
@@ -57,6 +57,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/customization/customTheme/antd/src/App.tsx
+++ b/examples/customization/customTheme/antd/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/customization/customTheme/mui/src/App.tsx
+++ b/examples/customization/customTheme/mui/src/App.tsx
@@ -39,6 +39,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ColorModeContextProvider>

--- a/examples/customization/offLayoutArea/src/App.tsx
+++ b/examples/customization/offLayoutArea/src/App.tsx
@@ -57,6 +57,7 @@ const App: React.FC = () => {
             ]}
             notificationProvider={notificationProvider}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/customization/rtl/src/App.tsx
+++ b/examples/customization/rtl/src/App.tsx
@@ -32,6 +32,7 @@ const App: React.FC = () => {
                 notificationProvider={notificationProvider}
                 Layout={Layout}
                 catchAll={<ErrorComponent />}
+                disableTelemetry={true}
             />
         </ConfigProvider>
     );

--- a/examples/customization/topMenuLayout/src/App.tsx
+++ b/examples/customization/topMenuLayout/src/App.tsx
@@ -54,6 +54,7 @@ const App: React.FC = () => {
             ]}
             notificationProvider={notificationProvider}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/dataProvider/airtable/src/App.tsx
+++ b/examples/dataProvider/airtable/src/App.tsx
@@ -39,6 +39,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/dataProvider/altogic/src/App.tsx
+++ b/examples/dataProvider/altogic/src/App.tsx
@@ -55,6 +55,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/dataProvider/appwrite/src/App.tsx
+++ b/examples/dataProvider/appwrite/src/App.tsx
@@ -71,6 +71,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/dataProvider/hasura/src/App.tsx
+++ b/examples/dataProvider/hasura/src/App.tsx
@@ -48,6 +48,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/dataProvider/multiple/src/App.tsx
+++ b/examples/dataProvider/multiple/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/dataProvider/nestjsxCrud/src/App.tsx
+++ b/examples/dataProvider/nestjsxCrud/src/App.tsx
@@ -37,6 +37,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/dataProvider/nhost/src/App.tsx
+++ b/examples/dataProvider/nhost/src/App.tsx
@@ -102,6 +102,7 @@ const App: React.FC = () => {
                 Layout={Layout}
                 LoginPage={LoginPage}
                 catchAll={<ErrorComponent />}
+                disableTelemetry={true}
             />
         </NhostAuthProvider>
     );

--- a/examples/dataProvider/strapi-graphql/src/App.tsx
+++ b/examples/dataProvider/strapi-graphql/src/App.tsx
@@ -124,6 +124,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/dataProvider/strapi-v4/src/App.tsx
+++ b/examples/dataProvider/strapi-v4/src/App.tsx
@@ -104,6 +104,7 @@ const App: React.FC = () => {
             LoginPage={LoginPage}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/dataProvider/strapi/src/App.tsx
+++ b/examples/dataProvider/strapi/src/App.tsx
@@ -100,6 +100,7 @@ const App: React.FC = () => {
             LoginPage={LoginPage}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/dataProvider/supabase/src/App.tsx
+++ b/examples/dataProvider/supabase/src/App.tsx
@@ -88,6 +88,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/e2e/src/App.tsx
+++ b/examples/e2e/src/App.tsx
@@ -32,6 +32,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/field/useCheckboxGroup/src/App.tsx
+++ b/examples/field/useCheckboxGroup/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/field/useRadioGroup/src/App.tsx
+++ b/examples/field/useRadioGroup/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/field/useSelect/mui/src/App.tsx
+++ b/examples/field/useSelect/mui/src/App.tsx
@@ -36,6 +36,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </SnackbarProvider>
         </ThemeProvider>

--- a/examples/field/useSelect/src/App.tsx
+++ b/examples/field/useSelect/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/fineFoods/admin/antd/src/App.tsx
+++ b/examples/fineFoods/admin/antd/src/App.tsx
@@ -117,6 +117,7 @@ const App: React.FC = () => {
                 ]}
                 notificationProvider={notificationProvider}
                 catchAll={<ErrorComponent />}
+                disableTelemetry={true}
             ></Refine>
         </ConfigProvider>
     );

--- a/examples/fineFoods/admin/mui/src/App.tsx
+++ b/examples/fineFoods/admin/mui/src/App.tsx
@@ -113,6 +113,7 @@ const App: React.FC = () => {
                             icon: <StarBorderOutlined />,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ColorModeContextProvider>

--- a/examples/fineFoods/client/pages/_app.tsx
+++ b/examples/fineFoods/client/pages/_app.tsx
@@ -17,6 +17,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
             dataProvider={dataProvider(API_URL)}
             Layout={Layout}
             resources={[{ name: "users" }]}
+            disableTelemetry={true}
         >
             <Head>
                 <title>finefoods client example - refine</title>

--- a/examples/form/antd/customValidation/src/App.tsx
+++ b/examples/form/antd/customValidation/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/form/antd/useDrawerForm/src/App.tsx
+++ b/examples/form/antd/useDrawerForm/src/App.tsx
@@ -27,6 +27,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/form/antd/useForm/src/App.tsx
+++ b/examples/form/antd/useForm/src/App.tsx
@@ -29,6 +29,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/form/antd/useModalForm/src/App.tsx
+++ b/examples/form/antd/useModalForm/src/App.tsx
@@ -27,6 +27,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/form/antd/useStepsForm/src/App.tsx
+++ b/examples/form/antd/useStepsForm/src/App.tsx
@@ -29,6 +29,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/form/headless/saveAndContinue/src/App.tsx
+++ b/examples/form/headless/saveAndContinue/src/App.tsx
@@ -19,6 +19,7 @@ const App: React.FC = () => {
                     edit: PostEdit,
                 },
             ]}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/form/mui/useDrawerForm/src/App.tsx
+++ b/examples/form/mui/useDrawerForm/src/App.tsx
@@ -38,6 +38,7 @@ const App: React.FC = () => {
                             list: PostsList,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/form/mui/useForm/src/App.tsx
+++ b/examples/form/mui/useForm/src/App.tsx
@@ -40,6 +40,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/form/mui/useModalForm/src/App.tsx
+++ b/examples/form/mui/useModalForm/src/App.tsx
@@ -38,6 +38,7 @@ const App: React.FC = () => {
                             list: PostsList,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/form/mui/useStepsForm/src/App.tsx
+++ b/examples/form/mui/useStepsForm/src/App.tsx
@@ -40,6 +40,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/form/reactHookForm/useForm/src/App.tsx
+++ b/examples/form/reactHookForm/useForm/src/App.tsx
@@ -17,6 +17,7 @@ const App: React.FC = () => {
                     edit: PostEdit,
                 },
             ]}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/form/reactHookForm/useModalForm/src/App.tsx
+++ b/examples/form/reactHookForm/useModalForm/src/App.tsx
@@ -17,6 +17,7 @@ const App: React.FC = () => {
                     list: PostList,
                 },
             ]}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/form/reactHookForm/useStepsForm/src/App.tsx
+++ b/examples/form/reactHookForm/useStepsForm/src/App.tsx
@@ -17,6 +17,7 @@ const App: React.FC = () => {
                     edit: PostEdit,
                 },
             ]}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/i18n/nextjs/pages/_app.tsx
+++ b/examples/i18n/nextjs/pages/_app.tsx
@@ -47,6 +47,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         >
             <Component {...pageProps} />
         </Refine>

--- a/examples/i18n/react/src/App.tsx
+++ b/examples/i18n/react/src/App.tsx
@@ -43,6 +43,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/importExport/antd/src/App.tsx
+++ b/examples/importExport/antd/src/App.tsx
@@ -24,6 +24,7 @@ const App: React.FC = () => {
                     show: PostShow,
                 },
             ]}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/importExport/mui/src/App.tsx
+++ b/examples/importExport/mui/src/App.tsx
@@ -37,6 +37,7 @@ const App: React.FC = () => {
                             list: ImportList,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/inputs/customInputs/src/App.tsx
+++ b/examples/inputs/customInputs/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/inputs/datePicker/src/App.tsx
+++ b/examples/inputs/datePicker/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/javascript/src/App.js
+++ b/examples/javascript/src/App.js
@@ -30,6 +30,7 @@ const App = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         ></Refine>
     );
 };

--- a/examples/list/useSimpleList/src/App.tsx
+++ b/examples/list/useSimpleList/src/App.tsx
@@ -27,6 +27,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/multi-level-menu/src/App.tsx
+++ b/examples/multi-level-menu/src/App.tsx
@@ -42,6 +42,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/multi-tenancy/appwrite/src/App.tsx
+++ b/examples/multi-tenancy/appwrite/src/App.tsx
@@ -54,6 +54,7 @@ function App() {
                 notificationProvider={notificationProvider}
                 Layout={Layout}
                 catchAll={<ErrorComponent />}
+                disableTelemetry={true}
             />
         </StoreProvider>
     );

--- a/examples/multi-tenancy/strapi/src/App.tsx
+++ b/examples/multi-tenancy/strapi/src/App.tsx
@@ -41,6 +41,7 @@ const App: React.FC = () => {
                 LoginPage={LoginPage}
                 Layout={Layout}
                 catchAll={ErrorComponent}
+                disableTelemetry={true}
             />
         </StoreProvider>
     );

--- a/examples/mutationMode/src/App.tsx
+++ b/examples/mutationMode/src/App.tsx
@@ -41,6 +41,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/reactToastify/src/App.tsx
+++ b/examples/reactToastify/src/App.tsx
@@ -29,6 +29,7 @@ const App: React.FC = () => {
                     <ToastContainer />
                 </div>
             )}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/real-world-example/src/App.tsx
+++ b/examples/real-world-example/src/App.tsx
@@ -81,6 +81,7 @@ function App() {
                 { name: "editor", list: EditorPage },
             ]}
             Layout={Layout}
+            disableTelemetry={true}
         />
     );
 }

--- a/examples/refine-next/pages/_app.tsx
+++ b/examples/refine-next/pages/_app.tsx
@@ -41,6 +41,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
             LoginPage={LoginPage}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         >
             <Component {...pageProps} />
         </Refine>

--- a/examples/routerProvider/react-location/src/App.tsx
+++ b/examples/routerProvider/react-location/src/App.tsx
@@ -32,6 +32,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/search/src/App.tsx
+++ b/examples/search/src/App.tsx
@@ -46,6 +46,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/storybook/antd/.storybook/preview.js
+++ b/examples/storybook/antd/.storybook/preview.js
@@ -33,6 +33,7 @@ export const RefineWithLayout = (Story) => (
         list: Story,
       },
     ]}
+    disableTelemetry={true}
   />
 );
 
@@ -49,5 +50,6 @@ export const RefineWithoutLayout = (Story) => (
         list: Story,
       },
     ]}
+    disableTelemetry={true}
   />
 );

--- a/examples/storybook/antd/src/App.tsx
+++ b/examples/storybook/antd/src/App.tsx
@@ -18,6 +18,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/storybook/mui/.storybook/preview.js
+++ b/examples/storybook/mui/.storybook/preview.js
@@ -53,6 +53,7 @@ export const RefineWithLayout = (Story) => (
                     list: Story,
                 },
             ]}
+            disableTelemetry={true}
         />
     </ThemeProvider>
 );
@@ -79,6 +80,7 @@ export const RefineWithoutLayout = (Story) => (
                     list: Story,
                 },
             ]}
+            disableTelemetry={true}
         />
     </ThemeProvider>
 );

--- a/examples/storybook/mui/src/App.tsx
+++ b/examples/storybook/mui/src/App.tsx
@@ -10,6 +10,7 @@ const App: React.FC = () => {
         <Refine
             routerProvider={routerProvider}
             dataProvider={dataProvider(API_URL)}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/table/antd/advancedTable/src/App.tsx
+++ b/examples/table/antd/advancedTable/src/App.tsx
@@ -37,6 +37,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/table/antd/tableFilter/src/App.tsx
+++ b/examples/table/antd/tableFilter/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/table/antd/useDeleteMany/src/App.tsx
+++ b/examples/table/antd/useDeleteMany/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/table/antd/useEditableTable/src/App.tsx
+++ b/examples/table/antd/useEditableTable/src/App.tsx
@@ -27,6 +27,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/table/antd/useTable/src/App.tsx
+++ b/examples/table/antd/useTable/src/App.tsx
@@ -27,6 +27,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/table/antd/useUpdateMany/src/App.tsx
+++ b/examples/table/antd/useUpdateMany/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/table/mui/advancedTable/src/App.tsx
+++ b/examples/table/mui/advancedTable/src/App.tsx
@@ -50,6 +50,7 @@ const App: React.FC = () => {
                             options: { route: "data-grid", label: "Data Grid" },
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/table/mui/dataGridPro/src/App.tsx
+++ b/examples/table/mui/dataGridPro/src/App.tsx
@@ -36,6 +36,7 @@ const App: React.FC = () => {
                             list: PostsList,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/table/mui/tableFilter/src/App.tsx
+++ b/examples/table/mui/tableFilter/src/App.tsx
@@ -37,6 +37,7 @@ const App: React.FC = () => {
                             list: PostsList,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/table/mui/useDataGrid/src/App.tsx
+++ b/examples/table/mui/useDataGrid/src/App.tsx
@@ -36,6 +36,7 @@ const App: React.FC = () => {
                             list: PostsList,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/table/mui/useDeleteMany/src/App.tsx
+++ b/examples/table/mui/useDeleteMany/src/App.tsx
@@ -38,6 +38,7 @@ const App: React.FC = () => {
                             list: PostsList,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/table/mui/useUpdateMany/src/App.tsx
+++ b/examples/table/mui/useUpdateMany/src/App.tsx
@@ -36,6 +36,7 @@ const App: React.FC = () => {
                             list: PostsList,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/table/reactTable/advanced/src/App.tsx
+++ b/examples/table/reactTable/advanced/src/App.tsx
@@ -17,6 +17,7 @@ const App: React.FC = () => {
                     list: PostList,
                 },
             ]}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/table/reactTable/basic/src/App.tsx
+++ b/examples/table/reactTable/basic/src/App.tsx
@@ -11,6 +11,7 @@ const App: React.FC = () => {
             dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
             routerProvider={routerProvider}
             resources={[{ name: "posts", list: PostList }]}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/tutorial/antd/src/App.tsx
+++ b/examples/tutorial/antd/src/App.tsx
@@ -31,6 +31,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/tutorial/headless/src/App.tsx
+++ b/examples/tutorial/headless/src/App.tsx
@@ -22,6 +22,7 @@ const App: React.FC = () => {
                 },
             ]}
             Layout={Layout}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/tutorial/mui/src/App.tsx
+++ b/examples/tutorial/mui/src/App.tsx
@@ -39,6 +39,7 @@ const App: React.FC = () => {
                             canDelete: true,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/ui/useModal/src/App.tsx
+++ b/examples/ui/useModal/src/App.tsx
@@ -27,6 +27,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/upload/antd/base64/src/App.tsx
+++ b/examples/upload/antd/base64/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/upload/antd/multipart/src/App.tsx
+++ b/examples/upload/antd/multipart/src/App.tsx
@@ -30,6 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/upload/mui/base64/src/App.tsx
+++ b/examples/upload/mui/base64/src/App.tsx
@@ -40,6 +40,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/upload/mui/multipart/src/App.tsx
+++ b/examples/upload/mui/multipart/src/App.tsx
@@ -40,6 +40,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
+                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -28,6 +28,7 @@ const App: React.FC = () => {
                     canDelete: true,
                 },
             ]}
+            disableTelemetry={true}
         />
     );
 };

--- a/examples/web3/ethereumLogin/src/App.tsx
+++ b/examples/web3/ethereumLogin/src/App.tsx
@@ -35,6 +35,7 @@ function App() {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
+            disableTelemetry={true}
         />
     );
 }


### PR DESCRIPTION
We turn off telemetry in the examples to get telemetry data more accurately.