### PR TITLE
fix: useModal hook doesn't return "modalProps"

### DIFF
--- a/.changeset/breezy-teachers-smile.md
+++ b/.changeset/breezy-teachers-smile.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": patch
+---
+
+Fix `useModal` hook doesn't return `modalProps`

--- a/packages/antd/src/hooks/modal/useModal/index.tsx
+++ b/packages/antd/src/hooks/modal/useModal/index.tsx
@@ -26,6 +26,7 @@ export const useModal = ({
                 close();
             },
             visible,
+            ...modalProps,
         },
         show,
         close,

--- a/packages/antd/src/hooks/modal/useModal/index.tsx
+++ b/packages/antd/src/hooks/modal/useModal/index.tsx
@@ -21,12 +21,12 @@ export const useModal = ({
 
     return {
         modalProps: {
+            ...modalProps,
             onCancel: (e: React.MouseEvent<HTMLElement>) => {
                 modalProps.onCancel?.(e);
                 close();
             },
             visible,
-            ...modalProps,
         },
         show,
         close,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

- #2202 

### Closing issues

- #2202 
- 
### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
