### PR TITLE
fix: `unhandled promise` in `@pankod/refine-antd#useForm`

### DIFF
--- a/.changeset/rare-ghosts-invite.md
+++ b/.changeset/rare-ghosts-invite.md
@@ -1,0 +1,7 @@
+---
+"@pankod/refine-antd": patch
+---
+
+Fixed the `Unhandled Promise` error on console for `useForm` with failed requests (Resolves #2156).
+
+This fix only catches the errors triggered by submitting the form, requests by invoking `onFinish` function should be handled by the user.

--- a/packages/antd/src/hooks/form/useForm.ts
+++ b/packages/antd/src/hooks/form/useForm.ts
@@ -144,7 +144,8 @@ export const useForm = <
         form: formSF.form,
         formProps: {
             ...formSF.formProps,
-            onFinish,
+            onFinish: (values: TVariables) =>
+                onFinish?.(values).catch((error) => error),
             onKeyUp,
             onValuesChange,
             initialValues: queryResult?.data?.data,


### PR DESCRIPTION
Fixed the `Unhandled Promise` error on console for `useForm` with failed requests (Resolves #2156).

This fix only catches the errors triggered by submitting the form, requests by invoking `onFinish` function should be handled by the user.


### Test plan (required)

Tests are unaffected.

### Closing issues

closes #2156 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
