### PR TITLE
refactor: missing memoizations in `refine-core`

### DIFF
--- a/.changeset/early-penguins-cheer.md
+++ b/.changeset/early-penguins-cheer.md
@@ -1,0 +1,9 @@
+---
+"@pankod/refine-core": patch
+---
+
+Updated `<Refine/>` component with memoization to prevent unwanted effects.
+
+-   Fixed the issue: `react-query`'s `queryClient` was re-initializing on every render which was causing it to reset the query cache.
+-   Memoized the `notificationProvider` prop to prevent unnecessary re-renders.
+-   Memoized the `resources` prop to prevent unnecessary transform calls on every render.

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -23,6 +23,7 @@ import { AuditLogContextProvider } from "@contexts/auditLog";
 import { ReadyPage as DefaultReadyPage, RouteChangeHandler } from "@components";
 import { routeGenerator } from "@definitions";
 import { Telemetry } from "@components/telemetry";
+import { useDeepMemo } from "@hooks/deepMemo";
 
 import {
     MutationMode,
@@ -116,17 +117,19 @@ export const Refine: React.FC<RefineProps> = ({
     onLiveEvent,
     disableTelemetry = false,
 }) => {
-    const queryClient = new QueryClient({
-        ...reactQueryClientConfig,
-        defaultOptions: {
-            ...reactQueryClientConfig?.defaultOptions,
-            queries: {
-                refetchOnWindowFocus: false,
-                keepPreviousData: true,
-                ...reactQueryClientConfig?.defaultOptions?.queries,
+    const queryClient = useDeepMemo(() => {
+        return new QueryClient({
+            ...reactQueryClientConfig,
+            defaultOptions: {
+                ...reactQueryClientConfig?.defaultOptions,
+                queries: {
+                    refetchOnWindowFocus: false,
+                    keepPreviousData: true,
+                    ...reactQueryClientConfig?.defaultOptions?.queries,
+                },
             },
-        },
-    });
+        });
+    }, [reactQueryClientConfig]);
 
     const notificationProviderContextValues =
         typeof notificationProvider === "function"

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -137,29 +137,33 @@ export const Refine: React.FC<RefineProps> = ({
             : notificationProvider ?? {};
     }, [notificationProvider]);
 
-    const resources: IResourceItem[] = [];
+    const resources: IResourceItem[] = useDeepMemo(() => {
+        const _resources: IResourceItem[] = [];
 
-    resourcesFromProps?.map((resource) => {
-        resources.push({
-            key: resource.key,
-            name: resource.name,
-            label: resource.options?.label,
-            icon: resource.icon,
-            route:
-                resource.options?.route ??
-                routeGenerator(resource, resourcesFromProps),
-            canCreate: !!resource.create,
-            canEdit: !!resource.edit,
-            canShow: !!resource.show,
-            canDelete: resource.canDelete,
-            create: resource.create,
-            show: resource.show,
-            list: resource.list,
-            edit: resource.edit,
-            options: resource.options,
-            parentName: resource.parentName,
+        resourcesFromProps?.forEach((resource) => {
+            _resources.push({
+                key: resource.key,
+                name: resource.name,
+                label: resource.options?.label,
+                icon: resource.icon,
+                route:
+                    resource.options?.route ??
+                    routeGenerator(resource, resourcesFromProps),
+                canCreate: !!resource.create,
+                canEdit: !!resource.edit,
+                canShow: !!resource.show,
+                canDelete: resource.canDelete,
+                create: resource.create,
+                show: resource.show,
+                list: resource.list,
+                edit: resource.edit,
+                options: resource.options,
+                parentName: resource.parentName,
+            });
         });
-    });
+
+        return _resources;
+    }, [resourcesFromProps]);
 
     if (resources.length === 0) {
         return ReadyPage ? <ReadyPage /> : <DefaultReadyPage />;

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -131,10 +131,11 @@ export const Refine: React.FC<RefineProps> = ({
         });
     }, [reactQueryClientConfig]);
 
-    const notificationProviderContextValues =
-        typeof notificationProvider === "function"
+    const notificationProviderContextValues = React.useMemo(() => {
+        return typeof notificationProvider === "function"
             ? notificationProvider()
             : notificationProvider ?? {};
+    }, [notificationProvider]);
 
     const resources: IResourceItem[] = [];
 

--- a/packages/core/src/hooks/deepMemo/index.spec.tsx
+++ b/packages/core/src/hooks/deepMemo/index.spec.tsx
@@ -1,0 +1,41 @@
+import { renderHook } from "@testing-library/react";
+
+import { useDeepMemo } from ".";
+
+describe("useDeepMemo Hook", () => {
+    it("should return the same instance when new dependency is deep equal", () => {
+        const initialValue = { value: 5 };
+        const { result, rerender } = renderHook(
+            (value) => useDeepMemo(() => value, [value]),
+            {
+                initialProps: initialValue,
+            },
+        );
+        expect(result.current).toBe(initialValue);
+
+        const newButSameValue = { value: 5 };
+
+        rerender(newButSameValue);
+
+        expect(result.current).toBe(initialValue);
+        expect(result.current).not.toBe(newButSameValue);
+    });
+
+    it("should return the new value when new dependency is not deep equal", () => {
+        const initialValue = { value: 5 };
+        const { result, rerender } = renderHook(
+            (value) => useDeepMemo(() => value, [value]),
+            {
+                initialProps: initialValue,
+            },
+        );
+        expect(result.current).toBe(initialValue);
+
+        const newValue = { value: 6 };
+
+        rerender(newValue);
+
+        expect(result.current).not.toBe(initialValue);
+        expect(result.current).toBe(newValue);
+    });
+});

--- a/packages/core/src/hooks/deepMemo/index.tsx
+++ b/packages/core/src/hooks/deepMemo/index.tsx
@@ -1,0 +1,17 @@
+import React, { useMemo } from "react";
+import { useMemoized } from "@hooks/memoized";
+
+/**
+ * Hook that memoizes the given dependency array and checks the consecutive calls with deep equality and returns the same value as the first call if dependencies are not changed.
+ * @internal
+ */
+export const useDeepMemo = <T,>(
+    fn: () => T,
+    dependencies: React.DependencyList,
+): T => {
+    const memoizedDependencies = useMemoized(dependencies);
+
+    const value = useMemo(fn, memoizedDependencies);
+
+    return value;
+};

--- a/packages/core/src/hooks/memoized/index.spec.tsx
+++ b/packages/core/src/hooks/memoized/index.spec.tsx
@@ -1,0 +1,134 @@
+import { renderHook } from "@testing-library/react";
+import React from "react";
+
+import { useMemoized } from ".";
+
+describe("useMemoized Hook", () => {
+    it("should return true for empty arrays", () => {
+        const dependencies: React.DependencyList = [];
+        const { result } = renderHook(() => useMemoized(dependencies));
+        expect(result.current).toBe(dependencies);
+    });
+
+    it("should return true for deep equal arrays", () => {
+        const dependencies: React.DependencyList = [1, 2, 3];
+        const { result } = renderHook(() => useMemoized(dependencies));
+        expect(result.current).toBe(dependencies);
+    });
+
+    it("should return same instance when send with different instance", () => {
+        const dependencies: React.DependencyList = [1, 2, 3];
+        const { result, ...rest } = renderHook((deps) => useMemoized(deps), {
+            initialProps: dependencies,
+        });
+
+        rest.rerender([...dependencies]);
+
+        expect(result.current).toBe(dependencies);
+    });
+
+    it("should return the new instance when new dependencies sent", () => {
+        const dependencies: React.DependencyList = [1, 2, 3];
+        const { result, ...rest } = renderHook((deps) => useMemoized(deps), {
+            initialProps: dependencies,
+        });
+
+        const newDependencies: React.DependencyList = [4, 5, 6];
+
+        rest.rerender(newDependencies);
+
+        expect(result.current).toBe(newDependencies);
+    });
+
+    it("should return the same instance for react node instances", () => {
+        const node = <div>hello</div>;
+
+        const { result, ...rest } = renderHook((deps) => useMemoized(deps), {
+            initialProps: node,
+        });
+
+        const newNode = <div>hello</div>;
+
+        rest.rerender(newNode);
+
+        expect(result.current).toBe(node);
+    });
+
+    it("should return same instance when re-initialized object array (fake resources)", () => {
+        const show = () => null;
+
+        const first = [
+            {
+                name: "posts",
+                icon: <div>POSTS</div>,
+                show: show,
+            },
+            {
+                name: "categories",
+                icon: <div>CATEGORIES</div>,
+                show: show,
+            },
+        ];
+
+        const { result, ...rest } = renderHook((deps) => useMemoized(deps), {
+            initialProps: first,
+        });
+
+        const second = [
+            {
+                name: "posts",
+                icon: <div>POSTS</div>,
+                show: show,
+            },
+            {
+                name: "categories",
+                icon: <div>CATEGORIES</div>,
+                show: show,
+            },
+        ];
+
+        rest.rerender(second);
+
+        expect(result.current).toBe(first);
+        expect(result.current).not.toBe(second);
+    });
+
+    it("should return next instance when re-initialized object array with changes (fake resources)", () => {
+        const show = () => null;
+
+        const first = [
+            {
+                name: "posts",
+                icon: <div>POSTS</div>,
+                show: show,
+            },
+            {
+                name: "categories",
+                icon: <div>CATEGORIES</div>,
+                show: show,
+            },
+        ];
+
+        const { result, ...rest } = renderHook((deps) => useMemoized(deps), {
+            initialProps: first,
+        });
+
+        const second = [
+            {
+                name: "posts",
+                icon: <div>POSTS NEW</div>,
+                show: show,
+            },
+            {
+                name: "categories",
+                icon: <div>CATEGORIES</div>,
+                show: show,
+            },
+        ];
+
+        rest.rerender(second);
+
+        expect(result.current).toBe(second);
+        expect(result.current).not.toBe(first);
+    });
+});

--- a/packages/core/src/hooks/memoized/index.tsx
+++ b/packages/core/src/hooks/memoized/index.tsx
@@ -1,0 +1,16 @@
+import { useRef } from "react";
+import isEqual from "lodash/isEqual";
+
+/**
+ * Hook that memoizes the given value with deep equality.
+ * @internal
+ */
+export const useMemoized = <T = unknown,>(value: T): T => {
+    const ref = useRef(value);
+
+    if (!isEqual(ref.current, value)) {
+        ref.current = value;
+    }
+
+    return ref.current;
+};


### PR DESCRIPTION
Updated `<Refine/>` component in `refine-core` package with memoized props to avoid re-renders and unnecessary calculations/transforms.

Fixed: In `next.js` projects, `react-query`'s cache was being reset on every route changes and causing it to reload all previous data.

Added two internal hooks to achieve better memoizations (`useMemoized` and `useDeepMemo`)

### Test plan (required)

<img width="762" alt="Screen Shot 2022-08-04 at 16 16 14" src="https://user-images.githubusercontent.com/11361964/182856261-289400b9-c842-4891-a679-962cfaf67876.png">

### Closing issues


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
