### PR TITLE
feat: add query context function params to `metaData`

### DIFF
--- a/.changeset/sweet-boxes-wave.md
+++ b/.changeset/sweet-boxes-wave.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Added [QueryFunctionContext](https://tanstack.com/query/v4/docs/guides/query-functions#queryfunctioncontext)'s values to `queryContext` in `metaData`.

--- a/documentation/docs/core/interfaces.md
+++ b/documentation/docs/core/interfaces.md
@@ -34,7 +34,6 @@ title: Interface References
     "nbetween" |
     "null" |
     "nnull";
-
 ```
 
 | Type           | Description                     |
@@ -73,11 +72,9 @@ title: Interface References
 | `"desc"`     | Descending order |
 
 ## SortOrder
-```ts
-"desc" |
-    "asc" |
-    "null";
 
+```ts
+"desc" | "asc" | "null";
 ```
 
 ## Pagination
@@ -92,7 +89,6 @@ title: Interface References
 | Type                 |
 | -------------------- |
 | `string` \| `number` |
-
 
 ## BaseRecord
 
@@ -148,19 +144,20 @@ ButtonProps
 
 ## SuccessErrorNotification
 
-| Key                 | Type                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------ |
-| successNotification | `(data?: TData, values?: TVariables, resource?: string) => NotificationProperties` \| [Notification Properties](https://ant.design/components/notification/#API) \| `false` |
+| Key                 | Type                                                                                                                                                                          |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| successNotification | `(data?: TData, values?: TVariables, resource?: string) => NotificationProperties` \| [Notification Properties](https://ant.design/components/notification/#API) \| `false`   |
 | errorNotification   | `(error?: TError, values?: TVariables, resource?: string) => NotificationProperties` \| [Notification Properties](https://ant.design/components/notification/#API) \| `false` |
 
 ## MetaDataQuery
 
-| Key         | Type                                                       |
-| ----------- | ---------------------------------------------------------- |
-| [k: string] | `any`                                                      |
-| operation?  | `string`                                                   |
-| fields?     | `Array<string` \| `object` \| [NestedField](#nestedfield)> |
-| variables?  | [VariableOptions](#variableoptions)                        |
+| Key           | Type                                                                                                                 |
+| ------------- | -------------------------------------------------------------------------------------------------------------------- |
+| [k: string]   | `any`                                                                                                                |
+| operation?    | `string`                                                                                                             |
+| fields?       | `Array<string` \| `object` \| [NestedField](#nestedfield)>                                                           |
+| variables?    | [VariableOptions](#variableoptions)                                                                                  |
+| queryContext? | [Omit<QueryFunctionContext, "meta">](https://tanstack.com/query/v4/docs/guides/query-functions#queryfunctioncontext) |
 
 ### NestedField
 
@@ -199,11 +196,11 @@ ButtonProps
 
 ## CanParams
 
-| Key      | Type     |
-| -------- | -------- |
-| resource | `string` |
-| action   | `string` |
-| params?  | { `resource`?: [IResourceItem](/docs/core/interfaces.md#resourceitemprops), `id`?: [BaseKey](/docs/core/interfaces.md#basekey), `[key: string]: any` }    |
+| Key      | Type                                                                                                                                                   |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| resource | `string`                                                                                                                                               |
+| action   | `string`                                                                                                                                               |
+| params?  | { `resource`?: [IResourceItem](/docs/core/interfaces.md#resourceitemprops), `id`?: [BaseKey](/docs/core/interfaces.md#basekey), `[key: string]: any` } |
 
 ## CanReturnType
 
@@ -228,6 +225,7 @@ ButtonProps
 | liveMode?    | `"auto"` \| `"manual"` \| `"off"`       |
 | liveParams?  | `{ids?: BaseKey[]; [x: string]: any; }` |
 | onLiveEvent? | `(event: LiveEvent) => void`            |
+
 ## OptionsProps
 
 | Key           | Type     |
@@ -250,7 +248,6 @@ ButtonProps
 | canDelete?  | `boolean`   |
 | options?    | `object`    |
 | parentName? | `string`    |
-
 
 ## SyncWithLocationParams
 

--- a/packages/core/src/hooks/data/useCustom.ts
+++ b/packages/core/src/hooks/data/useCustom.ts
@@ -84,7 +84,20 @@ export const useCustom = <
                 url,
                 { ...config, ...metaData },
             ],
-            () => custom<TData>({ url, method, ...config, metaData }),
+            ({ queryKey, pageParam, signal }) =>
+                custom<TData>({
+                    url,
+                    method,
+                    ...config,
+                    metaData: {
+                        ...metaData,
+                        queryContext: {
+                            queryKey,
+                            pageParam,
+                            signal,
+                        },
+                    },
+                }),
             {
                 ...queryOptions,
                 onSuccess: (data) => {

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -99,13 +99,20 @@ export const useList = <
 
     const queryResponse = useQuery<GetListResponse<TData>, TError>(
         queryKey.list(config),
-        () => {
+        ({ queryKey, pageParam, signal }) => {
             const { hasPagination, ...restConfig } = config || {};
             return getList<TData>({
                 resource,
                 ...restConfig,
                 hasPagination,
-                metaData,
+                metaData: {
+                    ...metaData,
+                    queryContext: {
+                        queryKey,
+                        pageParam,
+                        signal,
+                    },
+                },
             });
         },
         {

--- a/packages/core/src/hooks/data/useMany.ts
+++ b/packages/core/src/hooks/data/useMany.ts
@@ -88,7 +88,19 @@ export const useMany = <
 
     const queryResponse = useQuery<GetManyResponse<TData>, TError>(
         queryKey.many(ids),
-        () => getMany<TData>({ resource, ids, metaData }),
+        ({ queryKey, pageParam, signal }) =>
+            getMany<TData>({
+                resource,
+                ids,
+                metaData: {
+                    ...metaData,
+                    queryContext: {
+                        queryKey,
+                        pageParam,
+                        signal,
+                    },
+                },
+            }),
         {
             ...queryOptions,
             onSuccess: (data) => {

--- a/packages/core/src/hooks/data/useOne.ts
+++ b/packages/core/src/hooks/data/useOne.ts
@@ -83,7 +83,19 @@ export const useOne = <
 
     const queryResponse = useQuery<GetOneResponse<TData>, TError>(
         queryKey.detail(id),
-        () => getOne<TData>({ resource, id, metaData }),
+        ({ queryKey, pageParam, signal }) =>
+            getOne<TData>({
+                resource,
+                id,
+                metaData: {
+                    ...metaData,
+                    queryContext: {
+                        queryKey,
+                        pageParam,
+                        signal,
+                    },
+                },
+            }),
         {
             ...queryOptions,
             onSuccess: (data) => {

--- a/packages/core/src/hooks/useSelect/index.spec.ts
+++ b/packages/core/src/hooks/useSelect/index.spec.ts
@@ -440,6 +440,22 @@ describe("useSelect Hook", () => {
             filters: [],
             pagination: { pageSize: 20 },
             resource: "posts",
+            metaData: {
+                queryContext: {
+                    queryKey: [
+                        "default",
+                        "posts",
+                        "list",
+                        {
+                            filters: [],
+                            pagination: {
+                                pageSize: 20,
+                            },
+                        },
+                    ],
+                    signal: new AbortController().signal,
+                },
+            },
         });
     });
 
@@ -495,6 +511,19 @@ describe("useSelect Hook", () => {
         expect(mockDataProvider.default?.getList).toHaveBeenCalledWith({
             filters: [],
             resource: "posts",
+            metaData: {
+                queryContext: {
+                    queryKey: [
+                        "default",
+                        "posts",
+                        "list",
+                        {
+                            filters: [],
+                        },
+                    ],
+                    signal: new AbortController().signal,
+                },
+            },
         });
 
         await act(async () => {
@@ -509,6 +538,19 @@ describe("useSelect Hook", () => {
             expect(mockDataProvider.default?.getList).toHaveBeenCalledWith({
                 filters,
                 resource: "posts",
+                metaData: {
+                    queryContext: {
+                        queryKey: [
+                            "default",
+                            "posts",
+                            "list",
+                            {
+                                filters,
+                            },
+                        ],
+                        signal: new AbortController().signal,
+                    },
+                },
             });
         });
     });

--- a/packages/core/src/interfaces/metaData/metaDataQuery.ts
+++ b/packages/core/src/interfaces/metaData/metaDataQuery.ts
@@ -1,5 +1,7 @@
+import { QueryFunctionContext } from "@tanstack/react-query";
 import { QueryBuilderOptions } from "./queryBuilderOptions";
 
 export type MetaDataQuery = {
     [k: string]: any;
+    queryContext?: Omit<QueryFunctionContext, "meta">;
 } & QueryBuilderOptions;


### PR DESCRIPTION
Added [QueryFunctionContext](https://tanstack.com/query/v4/docs/guides/query-functions#queryfunctioncontext)'s values to queryContext in metaData.

### Test plan (required)

All test are passed.

<!-- Make sure tests pass. -->

### Closing issues

-

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
