### PR TITLE
fix: internal packages dependencies

### DIFF
--- a/.changeset/nasty-grapes-reflect.md
+++ b/.changeset/nasty-grapes-reflect.md
@@ -1,0 +1,30 @@
+---
+"@pankod/refine-ably": minor
+"@pankod/refine-airtable": minor
+"@pankod/refine-altogic": minor
+"@pankod/refine-antd": minor
+"@pankod/refine-appwrite": minor
+"@pankod/refine-cloud": minor
+"@pankod/refine-core": minor
+"@pankod/refine-demo-sidebar": minor
+"@pankod/refine-graphql": minor
+"@pankod/refine-hasura": minor
+"@pankod/refine-kbar": minor
+"@pankod/refine-mui": minor
+"@pankod/refine-nestjsx-crud": minor
+"@pankod/refine-nextjs-router": minor
+"@pankod/refine-nhost": minor
+"@pankod/refine-react-hook-form": minor
+"@pankod/refine-react-location": minor
+"@pankod/refine-react-router-v6": minor
+"@pankod/refine-react-table": minor
+"@pankod/refine-simple-rest": minor
+"@pankod/refine-strapi": minor
+"@pankod/refine-strapi-graphql": minor
+"@pankod/refine-strapi-v4": minor
+"@pankod/refine-supabase": minor
+---
+
+All of the refine packages have dependencies on the `@pankod/refine-core` package. So far we have managed these dependencies with `peerDependencies` + `dependencies` but this causes issues like #2183. (having more than one @pankod/refine-core version in node_modules and creating different instances)
+
+Managing as `peerDependencies` + `devDependencies` seems like the best way for now to avoid such issues.

--- a/packages/ably/package.json
+++ b/packages/ably/package.json
@@ -22,6 +22,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "nock": "^13.1.3",
@@ -30,7 +31,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.25.0",
     "ably": "^1.2.15"
   },
   "peerDependencies": {

--- a/packages/airtable/package.json
+++ b/packages/airtable/package.json
@@ -22,6 +22,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "nock": "^13.1.3",
@@ -30,7 +31,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.36.0",
     "@qualifyze/airtable-formulator": "^1.0.1",
     "airtable": "^0.11.1",
     "asyncairtable": "^2.1.0",

--- a/packages/altogic/package.json
+++ b/packages/altogic/package.json
@@ -22,6 +22,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "nock": "^13.1.3",
@@ -30,7 +31,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.36.0",
     "axios": "^0.26.1",
     "query-string": "^7.1.1"
   },

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -21,6 +21,7 @@
         "react-dom": "^17.0.0 || ^18.0.0"
     },
     "devDependencies": {
+        "@pankod/refine-core": "^3.23.2",
         "@esbuild-plugins/node-resolve": "^0.1.4",
         "@testing-library/jest-dom": "^5.12.0",
         "@testing-library/react": "^11.2.6",
@@ -42,7 +43,6 @@
     },
     "dependencies": {
         "@ant-design/icons": "^4.5.0",
-        "@pankod/refine-core": "^3.44.0",
         "antd": "^4.17.1",
         "dayjs": "^1.10.7",
         "react-markdown": "^6.0.1",

--- a/packages/appwrite/package.json
+++ b/packages/appwrite/package.json
@@ -21,6 +21,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "nock": "^13.1.3",
@@ -29,7 +30,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.36.0",
     "appwrite": "^7.0.0"
   },
   "peerDependencies": {

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -29,6 +29,7 @@
     },
     "devDependencies": {
         "@pankod/refine-core": "^3.23.2",
+        "@pankod/refine-sdk": "^0.0.25",
         "@esbuild-plugins/node-resolve": "^0.1.4",
         "@types/lodash": "^4.14.171",
         "jest": "^27.5.1",

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -28,6 +28,7 @@
         "react-dom": "^17.0.0 || ^18.0.0"
     },
     "devDependencies": {
+        "@pankod/refine-core": "^3.23.2",
         "@esbuild-plugins/node-resolve": "^0.1.4",
         "@types/lodash": "^4.14.171",
         "jest": "^27.5.1",
@@ -37,8 +38,6 @@
         "tsup": "^5.11.13"
     },
     "dependencies": {
-        "@pankod/refine-core": "^3.34.0",
-        "@pankod/refine-sdk": "^0.0.25",
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.21"
     },

