### PR TITLE
feat(customMutationHook): add config param

### DIFF
--- a/.changeset/serious-terms-fetch.md
+++ b/.changeset/serious-terms-fetch.md
@@ -1,0 +1,23 @@
+---
+"@pankod/refine-core": major
+---
+Added config parameter to useCustomMutationHook to send headers.
+
+```
+const apiUrl = useApiUrl();
+
+const { mutate } = useCustomMutation<ICategory>();
+
+mutate({
+    url: `${API_URL}/categories`,
+    method: "post",
+    values: {
+      title: "New Category",
+    },
+    config: {
+      headers: {
+          Authorization: "Bearer ****",
+      },
+    },
+});
+```

--- a/.changeset/serious-terms-fetch.md
+++ b/.changeset/serious-terms-fetch.md
@@ -1,5 +1,5 @@
 ---
-"@pankod/refine-core": major
+"@pankod/refine-core": minor
 ---
 Added config parameter to useCustomMutationHook to send headers.
 

--- a/documentation/docs/core/hooks/data/useCustomMutation.md
+++ b/documentation/docs/core/hooks/data/useCustomMutation.md
@@ -60,11 +60,12 @@ mutate({
 | Property                                        | Description                                                                                        | Type                                                                       |
 | ----------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
 | url <div className="required">Required</div>    | URL                                                                                                | string                                                                     |
-| method <div className="required">Required</div> | Method                                                                                             | `post`, `put`, `patch`, `delete`                                                     |
+| method <div className="required">Required</div> | Method                                                                                             | `post`, `put`, `patch`, `delete`                                           |
 | successNotification                             | Successful Mutation notification                                                                   | [`SuccessErrorNotification`](/core/interfaces.md#successerrornotification) |
 | errorNotification                               | Unsuccessful Mutation notification                                                                 | [`SuccessErrorNotification`](/core/interfaces.md#successerrornotification) |
 | metaData                                        | Metadata query for `dataProvider`                                                                  | [`MetaDataQuery`](/core/interfaces.md#metadataquery)                       |
 | dataProviderName                                | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use. | `string`                                                                   |
+| config                                          | Config Params                                                                                      | { headers?: {};                                                            |
 
 ### Type Parameters
 

--- a/packages/core/src/hooks/data/useCustomMutation.ts
+++ b/packages/core/src/hooks/data/useCustomMutation.ts
@@ -86,22 +86,37 @@ export const useCustomMutation = <
         {
             onSuccess: (
                 data,
-                { successNotification: successNotificationFromProp },
+                {
+                    successNotification: successNotificationFromProp,
+                    config,
+                    metaData,
+                },
             ) => {
                 const notificationConfig =
                     typeof successNotificationFromProp === "function"
-                        ? successNotificationFromProp(data)
+                        ? successNotificationFromProp(data, {
+                              ...config,
+                              ...metaData,
+                          })
                         : successNotificationFromProp;
 
                 handleNotification(notificationConfig);
             },
             onError: (
                 err: TError,
-                { errorNotification: errorNotificationFromProp, method },
+                {
+                    errorNotification: errorNotificationFromProp,
+                    method,
+                    config,
+                    metaData,
+                },
             ) => {
                 const notificationConfig =
                     typeof errorNotificationFromProp === "function"
-                        ? errorNotificationFromProp(err)
+                        ? errorNotificationFromProp(err, {
+                              ...config,
+                              ...metaData,
+                          })
                         : errorNotificationFromProp;
 
                 handleNotification(notificationConfig, {

--- a/packages/core/src/hooks/data/useCustomMutation.ts
+++ b/packages/core/src/hooks/data/useCustomMutation.ts
@@ -9,12 +9,17 @@ import {
     MetaDataQuery,
 } from "../../interfaces";
 
+interface UseCustomMutationConfig {
+    headers?: {};
+}
+
 type useCustomMutationParams<TVariables> = {
     url: string;
     method: "post" | "put" | "patch" | "delete";
     values: TVariables;
     metaData?: MetaDataQuery;
     dataProviderName?: string;
+    config?: UseCustomMutationConfig;
 } & SuccessErrorNotification;
 
 export type UseCustomMutationReturnType<
@@ -62,6 +67,7 @@ export const useCustomMutation = <
             values,
             metaData,
             dataProviderName,
+            config,
         }: useCustomMutationParams<TVariables>) => {
             const { custom } = dataProvider(dataProviderName);
 
@@ -71,6 +77,7 @@ export const useCustomMutation = <
                     method,
                     payload: values,
                     metaData,
+                    headers: { ...config?.headers },
                 });
             }
 


### PR DESCRIPTION
Added `config` parameter to `useCustomMutationHook` to send headers.