### PR TITLE
fix: 'handleSubmit' triggering instantly when hook init on react-hook-form package

### DIFF
--- a/.changeset/brave-fireants-grow.md
+++ b/.changeset/brave-fireants-grow.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-react-hook-form": patch
+---
+
+Fixed immediate triggering of `handleSubmit`

--- a/documentation/docs/packages/react-hook-form/useForm.md
+++ b/documentation/docs/packages/react-hook-form/useForm.md
@@ -455,7 +455,7 @@ const {
 
 | Property        | Description               | Type                                          |
 | --------------- | ------------------------- | --------------------------------------------- |
-| saveButtonProps | Props for a submit button | `{ disabled: boolean; onClick: () => void; }` |
+| saveButtonProps | Props for a submit button | `{ disabled: boolean; onClick: (e: React.BaseSyntheticEvent) => void; }` |
 
 
 ### Type Parameters

--- a/documentation/docs/packages/react-hook-form/useModalForm.md
+++ b/documentation/docs/packages/react-hook-form/useModalForm.md
@@ -423,7 +423,7 @@ export const EditPost: React.FC<UseModalFormReturnType> = ({
 > | close           | Sets the visible state to false                | `() => void`                                 |
 > | submit          | Submits the form                               | `(values: TVariables) => void`               |
 > | title           | Modal title based on resource and action value | `string`                                     |
-> | saveButtonProps | Props for a submit button                      | `{ disabled: boolean, onClick: () => void }` |
+> | saveButtonProps | Props for a submit button                      | `{ disabled: boolean, onClick: (e: React.BaseSyntheticEvent) => void;  }` |
 
 ## Live StackBlitz Example
 

--- a/packages/react-hook-form/src/useForm/index.ts
+++ b/packages/react-hook-form/src/useForm/index.ts
@@ -1,9 +1,12 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import {
     useForm as useHookForm,
     UseFormProps as UseHookFormProps,
     UseFormReturn,
     FieldValues,
+    UseFormHandleSubmit,
+    SubmitHandler,
+    SubmitErrorHandler,
 } from "react-hook-form";
 import {
     BaseRecord,
@@ -23,7 +26,7 @@ export type UseFormReturnType<
     refineCore: UseFormReturnTypeCore<TData, TError, TVariables>;
     saveButtonProps: {
         disabled: boolean;
-        onClick: () => void;
+        onClick: (e: React.BaseSyntheticEvent) => void;
     };
 };
 
@@ -106,15 +109,16 @@ export const useForm = <
         return changeValues;
     };
 
-    const handleSubmit = (e: any) => {
-        setWarnWhen(false);
-        return handleSubmitReactHookForm(e);
-    };
+    const handleSubmit: UseFormHandleSubmit<TVariables> =
+        (onValid, onInvalid) => async (e) => {
+            setWarnWhen(false);
+            return await handleSubmitReactHookForm(onValid, onInvalid)(e);
+        };
 
     const saveButtonProps = {
         disabled: formLoading,
-        onClick: () => {
-            handleSubmit(onFinish)();
+        onClick: (e: React.BaseSyntheticEvent) => {
+            handleSubmit(onFinish, () => false)(e);
         },
     };
 

--- a/packages/react-hook-form/src/useModalForm/index.ts
+++ b/packages/react-hook-form/src/useModalForm/index.ts
@@ -145,7 +145,7 @@ export const useModalForm = <
         ...useHookFormResult,
         saveButtonProps: {
             ...saveButtonProps,
-            onClick: () => handleSubmit(submit as any)(),
+            onClick: (e) => handleSubmit(submit)(e),
         },
     };
 };


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Fixed: 'handleSubmit' triggering instantly when hook init

### Closing issues

-

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
