### PR TITLE
feat(core): disable react query devtools

### DIFF
--- a/.changeset/long-lobsters-cough.md
+++ b/.changeset/long-lobsters-cough.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": minor
+---
+
+Updated `reactQueryDevtoolConfig` prop type and added `false` option to disable the React Query Devtools.

--- a/documentation/docs/core/components/refine-config.md
+++ b/documentation/docs/core/components/refine-config.md
@@ -672,7 +672,7 @@ const App: React.FC = () => (
 
 ### `reactQueryDevtoolConfig`
 
-Config for customize React Query Devtools.
+Config for customize React Query Devtools. If you want to disable the Devtools, set `reactQueryDevtoolConfig` to `false`.
 
 **refine** uses some defaults that applies to react-query devtool:
 

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -72,7 +72,9 @@ export interface RefineProps {
     OffLayoutArea?: React.FC;
     Title?: React.FC<TitleProps>;
     reactQueryClientConfig?: QueryClientConfig;
-    reactQueryDevtoolConfig?: any;
+    reactQueryDevtoolConfig?:
+        | React.ComponentProps<typeof ReactQueryDevtools>
+        | false;
     liveMode?: LiveModeProps["liveMode"];
     onLiveEvent?: LiveModeProps["onLiveEvent"];
     children?: React.ReactNode;
@@ -246,11 +248,13 @@ export const Refine: React.FC<RefineProps> = ({
                     </DataContextProvider>
                 </AuthContextProvider>
             </NotificationContextProvider>
-            <ReactQueryDevtools
-                initialIsOpen={false}
-                position="bottom-right"
-                {...reactQueryDevtoolConfig}
-            />
+            {reactQueryDevtoolConfig === false ? null : (
+                <ReactQueryDevtools
+                    initialIsOpen={false}
+                    position="bottom-right"
+                    {...(reactQueryDevtoolConfig ?? {})}
+                />
+            )}
         </QueryClientProvider>
     );
 };


### PR DESCRIPTION
Updated `reactQueryDevtoolConfig` prop type and added `false` option to disable the React Query Devtools.

### Test plan (required)

Tests are not affected.

### Closing issues

### Self Check before Merge

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
