### PR TITLE
fix(nhost): same field name filters not working with together

### DIFF
--- a/.changeset/kind-falcons-move.md
+++ b/.changeset/kind-falcons-move.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-nhost": patch
+---
+
+Add support for multiple operators on the same field

--- a/packages/nhost/src/dataProvider/index.ts
+++ b/packages/nhost/src/dataProvider/index.ts
@@ -81,7 +81,9 @@ export const generateFilters: any = (filters?: CrudFilters) => {
         }
 
         if (filter.operator !== "or") {
-            resultFilter[filter.field] = {};
+            if (!resultFilter.hasOwnProperty(filter.field)) {
+                resultFilter[filter.field] = {};
+            }
             resultFilter[filter.field][operator] = filter.value;
         } else {
             const orFilter: any = [];
@@ -95,7 +97,9 @@ export const generateFilters: any = (filters?: CrudFilters) => {
                         `Operator ${val.operator} is not supported`,
                     );
                 }
-                filterObject[val.field] = {};
+                if (!filterObject.hasOwnProperty(val.field)) {
+                    filterObject[val.field] = {};
+                }
                 filterObject[val.field][mapedOperator] = val.value;
                 orFilter.push(filterObject);
             });


### PR DESCRIPTION
When using multiple filter with a same field name, it is not apply both of them it is only accept the latest. This PR fix the issue.