### PR TITLE
Fix react-dom dependency version

### DIFF
--- a/.changeset/neat-badgers-exist.md
+++ b/.changeset/neat-badgers-exist.md
@@ -2,7 +2,7 @@
 "@pankod/refine-kbar": patch
 ---
 
-changed `react-dom` version
+Fixed `react-dom` dependency version
 
 ```diff
 - "react-dom": "^17.0.4"

--- a/.changeset/neat-badgers-exist.md
+++ b/.changeset/neat-badgers-exist.md
@@ -1,0 +1,10 @@
+---
+"@pankod/refine-kbar": patch
+---
+
+changed `react-dom` version
+
+```diff
+- "react-dom": "^17.0.4"
++ "react-dom": "^17.0.0 || ^18.0.0"
+```

--- a/.changeset/shiny-crews-flow.md
+++ b/.changeset/shiny-crews-flow.md
@@ -2,7 +2,7 @@
 "@pankod/refine-demo-sidebar": patch
 ---
 
-changed `react-dom` version
+Fixed `react-dom` dependency version
 
 ```diff
 - "react-dom": "^17.0.4"

--- a/.changeset/shiny-crews-flow.md
+++ b/.changeset/shiny-crews-flow.md
@@ -1,0 +1,10 @@
+---
+"@pankod/refine-demo-sidebar": patch
+---
+
+changed `react-dom` version
+
+```diff
+- "react-dom": "^17.0.4"
++ "react-dom": "^17.0.0 || ^18.0.0"
+```

--- a/.changeset/ten-feet-end.md
+++ b/.changeset/ten-feet-end.md
@@ -1,0 +1,12 @@
+---
+"@pankod/refine-antd-audit-log": patch
+---
+
+changed `react` and `react-dom` version
+
+```diff
+- "react": "^17.0.2",
+- "react-dom": "^17.0.4"
++ "react": "^17.0.0 || ^18.0.0",
++ "react-dom": "^17.0.0 || ^18.0.0"
+```

--- a/.changeset/ten-feet-end.md
+++ b/.changeset/ten-feet-end.md
@@ -2,7 +2,7 @@
 "@pankod/refine-antd-audit-log": patch
 ---
 
-changed `react` and `react-dom` version
+Fixed `react-dom` dependency version
 
 ```diff
 - "react": "^17.0.2",

--- a/packages/antd-audit-log/package.json
+++ b/packages/antd-audit-log/package.json
@@ -19,8 +19,8 @@
         "prepare": "npm run build"
     },
     "peerDependencies": {
-        "react": "^17.0.2",
-        "react-dom": "^17.0.4"
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
     },
     "author": "Pankod",
     "module": "dist/esm/index.js",

--- a/packages/demo-sidebar/package.json
+++ b/packages/demo-sidebar/package.json
@@ -1,54 +1,54 @@
 {
-  "name": "@pankod/refine-demo-sidebar",
-  "description": "refine demo sidebar. refine is a React-based framework for building internal tools, rapidly. It ships with Ant Design System, an enterprise-level UI toolkit.",
-  "version": "3.25.0",
-  "license": "MIT",
-  "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
-  "private": false,
-  "files": [
-    "dist",
-    "src"
-  ],
-  "engines": {
-    "node": ">=10"
-  },
-  "scripts": {
-    "start": "tsup --watch --dts --format esm,cjs,iife --legacy-output",
-    "build": "tsup --dts --format esm,cjs,iife --minify --legacy-output",
-    "prepare": "npm run build"
-  },
-  "peerDependencies": {
-    "@pankod/refine-antd": "^3.23.2",
-    "@pankod/refine-core": "^3.23.2",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.4"
-  },
-  "author": "Pankod",
-  "module": "dist/esm/index.js",
-  "devDependencies": {
-    "@esbuild-plugins/node-resolve": "^0.1.4",
-    "@testing-library/jest-dom": "^5.12.0",
-    "@testing-library/react": "^11.2.6",
-    "@types/react": "^17.0.4",
-    "@types/react-dom": "^17.0.4",
-    "jest": "^27.5.1",
-    "ts-jest": "^27.1.3",
-    "tslib": "^2.3.1",
-    "tsup": "^5.11.13",
-    "typescript": "^4.4.3"
-  },
-  "dependencies": {
-    "@pankod/refine-antd": "^3.25.0",
-    "@pankod/refine-core": "^3.25.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/pankod/refine.git",
-    "directory": "packages/demo-sidebar"
-  },
-  "gitHead": "829f5a516f98c06f666d6be3e6e6099c75c07719",
-  "publishConfig": {
-    "access": "public"
-  }
+    "name": "@pankod/refine-demo-sidebar",
+    "description": "refine demo sidebar. refine is a React-based framework for building internal tools, rapidly. It ships with Ant Design System, an enterprise-level UI toolkit.",
+    "version": "3.25.0",
+    "license": "MIT",
+    "main": "dist/index.js",
+    "typings": "dist/index.d.ts",
+    "private": false,
+    "files": [
+        "dist",
+        "src"
+    ],
+    "engines": {
+        "node": ">=10"
+    },
+    "scripts": {
+        "start": "tsup --watch --dts --format esm,cjs,iife --legacy-output",
+        "build": "tsup --dts --format esm,cjs,iife --minify --legacy-output",
+        "prepare": "npm run build"
+    },
+    "peerDependencies": {
+        "@pankod/refine-antd": "^3.23.2",
+        "@pankod/refine-core": "^3.23.2",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+    },
+    "author": "Pankod",
+    "module": "dist/esm/index.js",
+    "devDependencies": {
+        "@esbuild-plugins/node-resolve": "^0.1.4",
+        "@testing-library/jest-dom": "^5.12.0",
+        "@testing-library/react": "^11.2.6",
+        "@types/react": "^17.0.4",
+        "@types/react-dom": "^17.0.4",
+        "jest": "^27.5.1",
+        "ts-jest": "^27.1.3",
+        "tslib": "^2.3.1",
+        "tsup": "^5.11.13",
+        "typescript": "^4.4.3"
+    },
+    "dependencies": {
+        "@pankod/refine-antd": "^3.25.0",
+        "@pankod/refine-core": "^3.25.0"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/pankod/refine.git",
+        "directory": "packages/demo-sidebar"
+    },
+    "gitHead": "829f5a516f98c06f666d6be3e6e6099c75c07719",
+    "publishConfig": {
+        "access": "public"
+    }
 }

--- a/packages/kbar/package.json
+++ b/packages/kbar/package.json
@@ -22,7 +22,7 @@
     "peerDependencies": {
         "@pankod/refine-core": "^3.23.2",
         "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.4"
+        "react-dom": "^17.0.0 || ^18.0.0"
     },
     "author": "Pankod",
     "module": "dist/esm/index.js",


### PR DESCRIPTION
In this PR, Fixed `react` and `react-dom` dependency versions.


- "@pankod/refine-demo-sidebar"
- "@pankod/refine-kbar"

```diff
- "react-dom": "^17.0.4"
+ "react-dom": "^17.0.0 || ^18.0.0"
```


- "@pankod/refine-antd-audit-log"

```diff
- "react": "^17.0.2",
- "react-dom": "^17.0.4"
+ "react": "^17.0.0 || ^18.0.0",
+ "react-dom": "^17.0.0 || ^18.0.0"
```


