### PR TITLE
fix: wrap default footer buttons to `<Space>`

### DIFF
--- a/.changeset/honest-cheetahs-study.md
+++ b/.changeset/honest-cheetahs-study.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": patch
+---
+
+Updated `<Edit/>` component's default footer buttons property wrapper with `<Space/>` component like `<Footer>

--- a/packages/antd/src/components/crud/edit/index.tsx
+++ b/packages/antd/src/components/crud/edit/index.tsx
@@ -173,30 +173,28 @@ export const Edit: React.FC<EditProps> = ({
                 <Spin spinning={isLoading}>
                     <Card
                         bordered={false}
-                        actions={
-                            footerButtons
-                                ? [
-                                      <Space
-                                          key="footer-buttons"
-                                          wrap
-                                          style={{
-                                              float: "right",
-                                              marginRight: 24,
-                                          }}
-                                          {...footerButtonProps}
-                                      >
-                                          {typeof footerButtons === "function"
-                                              ? footerButtons({
-                                                    defaultButtons:
-                                                        defaultFooterButtons,
-                                                })
-                                              : footerButtons}
-                                      </Space>,
-                                  ]
-                                : actionButtons
-                                ? [actionButtons]
-                                : [defaultFooterButtons]
-                        }
+                        actions={[
+                            <Space
+                                key="footer-buttons"
+                                wrap
+                                style={{
+                                    float: "right",
+                                    marginRight: 24,
+                                }}
+                                {...(footerButtonProps ?? {})}
+                            >
+                                {footerButtons
+                                    ? typeof footerButtons === "function"
+                                        ? footerButtons({
+                                              defaultButtons:
+                                                  defaultFooterButtons,
+                                          })
+                                        : footerButtons
+                                    : actionButtons
+                                    ? actionButtons
+                                    : defaultFooterButtons}
+                            </Space>,
+                        ]}
                         {...(contentProps ?? {})}
                     >
                         {children}


### PR DESCRIPTION
Added `<Space>` wrapper to `Crud#Edit#footerButtons` component in `@pankod/refine-antd` which was there before the refactoring changes and missed during the refactor and this leads to broken styles in the footer buttons.

### Test plan (required)

Tests are not affected.

### Closing issues


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
