### PR TITLE
fix: add missing react 17 versions to peer depps

### DIFF
--- a/.changeset/cold-cougars-marry.md
+++ b/.changeset/cold-cougars-marry.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": patch
+---
+
+Added React 17 support to `peerDependencies`.

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -13,9 +13,9 @@
         "prepare": "npm run build"
     },
     "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "@pankod/refine-core": "^3.23.2"
+        "@pankod/refine-core": "^3.23.2",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
     },
     "devDependencies": {
         "@pankod/refine-ui-tests": "^0.3.2",


### PR DESCRIPTION
Updated `peerDependencies` in `@pankod/refine-mui#package.json` to support React 17.

### Test plan (required)

Tests are not affected.

### Closing issues

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
