### PR TITLE
fix: `useForm` redirecting to wrong url

### DIFF
--- a/.changeset/poor-coats-sleep.md
+++ b/.changeset/poor-coats-sleep.md
@@ -2,6 +2,6 @@
 "@pankod/refine-core": patch
 ---
 
-Fix redirection after submit in `useForm`. Both `edit` and `create` will operate to `list` (it was `edit` previously)
+Fix redirection after submit in `useForm`. Both `edit` and `create` will redirect to `list` (it was `edit` previously)
 
 Resolves #2123

--- a/.changeset/poor-coats-sleep.md
+++ b/.changeset/poor-coats-sleep.md
@@ -1,0 +1,7 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fix redirection after submit in `useForm`. Both `edit` and `create` will operate to `list` (it was `edit` previously)
+
+Resolves #2123

--- a/packages/core/src/hooks/form/useForm.ts
+++ b/packages/core/src/hooks/form/useForm.ts
@@ -156,12 +156,7 @@ export const useForm = <
     const isEdit = action === "edit";
     const isClone = action === "clone";
 
-    const redirect =
-        redirectFromProps !== undefined
-            ? redirectFromProps
-            : isEdit
-            ? "list"
-            : "edit";
+    const redirect = redirectFromProps ?? "list";
 
     const enableQuery = id !== undefined && (isEdit || isClone);
 


### PR DESCRIPTION
Fix redirection after submit in `useForm`. Both `edit` and `create` will redirect to `list` (it was `edit` previously)

### Test plan (required)

Tests are not affected

### Closing issues

Resolves #2123

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
