### PR TITLE
fix: react-query devtools was consuming high CPU 

### DIFF
--- a/.changeset/brave-carpets-work.md
+++ b/.changeset/brave-carpets-work.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fixed react-query devtools was consuming high CPU when AccessControlProvider was not used

--- a/packages/core/src/hooks/accessControl/useCan/index.ts
+++ b/packages/core/src/hooks/accessControl/useCan/index.ts
@@ -35,7 +35,14 @@ export const useCan = ({
     const { resource: _resource, ...paramsRest } = params ?? {};
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { icon: _icon, ...restResource } = _resource ?? {};
+    const {
+        icon: _icon,
+        list: _list,
+        edit: _edit,
+        create: _create,
+        show: _show,
+        ...restResource
+    } = _resource ?? {};
 
     const queryResponse = useQuery<CanReturnType>(
         [

--- a/packages/core/src/hooks/accessControl/useCan/index.ts
+++ b/packages/core/src/hooks/accessControl/useCan/index.ts
@@ -34,7 +34,7 @@ export const useCan = ({
      */
     const { resource: _resource, ...paramsRest } = params ?? {};
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    /* eslint-disable @typescript-eslint/no-unused-vars */
     const {
         icon: _icon,
         list: _list,
@@ -43,6 +43,7 @@ export const useCan = ({
         show: _show,
         ...restResource
     } = _resource ?? {};
+    /* eslint-enable @typescript-eslint/no-unused-vars */
 
     const queryResponse = useQuery<CanReturnType>(
         [

--- a/packages/core/src/hooks/accessControl/useCan/index.ts
+++ b/packages/core/src/hooks/accessControl/useCan/index.ts
@@ -47,7 +47,9 @@ export const useCan = ({
             },
         ],
         // Enabled check for `can` is enough to be sure that it's defined in the query function but TS is not smart enough to know that.
-        () => can?.({ action, resource, params }) ?? { can: true },
+        () =>
+            can?.({ action, resource, params }) ??
+            Promise.resolve({ can: true }),
         {
             enabled: typeof can !== "undefined",
             ...queryOptions,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Fixed react-query devtools was consuming high CPU when AccessControlProvider was not used

Original Discord message: https://discord.com/channels/837692625737613362/906206669787234334/1009922875114917960


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
