### PR TITLE
fix: downgrade react-scripts 5 to 4 for web 3 example

### DIFF
--- a/examples/web3/ethereumLogin/package.json
+++ b/examples/web3/ethereumLogin/package.json
@@ -10,7 +10,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
     "@testing-library/user-event": "^14.1.1",
-    "@types/jest": "^26.0.23",
+    "@types/jest": "^26.0.24",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
@@ -18,13 +18,13 @@
     "@types/node": "^12.20.11",
     "react-markdown": "^6.0.1",
     "react-mde": "^11.1.0",
-    "react-scripts": "^5.0.0",
+    "react-scripts": "^4.0.0",
     "typescript": "^4.7.4",
     "web3": "^1.6.1",
     "web3modal": "^1.9.4"
   },
   "scripts": {
-    "dev": "react-scripts start",
+    "start": "DISABLE_ESLINT_PLUGIN=true SKIP_PREFLIGHT_CHECK=true react-scripts start",
     "build": "DISABLE_ESLINT_PLUGIN=true react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:
I downgraded to react-scripts@4 because the `web3` package doesn't support WebPack5

### Closing issues

- #2309 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
