### PR TITLE
fix: #2154 support combination filters on graphql fields

### DIFF
--- a/.changeset/eighty-zoos-lie.md
+++ b/.changeset/eighty-zoos-lie.md
@@ -2,4 +2,4 @@
 "@pankod/refine-hasura": patch
 ---
 
-Add support for multiple operators on the same field
+Add support for multiple operators on the same field - #2154

--- a/.changeset/eighty-zoos-lie.md
+++ b/.changeset/eighty-zoos-lie.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-hasura": patch
+---
+
+Add support for multiple operators on the same field

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -80,7 +80,9 @@ export const generateFilters: any = (filters?: CrudFilters) => {
         }
 
         if (filter.operator !== "or") {
-            resultFilter[filter.field] = {};
+            if (!resultFilter.hasOwnProperty(filter.field)) {
+                resultFilter[filter.field] = {};
+            }
             resultFilter[filter.field][operator] = filter.value;
         } else {
             const orFilter: any = [];
@@ -94,7 +96,9 @@ export const generateFilters: any = (filters?: CrudFilters) => {
                         `Operator ${val.operator} is not supported`,
                     );
                 }
-                filterObject[val.field] = {};
+                if (!filterObject.hasOwnProperty(val.field)) {
+                    filterObject[val.field] = {};
+                }
                 filterObject[val.field][mapedOperator] = val.value;
                 orFilter.push(filterObject);
             });


### PR DESCRIPTION
Support adding multiple filters on fields in a graphql query:
```
{
  "where": {
    "createdAt": {
      "lte": "2022-07-20T05:20:00Z"
      "gte": "2022-07-20T00:00:00Z"
    }
  }
}  
```

### Test plan (required)
```
@pankod/refine-hasura: Test Suites: 10 passed, 10 total
@pankod/refine-hasura: Tests:       18 passed, 18 total
@pankod/refine-hasura: Snapshots:   0 total
@pankod/refine-hasura: Time:        22.228 s, estimated 24 s
@pankod/refine-hasura: Ran all test suites.
```
### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
