### PR TITLE
feat: success/error notifications by API response

### DIFF
--- a/.changeset/beige-numbers-wash.md
+++ b/.changeset/beige-numbers-wash.md
@@ -1,0 +1,28 @@
+---
+"@pankod/refine-core": minor
+---
+
+Update notification props in data hooks of `@pankod/refine-core` to cover dynamic notifications.
+
+Now users will be able to show notifications according to the API response by assigning a function which returns `OpenNotificationParams` instead of an `OpenNotificationParams` object.
+
+**Example**
+
+```tsx
+{
+    const { mutate } = useCreate({
+        /* ... */
+        successNotification: (data, values, resource) => ({
+            message: data?.message ?? "Success!",
+            type: "success",
+            description: data?.description;
+        }),
+        errorNotification: (error, values, resource) => ({
+            message: error?.message ?? error?.code ?? "Error!",
+            type: "error",
+            description: error?.reason;
+        })
+        /* ... */
+    });
+}
+```

--- a/documentation/docs/core/interfaces.md
+++ b/documentation/docs/core/interfaces.md
@@ -150,8 +150,8 @@ ButtonProps
 
 | Key                 | Type                                                                                 |
 | ------------------- | ------------------------------------------------------------------------------------ |
-| successNotification | [Notification Properties](https://ant.design/components/notification/#API) & `false` |
-| errorNotification   | [Notification Properties](https://ant.design/components/notification/#API) & `false` |
+| successNotification | `(data?: TData, values?: TVariables, resource?: string) => NotificationProperties` \| [Notification Properties](https://ant.design/components/notification/#API) \| `false` |
+| errorNotification   | `(error?: TError, values?: TVariables, resource?: string) => NotificationProperties` \| [Notification Properties](https://ant.design/components/notification/#API) \| `false` |
 
 ## MetaDataQuery
 

--- a/packages/core/src/hooks/data/useCreate.ts
+++ b/packages/core/src/hooks/data/useCreate.ts
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationResult, useQueryClient } from "react-query";
+import { useMutation, UseMutationResult } from "react-query";
 import pluralize from "pluralize";
 
 import {
@@ -97,7 +97,12 @@ export const useCreate = <
             ) => {
                 const resourceSingular = pluralize.singular(resource);
 
-                handleNotification(successNotificationFromProp, {
+                const notificationConfig =
+                    typeof successNotificationFromProp === "function"
+                        ? successNotificationFromProp(data, values, resource)
+                        : successNotificationFromProp;
+
+                handleNotification(notificationConfig, {
                     key: `create-${resource}-notification`,
                     message: translate(
                         "notifications.createSuccess",
@@ -144,12 +149,21 @@ export const useCreate = <
             },
             onError: (
                 err: TError,
-                { resource, errorNotification: errorNotificationFromProp },
+                {
+                    resource,
+                    errorNotification: errorNotificationFromProp,
+                    values,
+                },
             ) => {
                 checkError(err);
                 const resourceSingular = pluralize.singular(resource);
 
-                handleNotification(errorNotificationFromProp, {
+                const notificationConfig =
+                    typeof errorNotificationFromProp === "function"
+                        ? errorNotificationFromProp(err, values, resource)
+                        : errorNotificationFromProp;
+
+                handleNotification(notificationConfig, {
                     key: `create-${resource}-notification`,
                     description: err.message,
                     message: translate(

--- a/packages/core/src/hooks/data/useCreateMany.ts
+++ b/packages/core/src/hooks/data/useCreateMany.ts
@@ -84,11 +84,17 @@ export const useCreateMany = <
                     successNotification,
                     dataProviderName,
                     invalidates = ["list", "many"],
+                    values,
                 },
             ) => {
                 const resourcePlural = pluralize.plural(resource);
 
-                handleNotification(successNotification, {
+                const notificationConfig =
+                    typeof successNotification === "function"
+                        ? successNotification(response, values, resource)
+                        : successNotification;
+
+                handleNotification(notificationConfig, {
                     key: `createMany-${resource}-notification`,
                     message: translate(
                         "notifications.createSuccess",
@@ -123,8 +129,13 @@ export const useCreateMany = <
                     date: new Date(),
                 });
             },
-            onError: (err: TError, { resource, errorNotification }) => {
-                handleNotification(errorNotification, {
+            onError: (err: TError, { resource, errorNotification, values }) => {
+                const notificationConfig =
+                    typeof errorNotification === "function"
+                        ? errorNotification(err, values, resource)
+                        : errorNotification;
+
+                handleNotification(notificationConfig, {
                     key: `createMany-${resource}-notification`,
                     description: err.message,
                     message: translate(

--- a/packages/core/src/hooks/data/useDelete.ts
+++ b/packages/core/src/hooks/data/useDelete.ts
@@ -261,7 +261,12 @@ export const useDelete = <
                 // Remove the queries from the cache:
                 queryClient.removeQueries(context?.queryKey.detail(id));
 
-                handleNotification(successNotification, {
+                const notificationConfig =
+                    typeof successNotification === "function"
+                        ? successNotification(_data, id, resource)
+                        : successNotification;
+
+                handleNotification(notificationConfig, {
                     key: `${id}-${resource}-notification`,
                     description: translate("notifications.success", "Success"),
                     message: translate(
@@ -319,7 +324,12 @@ export const useDelete = <
 
                     const resourceSingular = pluralize.singular(resource ?? "");
 
-                    handleNotification(errorNotification, {
+                    const notificationConfig =
+                        typeof errorNotification === "function"
+                            ? errorNotification(err, id, resource)
+                            : errorNotification;
+
+                    handleNotification(notificationConfig, {
                         key: `${id}-${resource}-notification`,
                         message: translate(
                             "notifications.deleteError",

--- a/packages/core/src/hooks/data/useDeleteMany.ts
+++ b/packages/core/src/hooks/data/useDeleteMany.ts
@@ -275,7 +275,12 @@ export const useDeleteMany = <
                     queryClient.removeQueries(context?.queryKey.detail(id)),
                 );
 
-                handleNotification(successNotification, {
+                const notificationConfig =
+                    typeof successNotification === "function"
+                        ? successNotification(_data, ids, resource)
+                        : successNotification;
+
+                handleNotification(notificationConfig, {
                     key: `${ids}-${resource}-notification`,
                     description: translate("notifications.success", "Success"),
                     message: translate(
@@ -315,7 +320,12 @@ export const useDeleteMany = <
                     checkError(err);
                     const resourceSingular = pluralize.singular(resource);
 
-                    handleNotification(errorNotification, {
+                    const notificationConfig =
+                        typeof errorNotification === "function"
+                            ? errorNotification(err, ids, resource)
+                            : errorNotification;
+
+                    handleNotification(notificationConfig, {
                         key: `${ids}-${resource}-notification`,
                         message: translate(
                             "notifications.deleteError",

--- a/packages/core/src/hooks/data/useMany.ts
+++ b/packages/core/src/hooks/data/useMany.ts
@@ -7,7 +7,7 @@ import {
     HttpError,
     MetaDataQuery,
     LiveModeProps,
-    OpenNotificationParams,
+    SuccessErrorNotification,
 } from "../../interfaces";
 import {
     useTranslate,
@@ -22,11 +22,10 @@ export type UseManyProps<TData, TError> = {
     resource: string;
     ids: BaseKey[];
     queryOptions?: UseQueryOptions<GetManyResponse<TData>, TError>;
-    successNotification?: OpenNotificationParams | false;
-    errorNotification?: OpenNotificationParams | false;
     metaData?: MetaDataQuery;
     dataProviderName?: string;
-} & LiveModeProps;
+} & SuccessErrorNotification &
+    LiveModeProps;
 
 /**
  * `useMany` is a modified version of `react-query`'s {@link https://react-query.tanstack.com/guides/queries `useQuery`} used for retrieving multiple items from a `resource`.
@@ -90,13 +89,24 @@ export const useMany = <
             ...queryOptions,
             onSuccess: (data) => {
                 queryOptions?.onSuccess?.(data);
-                handleNotification(successNotification);
+
+                const notificationConfig =
+                    typeof successNotification === "function"
+                        ? successNotification(data, ids, resource)
+                        : successNotification;
+
+                handleNotification(notificationConfig);
             },
             onError: (err: TError) => {
                 checkError(err);
                 queryOptions?.onError?.(err);
 
-                handleNotification(errorNotification, {
+                const notificationConfig =
+                    typeof errorNotification === "function"
+                        ? errorNotification(err, ids, resource)
+                        : errorNotification;
+
+                handleNotification(notificationConfig, {
                     key: `${ids[0]}-${resource}-getMany-notification`,
                     message: translate(
                         "notifications.error",

--- a/packages/core/src/hooks/data/useOne.ts
+++ b/packages/core/src/hooks/data/useOne.ts
@@ -7,7 +7,7 @@ import {
     BaseKey,
     MetaDataQuery,
     LiveModeProps,
-    OpenNotificationParams,
+    SuccessErrorNotification,
 } from "../../interfaces";
 import {
     useCheckError,
@@ -22,11 +22,10 @@ export type UseOneProps<TData, TError> = {
     resource: string;
     id: BaseKey;
     queryOptions?: UseQueryOptions<GetOneResponse<TData>, TError>;
-    successNotification?: OpenNotificationParams | false;
-    errorNotification?: OpenNotificationParams | false;
     metaData?: MetaDataQuery;
     dataProviderName?: string;
-} & LiveModeProps;
+} & SuccessErrorNotification &
+    LiveModeProps;
 
 /**
  * `useOne` is a modified version of `react-query`'s {@link https://react-query.tanstack.com/guides/queries `useQuery`} used for retrieving single items from a `resource`.
@@ -85,13 +84,24 @@ export const useOne = <
             ...queryOptions,
             onSuccess: (data) => {
                 queryOptions?.onSuccess?.(data);
-                handleNotification(successNotification);
+
+                const notificationConfig =
+                    typeof successNotification === "function"
+                        ? successNotification(data, { id, metaData }, resource)
+                        : successNotification;
+
+                handleNotification(notificationConfig);
             },
             onError: (err: TError) => {
                 checkError(err);
                 queryOptions?.onError?.(err);
 
-                handleNotification(errorNotification, {
+                const notificationConfig =
+                    typeof errorNotification === "function"
+                        ? errorNotification(err, { id, metaData }, resource)
+                        : errorNotification;
+
+                handleNotification(notificationConfig, {
                     key: `${id}-${resource}-getOne-notification`,
                     message: translate(
                         "notifications.error",

--- a/packages/core/src/hooks/data/useUpdate.ts
+++ b/packages/core/src/hooks/data/useUpdate.ts
@@ -283,7 +283,12 @@ export const useUpdate = <
             ) => {
                 const resourceSingular = pluralize.singular(resource);
 
-                handleNotification(successNotification, {
+                const notificationConfig =
+                    typeof successNotification === "function"
+                        ? successNotification(data, { id, values }, resource)
+                        : successNotification;
+
+                handleNotification(notificationConfig, {
                     key: `${id}-${resource}-notification`,
                     description: translate(
                         "notifications.success",
@@ -343,7 +348,7 @@ export const useUpdate = <
             },
             onError: (
                 err: TError,
-                { id, resource, errorNotification },
+                { id, resource, errorNotification, values },
                 context,
             ) => {
                 // set back the queries to the context:
@@ -359,7 +364,12 @@ export const useUpdate = <
 
                     const resourceSingular = pluralize.singular(resource);
 
-                    handleNotification(errorNotification, {
+                    const notificationConfig =
+                        typeof errorNotification === "function"
+                            ? errorNotification(err, { id, values }, resource)
+                            : errorNotification;
+
+                    handleNotification(notificationConfig, {
                         key: `${id}-${resource}-notification`,
                         message: translate(
                             "notifications.editError",

--- a/packages/core/src/hooks/data/useUpdateMany.ts
+++ b/packages/core/src/hooks/data/useUpdateMany.ts
@@ -292,10 +292,18 @@ export const useUpdateMany = <
                     payload: { id: ids, resource },
                 });
             },
-            onSuccess: (data, { ids, resource, successNotification }) => {
+            onSuccess: (
+                data,
+                { ids, resource, successNotification, values },
+            ) => {
                 const resourceSingular = pluralize.singular(resource);
 
-                handleNotification(successNotification, {
+                const notificationConfig =
+                    typeof successNotification === "function"
+                        ? successNotification(data, { ids, values }, resource)
+                        : successNotification;
+
+                handleNotification(notificationConfig, {
                     key: `${ids}-${resource}-notification`,
                     description: translate(
                         "notifications.success",
@@ -325,7 +333,7 @@ export const useUpdateMany = <
             },
             onError: (
                 err: TError,
-                { ids, resource, errorNotification },
+                { ids, resource, errorNotification, values },
                 context,
             ) => {
                 // set back the queries to the context:
@@ -340,7 +348,12 @@ export const useUpdateMany = <
 
                     const resourceSingular = pluralize.singular(resource);
 
-                    handleNotification(errorNotification, {
+                    const notificationConfig =
+                        typeof errorNotification === "function"
+                            ? errorNotification(err, { ids, values }, resource)
+                            : errorNotification;
+
+                    handleNotification(notificationConfig, {
                         key: `${ids}-${resource}-updateMany-error-notification`,
                         message: translate(
                             "notifications.editError",

--- a/packages/core/src/interfaces/successErrorNotification.ts
+++ b/packages/core/src/interfaces/successErrorNotification.ts
@@ -1,6 +1,24 @@
 import { OpenNotificationParams } from ".";
 
-export type SuccessErrorNotification = {
-    successNotification?: OpenNotificationParams | false;
-    errorNotification?: OpenNotificationParams | false;
+export type SuccessErrorNotification<
+    TData = unknown,
+    TError = unknown,
+    TVariables = unknown,
+> = {
+    successNotification?:
+        | OpenNotificationParams
+        | false
+        | ((
+              data?: TData,
+              values?: TVariables,
+              resource?: string,
+          ) => OpenNotificationParams);
+    errorNotification?:
+        | OpenNotificationParams
+        | false
+        | ((
+              error?: TError,
+              values?: TVariables,
+              resource?: string,
+          ) => OpenNotificationParams);
 };


### PR DESCRIPTION
Update notification props in data hooks of `@pankod/refine-core` to cover dynamic notifications.

Now users will be able to show notifications according to the API response by assigning a function which returns `OpenNotificationParams` instead of an `OpenNotificationParams` object.

### Example

```tsx
{
    const { mutate } = useCreate({
        /* ... */
        successNotification: (data, values, resource) => ({
            message: data?.message ?? "Success!",
            type: "success",
            description: data?.description;
        }),
        errorNotification: (error, values, resource) => ({
            message: error?.message ?? error?.code ?? "Error!",
            type: "error",
            description: error?.reason;
        })
        /* ... */
    });
}
```


### Test plan (required)

Tests are not affected.

<!-- Make sure tests pass. -->

### Closing issues

Resolves #2131 - Rest of this issue is going to be marked as not planned to encourage error handling on data providers.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