--- a/packages/demo-sidebar/package.json
+++ b/packages/demo-sidebar/package.json
@@ -27,6 +27,8 @@
     "author": "Pankod",
     "module": "dist/esm/index.js",
     "devDependencies": {
+        "@pankod/refine-core": "^3.23.2",
+        "@pankod/refine-antd": "^3.23.2",
         "@esbuild-plugins/node-resolve": "^0.1.4",
         "@testing-library/jest-dom": "^5.12.0",
         "@testing-library/react": "^11.2.6",
@@ -37,10 +39,6 @@
         "tslib": "^2.3.1",
         "tsup": "^5.11.13",
         "typescript": "^4.4.3"
-    },
-    "dependencies": {
-        "@pankod/refine-antd": "^3.25.0",
-        "@pankod/refine-core": "^3.25.0"
     },
     "repository": {
         "type": "git",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -22,6 +22,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@types/pluralize": "^0.0.29",
     "jest": "^27.5.1",
@@ -31,7 +32,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.42.0",
     "camelcase": "^6.2.0",
     "gql-query-builder": "^3.5.5",
     "graphql": "^15.6.1",

--- a/packages/hasura/package.json
+++ b/packages/hasura/package.json
@@ -22,6 +22,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "nock": "^13.1.3",
@@ -31,7 +32,6 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.42.0",
     "gql-query-builder": "^3.5.5",
     "graphql": "^15.6.1",
     "graphql-request": "^4.3.0",

--- a/packages/kbar/package.json
+++ b/packages/kbar/package.json
@@ -27,6 +27,7 @@
     "author": "Pankod",
     "module": "dist/esm/index.js",
     "devDependencies": {
+        "@pankod/refine-core": "^3.23.2",
         "@esbuild-plugins/node-resolve": "^0.1.4",
         "@testing-library/jest-dom": "^5.12.0",
         "@testing-library/react": "^11.2.6",
@@ -40,7 +41,6 @@
         "typescript": "^4.4.3"
     },
     "dependencies": {
-        "@pankod/refine-core": "^3.25.0",
         "kbar": "^0.1.0-beta.36"
     },
     "repository": {

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -14,9 +14,11 @@
     },
     "peerDependencies": {
         "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react-dom": "^17.0.2",
+        "@pankod/refine-core": "^3.23.2"
     },
     "devDependencies": {
+        "@pankod/refine-core": "^3.23.2",
         "@esbuild-plugins/node-resolve": "^0.1.4",
         "@testing-library/jest-dom": "^5.12.0",
         "@testing-library/react": "^11.2.6",
@@ -44,7 +46,6 @@
         "@mui/lab": "^5.0.0-alpha.85",
         "@mui/material": "^5.8.6",
         "@mui/x-data-grid": "^5.12.1",
-        "@pankod/refine-core": "^3.38.0",
         "@pankod/refine-react-hook-form": "^3.27.1",
         "dayjs": "^1.10.7",
         "lodash": "^4.17.21",

--- a/packages/nestjsx-crud/package.json
+++ b/packages/nestjsx-crud/package.json
@@ -22,6 +22,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "nock": "^13.1.3",
@@ -31,7 +32,6 @@
   },
   "dependencies": {
     "@nestjsx/crud-request": "^5.0.0-alpha.3",
-    "@pankod/refine-core": "^3.36.0",
     "axios": "^0.26.1",
     "query-string": "^7.1.1"
   },

--- a/packages/nextjs-router/package.json
+++ b/packages/nextjs-router/package.json
@@ -22,6 +22,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@types/qs": "^6.9.7",
     "jest": "^27.5.1",
@@ -31,7 +32,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.36.0",
     "qs": "^6.10.1"
   },
   "peerDependencies": {

--- a/packages/nhost/package.json
+++ b/packages/nhost/package.json
@@ -22,6 +22,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "nock": "^13.1.3",
@@ -32,7 +33,6 @@
   },
   "dependencies": {
     "@nhost/nhost-js": "^0.3.9",
-    "@pankod/refine-core": "^3.42.0",
     "gql-query-builder": "^3.5.5",
     "graphql": "^15.6.1",
     "graphql-ws": "^5.9.1"

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -28,6 +28,7 @@
     "react-hook-form": "^7.22.1"
   },
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "react-router-dom": "^6.0.0",
@@ -36,7 +37,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.25.0",
     "react-hook-form": "^7.30.0"
   },
   "repository": {

--- a/packages/react-location/package.json
+++ b/packages/react-location/package.json
@@ -22,6 +22,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.3",
@@ -29,7 +30,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.25.0",
     "react-location": "^3.1.10",
     "react-location-rank-routes": "^3.1.10"
   },

