### PR TITLE
Fix: Invalidation of authentication caches every time `checkAuth` is run

### DIFF
--- a/.changeset/large-kids-greet.md
+++ b/.changeset/large-kids-greet.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fixed invalidation of authentication caches every time `checkAuth` is run

--- a/packages/core/src/contexts/auth/index.tsx
+++ b/packages/core/src/contexts/auth/index.tsx
@@ -51,8 +51,6 @@ export const AuthContextProvider: React.FC<
                 replace((error as { redirectPath: string }).redirectPath);
             }
             return Promise.reject(error);
-        } finally {
-            invalidateAuthStore();
         }
     };
 

--- a/packages/core/src/contexts/auth/index.tsx
+++ b/packages/core/src/contexts/auth/index.tsx
@@ -23,22 +23,23 @@ export const AuthContextProvider: React.FC<
     const loginFunc = async (params: any) => {
         try {
             const result = await authOperations.login?.(params);
+
+            invalidateAuthStore();
             return Promise.resolve(result);
         } catch (error) {
             return Promise.reject(error);
-        } finally {
-            invalidateAuthStore();
         }
     };
 
     const logoutFunc = async (params: any) => {
         try {
             const redirectPath = await authOperations.logout?.(params);
+
+            invalidateAuthStore();
+
             return Promise.resolve(redirectPath);
         } catch (error) {
             return Promise.reject(error);
-        } finally {
-            invalidateAuthStore();
         }
     };
 
@@ -50,6 +51,7 @@ export const AuthContextProvider: React.FC<
             if ((error as { redirectPath?: string })?.redirectPath) {
                 replace((error as { redirectPath: string }).redirectPath);
             }
+
             return Promise.reject(error);
         }
     };


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Fixed invalidation of authentication caches every time `checkAuth` is run.

### Closing issues

- #2272 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
