### PR TITLE
fix(core): remove icon from useCan hook params

### DIFF
--- a/.changeset/angry-rabbits-speak.md
+++ b/.changeset/angry-rabbits-speak.md
@@ -1,0 +1,8 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fix **useCan** hook params keys.
+
+Since `react-query` stringifies the query keys, it will throw an error for a circular dependency if we include `React.ReactNode` elements inside the keys.
+The feature in #2220(https://github.com/pankod/refine/issues/2220) includes such change and to fix this, we need to remove `icon` property in the `resource`

--- a/packages/core/src/hooks/accessControl/useCan/index.ts
+++ b/packages/core/src/hooks/accessControl/useCan/index.ts
@@ -24,8 +24,24 @@ export const useCan = ({
 }: UseCanProps): UseQueryResult<CanReturnType> => {
     const { can } = useContext(AccessControlContext);
 
+    /**
+     * Since `react-query` stringifies the query keys, it will throw an error for a circular dependency if we include `React.ReactNode` elements inside the keys.
+     * The feature in #2220(https://github.com/pankod/refine/issues/2220) includes such change and to fix this, we need to remove `icon` property in the `resource`
+     */
+    const { resource: _resource, ...paramsRest } = params ?? {};
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { icon: _icon, ...restResource } = _resource ?? {};
+
     const queryResponse = useQuery<CanReturnType>(
-        ["useCan", { action, resource, params }],
+        [
+            "useCan",
+            {
+                action,
+                resource,
+                params: { ...paramsRest, resource: restResource },
+            },
+        ],
         // Enabled check for `can` is enough to be sure that it's defined in the query function but TS is not smart enough to know that.
         () => can?.({ action, resource, params }) ?? { can: true },
         {


### PR DESCRIPTION
Fix **useCan** hook params keys. Related issue is #2232 