--- a/packages/react-router-v6/package.json
+++ b/packages/react-router-v6/package.json
@@ -22,6 +22,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.3",
@@ -29,7 +30,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.25.0",
     "react-router-dom": "^6.0.0"
   },
   "peerDependencies": {

--- a/packages/react-table/package.json
+++ b/packages/react-table/package.json
@@ -23,11 +23,12 @@
   "module": "dist/esm/index.js",
   "peerDependencies": {
     "@pankod/refine-core": "^3.23.2",
+    "@tanstack/react-table": "^8.2.6",
     "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
-    "@tanstack/react-table": "^8.2.6"
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "react-router-dom": "^6.0.0",
@@ -36,7 +37,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.36.0",
     "@tanstack/react-table": "^8.2.6"
   },
   "repository": {

--- a/packages/simple-rest/package.json
+++ b/packages/simple-rest/package.json
@@ -22,6 +22,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "nock": "^13.1.3",
@@ -30,7 +31,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.36.0",
     "axios": "^0.26.1",
     "query-string": "^7.1.1"
   },

--- a/packages/strapi-graphql/package.json
+++ b/packages/strapi-graphql/package.json
@@ -22,6 +22,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@types/pluralize": "^0.0.29",
     "jest": "^27.5.1",
@@ -31,7 +32,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.38.2",
     "camelcase": "^6.2.0",
     "gql-query-builder": "^3.5.5",
     "graphql": "^15.6.1",

--- a/packages/strapi-v4/package.json
+++ b/packages/strapi-v4/package.json
@@ -27,6 +27,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "@types/qs": "^6.9.7",
     "jest": "^27.5.1",
@@ -36,7 +37,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.42.0",
     "axios": "^0.26.1",
     "qs": "^6.10.1"
   },

--- a/packages/strapi/package.json
+++ b/packages/strapi/package.json
@@ -27,6 +27,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "nock": "^13.1.3",
@@ -35,7 +36,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.36.0",
     "axios": "^0.26.1",
     "query-string": "^7.1.1"
   },

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -22,6 +22,7 @@
   "author": "Pankod",
   "module": "dist/esm/index.js",
   "devDependencies": {
+    "@pankod/refine-core": "^3.23.2",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
     "nock": "^13.1.3",
@@ -30,7 +31,6 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "@pankod/refine-core": "^3.36.0",
     "@supabase/supabase-js": "^1.22.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

All of the refine packages have dependencies on the `@pankod/refine-core` package. So far we have managed these dependencies with `peerDependencies` + `dependencies` but this causes issues like #2183. (having more than one @pankod/refine-core version in node_modules and creating different instances)

Managing as `peerDependencies` + `devDependencies` seems like the best way for now to avoid such issues.

### Closing issues

- #2183

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
