### PR TITLE
feat: add `options` prop to `<Refine>`

### DIFF
--- a/.changeset/blue-penguins-eat.md
+++ b/.changeset/blue-penguins-eat.md
@@ -1,0 +1,24 @@
+---
+"@pankod/refine-core": minor
+---
+
+Added a new `<Refine>` component property: `options`.
+
+Previously, the options were passed as a property to the `<Refine>` component. Now, the options are passed to the `<Refine>` via `options` property like this:
+
+```diff
+    <Refine
+-       mutationMode="undoable"
+-       undoableTimeout={5000}
+-       warnWhenUnsavedChanges
+-       syncWithLocation
+-       liveMode="off"
++       options={{
++           mutationMode: "undoable",
++           undoableTimeout: 5000,
++           warnWhenUnsavedChanges: true,
++           syncWithLocation: true,
++           liveMode: "off",
++       }}
+    />
+```

--- a/.changeset/blue-penguins-eat.md
+++ b/.changeset/blue-penguins-eat.md
@@ -13,12 +13,14 @@ Previously, the options were passed as a property to the `<Refine>` component. N
 -       warnWhenUnsavedChanges
 -       syncWithLocation
 -       liveMode="off"
+-       disableTelemetry={false}
 +       options={{
 +           mutationMode: "undoable",
 +           undoableTimeout: 5000,
 +           warnWhenUnsavedChanges: true,
 +           syncWithLocation: true,
 +           liveMode: "off",
++           disableTelemetry: false,
 +       }}
     />
 ```

--- a/documentation/blog/2022-02-21-react-antd-admin.md
+++ b/documentation/blog/2022-02-21-react-antd-admin.md
@@ -508,7 +508,7 @@ function App() {
             Header={Header}
             //highlight-start
             liveProvider={liveProvider(ablyClient)}
-            liveMode="auto"
+            options={{ liveMode: "auto" }}
             //highlight-end
             resources={[
                 {
@@ -666,7 +666,7 @@ const cerbos = new Cerbos({
     dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
     Header={() => <Header role={role} />}
     liveProvider={liveProvider(ablyClient)}
-    liveMode="auto"
+    options={{ liveMode: "auto" }}
     //highlight-start
     accessControlProvider={{
         can: async ({ action, params, resource }) => {

--- a/documentation/blog/2022-07-21-admin-panel-with-materialui-and-strapi.md
+++ b/documentation/blog/2022-07-21-admin-panel-with-materialui-and-strapi.md
@@ -937,7 +937,7 @@ During the timeout, mutation can be cancelled from the notification with an undo
 
 
 
-To activate mutation mode, we'll set `mutationMode` property to the `<Refine/>` component.
+To activate mutation mode, we'll set `mutationMode` property in `options` to the `<Refine/>` component.
 
 ```tsx title="src/App.tsx"
 ...
@@ -1016,9 +1016,11 @@ function App() {
             <RefineSnackbarProvider>
                 <Refine
                     ...
-                    mutationMode="undoable"
-                    //highlight-next-line
-                    syncWithLocation
+                    options={{ 
+                        mutationMode="undoable", 
+                        //highlight-next-line
+                        syncWithLocation: true 
+                    }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/documentation/blog/2022-07-21-admin-panel-with-materialui-and-strapi.md
+++ b/documentation/blog/2022-07-21-admin-panel-with-materialui-and-strapi.md
@@ -1017,7 +1017,7 @@ function App() {
                 <Refine
                     ...
                     options={{ 
-                        mutationMode="undoable", 
+                        mutationMode: "undoable", 
                         //highlight-next-line
                         syncWithLocation: true 
                     }}

--- a/documentation/blog/2022-07-21-admin-panel-with-materialui-and-strapi.md
+++ b/documentation/blog/2022-07-21-admin-panel-with-materialui-and-strapi.md
@@ -965,7 +965,7 @@ function App() {
                         },
                     ]}
                     //highlight-next-line
-                    mutationMode="undoable"
+                    options={{ mutationMode: "undoable" }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/documentation/docs/core/components/refine-config.md
+++ b/documentation/docs/core/components/refine-config.md
@@ -354,7 +354,7 @@ const App: React.FC = () => {
         <Refine
             ...
             // highlight-next-line
-            options={{ mutationMode="undoable", undoableTimeout: 3500 }}
+            options={{ mutationMode: "undoable", undoableTimeout: 3500 }}
         />
     );
 };

--- a/documentation/docs/core/components/refine-config.md
+++ b/documentation/docs/core/components/refine-config.md
@@ -314,6 +314,167 @@ const PostList: React.FC<IResourceComponentsProps<DataType, OptionType>> = (prop
 
 <br />
 
+## `options`
+
+`options` is used to configure the app.
+
+### `mutationMode`
+
+`mutationMode` determines which mode the mutations run with. (e.g. useUpdate, useDelete).
+
+```tsx title="App.tsx"
+const App: React.FC = () => {
+    return (
+        <Refine
+            ...
+            // highlight-next-line
+            options={{ mutationMode: "optimistic" }}
+        />
+    );
+};
+```
+
+`pessimistic`: The mutation runs immediately. Redirection and UI updates are executed after the mutation returns successfuly. This is the default setting.
+
+`optimistic`: The mutation is applied locally, redirection and UI updates are executed immediately as if the mutation is succesful. If the mutation returns with error, UI updates accordingly.
+
+`undoable`: The mutation is applied locally, redirection and UI updates are executed immediately as if mutation is succesful. Waits for a customizable amount of timeout before mutation is applied. During the timeout, mutation can be cancelled from the notification with the ?undo? button. UI will revert back accordingly.
+
+[Refer to the Mutation Mode docs for further information. &#8594](/guides-and-concepts/mutation-mode.md)
+
+### `undoableTimeout`
+
+The duration of the timeout period in **undoable** mode, shown in milliseconds. Mutations can be cancelled during this period. This period can also be set on the supported data hooks.  
+The value set in hooks will override the value set with `undoableTimeout`.  
+`undoableTimeout` has a default value of `5000`.
+
+```tsx title="App.tsx"
+const App: React.FC = () => {
+    return (
+        <Refine
+            ...
+            // highlight-next-line
+            options={{ mutationMode="undoable", undoableTimeout: 3500 }}
+        />
+    );
+};
+```
+
+### `syncWithLocation`
+
+List query parameter values can be edited manually by typing directly in the URL. To activate this feature `syncWithLocation` needs to be set to `true`.
+
+When `syncWithLocation` is active, URL on the listing page shows query parameters like below:
+
+```
+/posts?current=1&pageSize=8&sort[]=createdAt&order[]=desc
+```
+
+Users are able to change current page, items count per page, sort and filter parameters.
+
+Default value is `false`.
+
+### `warnWhenUnsavedChanges`
+
+When you have unsaved changes and try to leave the current page, **refine** shows a confirmation modal box.
+To activate this feature, set the `warnWhenUnsavedChanges` to `true`.
+
+<br />
+
+<div style={{textAlign: "center",  backgroundColor:"#efefef",  padding: "13px 10px 10px"}}>
+
+<img src={warnwhen} />
+
+</div>
+<br/>
+
+Default value is `false`.
+
+### `liveMode`
+
+Whether to update data automatically (`auto`) or not (`manual`) if a related live event is received. The `off` value is used to avoid creating a subscription.
+
+[Refer to live provider documentation for detailed information. &#8594](/core/providers/live-provider.md#livemode)
+
+### `reactQuery`
+
+#### `clientConfig`
+
+Config for React Query client that **refine** uses.
+
+**refine** uses some defaults that applies to all queries:
+
+```ts
+{
+    refetchOnWindowFocus: false,
+    keepPreviousData: true,
+}
+```
+
+[Refer to the QueryClient documentation for detailed information. &#8594](https://react-query.tanstack.com/reference/QueryClient#queryclient)
+
+```tsx
+const App: React.FC = () => (
+    <Refine
+        ...
+        // highlight-start
+        options={{
+            reactQuery: {
+                clientConfig: {
+                    defaultOptions: {
+                        queries: {
+                            staleTime: Infinity,
+                        },
+                    },
+                },
+            },
+        }}
+        // highlight-end
+    />
+);
+```
+
+#### `devtoolConfig`
+
+Config for customize React Query Devtools. If you want to disable the Devtools, set `devtoolConfig` to `false`.
+
+**refine** uses some defaults that applies to react-query devtool:
+
+```ts
+{
+    initialIsOpen: false,
+    position: "bottom-right"
+}
+```
+
+[Refer to the Devtools documentation for detailed information. &#8594](https://react-query.tanstack.com/devtools#options)
+
+```tsx {4-7}
+const App: React.FC = () => (
+    <Refine
+        ...
+        // highlight-start
+        options={{
+            reactQuery: {
+                devtoolConfig: {
+                    initialIsOpen: true,
+                    position: "bottom-left",
+                },
+            },
+        }}
+        // highlight-end
+    />
+);
+```
+
+<br />
+
+## `onLiveEvent`
+
+Callback to handle all live events.
+
+[Refer to live provider documentation for detailed information. &#8594](/core/providers/live-provider.md#refine)
+
 ## `catchAll`
 
 When the app is navigated to a non-existent route, **refine** shows a default error page. A custom error component can be used for this error page by passing the customized component to `catchAll` property:
@@ -334,97 +495,6 @@ const App: React.FC = () => {
 ```
 
 <br />
-
-## `mutationMode`
-
-`mutationMode` determines which mode the mutations run with. (e.g. useUpdate, useDelete).
-
-```tsx title="App.tsx"
-const App: React.FC = () => {
-    return (
-        <Refine
-            ...
-            // highlight-next-line
-            mutationMode="optimistic"
-        />
-    );
-};
-```
-
-`pessimistic`: The mutation runs immediately. Redirection and UI updates are executed after the mutation returns successfuly. This is the default setting.
-
-`optimistic`: The mutation is applied locally, redirection and UI updates are executed immediately as if the mutation is succesful. If the mutation returns with error, UI updates accordingly.
-
-`undoable`: The mutation is applied locally, redirection and UI updates are executed immediately as if mutation is succesful. Waits for a customizable amount of timeout before mutation is applied. During the timeout, mutation can be cancelled from the notification with the ?undo? button. UI will revert back accordingly.
-
-[Refer to the Mutation Mode docs for further information. &#8594](/guides-and-concepts/mutation-mode.md)
-
-## `undoableTimeout`
-
-The duration of the timeout period in **undoable** mode, shown in milliseconds. Mutations can be cancelled during this period. This period can also be set on the supported data hooks.  
-The value set in hooks will override the value set with `undoableTimeout`.  
-`undoableTimeout` has a default value of `5000`.
-
-```tsx title="App.tsx"
-const App: React.FC = () => {
-    return (
-        <Refine
-            ...
-            mutationMode="undoable"
-            // highlight-next-line
-            undoableTimeout={3500}
-        />
-    );
-};
-```
-
-<br />
-
-## `syncWithLocation`
-
-List query parameter values can be edited manually by typing directly in the URL. To activate this feature `syncWithLocation` needs to be set to `true`.
-
-When `syncWithLocation` is active, URL on the listing page shows query parameters like below:
-
-```
-/posts?current=1&pageSize=8&sort[]=createdAt&order[]=desc
-```
-
-Users are able to change current page, items count per page, sort and filter parameters.
-
-Default value is `false`.
-
-<br />
-
-## `warnWhenUnsavedChanges`
-
-When you have unsaved changes and try to leave the current page, **refine** shows a confirmation modal box.
-To activate this feature, set the `warnWhenUnsavedChanges` to `true`.
-
-<br />
-
-<div style={{textAlign: "center",  backgroundColor:"#efefef",  padding: "13px 10px 10px"}}>
-
-<img src={warnwhen} />
-
-</div>
-<br/>
-
-Default value is `false`.
-
-<br />
-
-## `liveMode`
-
-Whether to update data automatically (`auto`) or not (`manual`) if a related live event is received. The `off` value is used to avoid creating a subscription.
-
-[Refer to live provider documentation for detailed information. &#8594](/core/providers/live-provider.md#livemode)
-
-## `onLiveEvent`
-
-Callback to handle all live events.
-
-[Refer to live provider documentation for detailed information. &#8594](/core/providers/live-provider.md#refine)
 
 ## `LoginPage`
 
@@ -633,69 +703,6 @@ const App: React.FC = () => (
         // highlight-next-line
         Title={CustomTitle}
     />
-);
-```
-
-<br />
-
-## `reactQueryClientConfig`
-
-Config for React Query client that **refine** uses.
-
-**refine** uses some defaults that applies to all queries:
-
-```ts
-{
-    refetchOnWindowFocus: false,
-    keepPreviousData: true,
-}
-```
-
-[Refer to the QueryClient documentation for detailed information. &#8594](https://react-query.tanstack.com/reference/QueryClient#queryclient)
-
-```tsx
-const App: React.FC = () => (
-    <Refine
-        ...
-        // highlight-start
-        reactQueryClientConfig={{
-            defaultOptions: {
-                queries: {
-                    staleTime: Infinity,
-                },
-            },
-        }}
-        // highlight-end
-    />
-);
-```
-
-### `reactQueryDevtoolConfig`
-
-Config for customize React Query Devtools. If you want to disable the Devtools, set `reactQueryDevtoolConfig` to `false`.
-
-**refine** uses some defaults that applies to react-query devtool:
-
-```ts
-{
-    initialIsOpen: false,
-    position: "bottom-right"
-}
-```
-
-[Refer to the Devtools documentation for detailed information. &#8594](https://react-query.tanstack.com/devtools#options)
-
-```tsx {4-7}
-const App: React.FC = () => (
-    <Refine
-        dataProvider={dataProvider(API_URL)}
-        reactQueryDevtoolConfig={{
-            position: "bottom-left",
-            initialIsOpen: true,
-        }}
-    >
-        ...
-    </Refine>
 );
 ```
 

--- a/documentation/docs/core/components/refine-config.md
+++ b/documentation/docs/core/components/refine-config.md
@@ -396,6 +396,12 @@ Whether to update data automatically (`auto`) or not (`manual`) if a related liv
 
 [Refer to live provider documentation for detailed information. &#8594](/core/providers/live-provider.md#livemode)
 
+### `disableTelemetry`
+
+**refine** implements a simple and transparent telemetry module for collecting usage statistics defined in a very limited scope. This telemetry module is used to improve the **refine** experience. You can disable this by setting `disableTelemetry` to `true`.
+
+[Refer to refine telemetry documentation for detailed information. &#8594](/guides-and-concepts/telemetry/telemetry.md)
+
 ### `reactQuery`
 
 #### `clientConfig`

--- a/documentation/docs/core/providers/live-provider.md
+++ b/documentation/docs/core/providers/live-provider.md
@@ -225,7 +225,7 @@ const publish = usePublish();
 
 ## `liveMode`
 
-`liveMode` must be passed to either `<Refine>` or [supported hooks](#supported-hooks) for `liveProvider` to work. If it's not provided live features won't be activated. Passing it to `<Refine>` configures it app wide and hooks will use this option. It can also be passed to hooks directly without passing to `<Refine>` for detailed configuration. If both are provided value passed to the hook will override the value at `<Refine>`.
+`liveMode` must be passed to `<Refine>` in `options` or [supported hooks](#supported-hooks) for `liveProvider` to work. If it's not provided live features won't be activated. Passing it to `<Refine>` in `options` configures it app wide and hooks will use this option. It can also be passed to hooks directly without passing to `<Refine>` for detailed configuration. If both are provided value passed to the hook will override the value at `<Refine>`.
 
 #### Usage in `<Refine>`:
 
@@ -233,7 +233,9 @@ const publish = usePublish();
 // ...
 
 const App: React.FC = () => {
-    return <Refine liveProvider={liveProvider} liveMode="auto" />;
+    return (
+        <Refine liveProvider={liveProvider} options={{ liveMode: "auto" }} />
+    );
 };
 ```
 
@@ -273,7 +275,7 @@ const App: React.FC = () => {
     return (
         <Refine
             liveProvider={liveProvider}
-            liveMode="auto"
+            options={{ liveMode: "auto" }}
             onLiveEvent={(event) => {
                 // Put your own logic based on event
             }}
@@ -297,15 +299,15 @@ const { data } = useList({
 
 ## Supported Hooks
 
-| Supported data hooks                                     | Supported form hooks                                                 | Supported other hooks                                                       |
-| -------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| [`useList` &#8594](/core/hooks/data/useList.md) | [`useForm` &#8594](/core/hooks/useForm.md)             | [`useTable` &#8594](/core/hooks/useTable.md)                 |
+| Supported data hooks                            | Supported form hooks                                                      | Supported other hooks                                                            |
+| ----------------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [`useList` &#8594](/core/hooks/data/useList.md) | [`useForm` &#8594](/core/hooks/useForm.md)                                | [`useTable` &#8594](/core/hooks/useTable.md)                                     |
 | [`useOne` &#8594](/core/hooks/data/useOne.md)   | [`useModalForm` &#8594](/ui-frameworks/antd/hooks/form/useModalForm.md)   | [`useEditableTable` &#8594](/ui-frameworks/antd/hooks/table/useEditableTable.md) |
 | [`useMany` &#8594](/core/hooks/data/useMany.md) | [`useDrawerForm` &#8594](/ui-frameworks/antd/hooks/form/useDrawerForm.md) | [`useSimpleList` &#8594](/ui-frameworks/antd/hooks/list/useSimpleList.md)        |
-|                                                          | [`useStepsForm` &#8594](/ui-frameworks/antd/hooks/form/useStepsForm.md)   | [`useShow` &#8594](/core/hooks/show/useShow.md)                    |
-|                                                          |                                                                      | [`useCheckboxGroup` &#8594](/ui-frameworks/antd/hooks/field/useCheckboxGroup.md) |
-|                                                          |                                                                      | [`useSelect` &#8594](/core/hooks/useSelect.md)               |
-|                                                          |                                                                      | [`useRadioGroup` &#8594](/ui-frameworks/antd/hooks/field/useRadioGroup.md)       |
+|                                                 | [`useStepsForm` &#8594](/ui-frameworks/antd/hooks/form/useStepsForm.md)   | [`useShow` &#8594](/core/hooks/show/useShow.md)                                  |
+|                                                 |                                                                           | [`useCheckboxGroup` &#8594](/ui-frameworks/antd/hooks/field/useCheckboxGroup.md) |
+|                                                 |                                                                           | [`useSelect` &#8594](/core/hooks/useSelect.md)                                   |
+|                                                 |                                                                           | [`useRadioGroup` &#8594](/ui-frameworks/antd/hooks/field/useRadioGroup.md)       |
 
 ## Supported Hooks Subscriptions
 

--- a/documentation/docs/guides-and-concepts/data-provider/appwrite.md
+++ b/documentation/docs/guides-and-concepts/data-provider/appwrite.md
@@ -124,7 +124,7 @@ const App: React.FC = () => {
             liveProvider={liveProvider(appwriteClient, {
                 databaseId: "default",
             })}
-            liveMode="auto"
+             options={{ liveMode: "auto" }}
             authProvider={authProvider}
         //highlight-end    
             routerProvider={routerProvider}
@@ -377,7 +377,7 @@ const App: React.FC = () => {
             liveProvider={liveProvider(appwriteClient, {
                 databaseId: "default",
             })}
-            liveMode="auto"
+             options={{ liveMode: "auto" }}
             authProvider={authProvider}
             routerProvider={routerProvider}
             Layout={Layout}

--- a/documentation/docs/guides-and-concepts/multi-tenancy/appwrite.md
+++ b/documentation/docs/guides-and-concepts/multi-tenancy/appwrite.md
@@ -613,7 +613,7 @@ function App() {
                 routerProvider={routerProvider}
                 //highlight-start
                 liveProvider={liveProvider(appwriteClient)}
-                liveMode="auto"
+                options={{ liveMode: "auto" }}
                 //highlight-end
                 dataProvider={dataProvider(appwriteClient)}
                 authProvider={authProvider}

--- a/documentation/docs/guides-and-concepts/mutation-mode.md
+++ b/documentation/docs/guides-and-concepts/mutation-mode.md
@@ -82,7 +82,10 @@ The mutation is applied locally, redirection and UI updates are executed immedia
 Mutation mode can be set application-wide in [`<Refine>`](/core/components/refine-config.md#mutationmode) component.
 
 ```tsx title="App.tsx"
-<Refine ... mutationMode="optimistic" />
+<Refine
+    ...
+    options={{ mutationMode: "optimistic" }}
+/>
 ```
 
 > Its default value is `pessimistic`.
@@ -100,7 +103,7 @@ mutate({
     resource: "categories",
     id: "2",
     values: { title: "New Category Title" },
-// highlight-next-line
+    // highlight-next-line
     mutationMode: "optimistic",
 });
 ```

--- a/documentation/docs/guides-and-concepts/real-time.md
+++ b/documentation/docs/guides-and-concepts/real-time.md
@@ -76,7 +76,7 @@ const App: React.FC = () => {
             catchAll={<ErrorComponent />}
             //highlight-start
             liveProvider={liveProvider(ablyClient)}
-            liveMode="auto"
+            options={{ liveMode: "auto" }}
             //highlight-end
             resources={[
                 {
@@ -97,7 +97,7 @@ export default App;
 
 :::note
 
-For live features to work automatically we also added `liveMode="auto"`.
+For live features to work automatically we added `liveMode: "auto"` in `options` prop.
 
 [Refer to the Live Provider documentation for detailed information. &#8594](/core/providers/live-provider.md#livemode)
 :::

--- a/documentation/src/theme/ReactLiveScope/antd.tsx
+++ b/documentation/src/theme/ReactLiveScope/antd.tsx
@@ -7,7 +7,14 @@ import * as RefineAntd from "@pankod/refine-antd";
 const SIMPLE_REST_API_URL = "https://api.fake-rest.refine.dev";
 
 const Refine = (props) => (
-    <RefineCore.Refine {...props} reactQueryDevtoolConfig={false} />
+    <RefineCore.Refine
+        {...props}
+        options={{
+            reactQuery: {
+                devtoolConfig: false,
+            },
+        }}
+    />
 );
 
 const antLayoutSider: React.CSSProperties = {
@@ -174,8 +181,12 @@ const RefineAntdDemo: React.FC<
             Layout={RefineAntd.Layout}
             Sider={() => null}
             catchAll={<RefineAntd.ErrorComponent />}
-            disableTelemetry={true}
-            reactQueryDevtoolConfig={false}
+            options={{
+                disableTelemetry: true,
+                reactQuery: {
+                    devtoolConfig: false,
+                },
+            }}
             {...rest}
         />
     );

--- a/documentation/src/theme/ReactLiveScope/headless.tsx
+++ b/documentation/src/theme/ReactLiveScope/headless.tsx
@@ -6,7 +6,14 @@ import * as RefineSimpleRest from "@pankod/refine-simple-rest";
 const SIMPLE_REST_API_URL = "https://api.fake-rest.refine.dev";
 
 const Refine = (props) => (
-    <RefineCore.Refine {...props} reactQueryDevtoolConfig={false} />
+    <RefineCore.Refine
+        {...props}
+        options={{
+            reactQuery: {
+                devtoolConfig: false,
+            },
+        }}
+    />
 );
 
 const RefineDemoReactRouterV6 = (
@@ -27,8 +34,12 @@ const RefineHeadlessDemo: React.FC<
         <RefineCore.Refine
             routerProvider={RefineDemoReactRouterV6(initialRoutes)}
             dataProvider={RefineSimpleRest.default(SIMPLE_REST_API_URL)}
-            disableTelemetry={true}
-            reactQueryDevtoolConfig={false}
+            options={{
+                disableTelemetry: true,
+                reactQuery: {
+                    devtoolConfig: false,
+                },
+            }}
             {...rest}
         />
     );

--- a/documentation/src/theme/ReactLiveScope/mui.tsx
+++ b/documentation/src/theme/ReactLiveScope/mui.tsx
@@ -7,7 +7,14 @@ import * as RefineMui from "@pankod/refine-mui";
 const SIMPLE_REST_API_URL = "https://api.fake-rest.refine.dev";
 
 const Refine = (props) => (
-    <RefineCore.Refine {...props} reactQueryDevtoolConfig={false} />
+    <RefineCore.Refine
+        {...props}
+        options={{
+            reactQuery: {
+                devtoolConfig: false,
+            },
+        }}
+    />
 );
 
 const RefineDemoReactRouterV6 = (
@@ -38,8 +45,12 @@ const RefineMuiDemo: React.FC<
                     Layout={RefineMui.Layout}
                     Sider={() => null}
                     catchAll={<RefineMui.ErrorComponent />}
-                    disableTelemetry={true}
-                    reactQueryDevtoolConfig={false}
+                    options={{
+                        disableTelemetry: true,
+                        reactQuery: {
+                            devtoolConfig: false,
+                        },
+                    }}
                     {...rest}
                 />
             </RefineMui.RefineSnackbarProvider>

--- a/examples/ably/src/App.tsx
+++ b/examples/ably/src/App.tsx
@@ -40,12 +40,11 @@ const App: React.FC = () => {
                     show: CategoryShow,
                 },
             ]}
-            options={{ liveMode: "auto" }}
+            options={{ liveMode: "auto", disableTelemetry: true }}
             Sider={CustomSider}
             Title={Title}
             notificationProvider={notificationProvider}
             Layout={Layout}
-            disableTelemetry={true}
         />
     );
 };

--- a/examples/ably/src/App.tsx
+++ b/examples/ably/src/App.tsx
@@ -40,7 +40,7 @@ const App: React.FC = () => {
                     show: CategoryShow,
                 },
             ]}
-            liveMode="auto"
+            options={{ liveMode: "auto" }}
             Sider={CustomSider}
             Title={Title}
             notificationProvider={notificationProvider}

--- a/examples/accessControl/casbin/src/App.tsx
+++ b/examples/accessControl/casbin/src/App.tsx
@@ -87,7 +87,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/accessControl/cerbos/src/App.tsx
+++ b/examples/accessControl/cerbos/src/App.tsx
@@ -91,7 +91,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/antdAuditLog/src/App.tsx
+++ b/examples/antdAuditLog/src/App.tsx
@@ -110,7 +110,7 @@ const App: React.FC = () => {
                     });
                 },
             }}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/auditLogProvider/src/App.tsx
+++ b/examples/auditLogProvider/src/App.tsx
@@ -55,7 +55,7 @@ const App: React.FC = () => {
                     canDelete: true,
                 },
             ]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/authProvider/auth0/src/App.tsx
+++ b/examples/authProvider/auth0/src/App.tsx
@@ -78,7 +78,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/authProvider/googleLogin/src/App.tsx
+++ b/examples/authProvider/googleLogin/src/App.tsx
@@ -84,7 +84,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/authProvider/otpLogin/src/App.tsx
+++ b/examples/authProvider/otpLogin/src/App.tsx
@@ -54,7 +54,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/authentication/src/App.tsx
+++ b/examples/authentication/src/App.tsx
@@ -61,7 +61,7 @@ const App: React.FC = () => {
             LoginPage={LoginPage}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/authorization/src/App.tsx
+++ b/examples/authorization/src/App.tsx
@@ -87,7 +87,7 @@ const App: React.FC = () => {
             LoginPage={LoginPage}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/base/antd/src/App.tsx
+++ b/examples/base/antd/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/base/headless/src/App.tsx
+++ b/examples/base/headless/src/App.tsx
@@ -18,7 +18,7 @@ const App: React.FC = () => {
                     edit: PostEdit,
                 },
             ]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/base/mui/src/App.tsx
+++ b/examples/base/mui/src/App.tsx
@@ -40,7 +40,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/blog/ecommerce/pages/_app.tsx
+++ b/examples/blog/ecommerce/pages/_app.tsx
@@ -31,8 +31,8 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
                 dataProvider={dataProvider}
                 resources={[{ name: "products" }]}
                 Layout={Layout}
-                reactQueryDevtoolConfig={{
-                    position: "bottom-left",
+                options={{
+                    reactQuery: { devtoolConfig: { position: "bottom-left" } },
                 }}
                 disableTelemetry={true}
             >

--- a/examples/blog/ecommerce/pages/_app.tsx
+++ b/examples/blog/ecommerce/pages/_app.tsx
@@ -33,8 +33,8 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
                 Layout={Layout}
                 options={{
                     reactQuery: { devtoolConfig: { position: "bottom-left" } },
+                    disableTelemetry: true,
                 }}
-                disableTelemetry={true}
             >
                 <ChakraProvider>
                     <Component {...pageProps} />

--- a/examples/blog/hackathonize/src/App.tsx
+++ b/examples/blog/hackathonize/src/App.tsx
@@ -82,7 +82,7 @@ function App() {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 }

--- a/examples/blog/invoiceGenerator/src/App.tsx
+++ b/examples/blog/invoiceGenerator/src/App.tsx
@@ -68,7 +68,7 @@ function App() {
                     icon: <FileAddOutlined />,
                 },
             ]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 }

--- a/examples/blog/issueTracker/src/App.tsx
+++ b/examples/blog/issueTracker/src/App.tsx
@@ -49,7 +49,7 @@ function App() {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 }

--- a/examples/blog/jobPosting/src/App.tsx
+++ b/examples/blog/jobPosting/src/App.tsx
@@ -50,7 +50,7 @@ function App() {
                     show: CompanyShow,
                 },
             ]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 }

--- a/examples/blog/mailSubscription/src/App.tsx
+++ b/examples/blog/mailSubscription/src/App.tsx
@@ -43,7 +43,7 @@ function App() {
             notificationProvider={notificationProvider}
             LoginPage={LoginPage}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 }

--- a/examples/blog/material-ui/src/App.tsx
+++ b/examples/blog/material-ui/src/App.tsx
@@ -42,8 +42,10 @@ function App() {
                             canDelete: true,
                         },
                     ]}
-                    mutationMode="undoable"
-                    syncWithLocation={true}
+                    options={{
+                        mutationMode: "undoable",
+                        syncWithLocation: true,
+                    }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/blog/material-ui/src/App.tsx
+++ b/examples/blog/material-ui/src/App.tsx
@@ -45,6 +45,7 @@ function App() {
                     options={{
                         mutationMode: "undoable",
                         syncWithLocation: true,
+                        disableTelemetry: true,
                     }}
                 />
             </RefineSnackbarProvider>

--- a/examples/blog/react-aria/src/App.tsx
+++ b/examples/blog/react-aria/src/App.tsx
@@ -19,6 +19,7 @@ function App() {
                 },
             ]}
             Layout={({ children }) => <Layout> {children}</Layout>}
+            options={{ disableTelemetry: true }}
         />
     );
 }

--- a/examples/blog/refeedback/src/App.tsx
+++ b/examples/blog/refeedback/src/App.tsx
@@ -39,7 +39,7 @@ function App() {
             notificationProvider={notificationProvider}
             LoginPage={LoginPage}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 }

--- a/examples/blog/refineflix/src/App.tsx
+++ b/examples/blog/refineflix/src/App.tsx
@@ -57,7 +57,7 @@ function App() {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 }

--- a/examples/blog/win95/src/App.tsx
+++ b/examples/blog/win95/src/App.tsx
@@ -46,7 +46,7 @@ function App() {
                         edit: CategoryEdit,
                     },
                 ]}
-                disableTelemetry={true}
+                options={{ disableTelemetry: true }}
             />
         </ThemeProvider>
     );

--- a/examples/calendar/src/App.tsx
+++ b/examples/calendar/src/App.tsx
@@ -20,7 +20,7 @@ const App: React.FC = () => {
                 },
             ]}
             Layout={Layout}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/cloud/src/App.tsx
+++ b/examples/cloud/src/App.tsx
@@ -45,7 +45,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/commandPalette/kbar/src/App.tsx
+++ b/examples/commandPalette/kbar/src/App.tsx
@@ -49,6 +49,7 @@ const App: React.FC = () => {
                 Layout={Layout}
                 OffLayoutArea={OffLayoutArea}
                 catchAll={<ErrorComponent />}
+                options={{ disableTelemetry: true }}
             />
         </RefineKbarProvider>
     );

--- a/examples/core/useImport/src/App.tsx
+++ b/examples/core/useImport/src/App.tsx
@@ -10,7 +10,7 @@ const App: React.FC = () => {
             dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
             routerProvider={routerProvider}
             resources={[{ name: "posts", list: DummyList }]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/core/useModal/src/App.tsx
+++ b/examples/core/useModal/src/App.tsx
@@ -10,7 +10,7 @@ const App: React.FC = () => {
             dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
             routerProvider={routerProvider}
             resources={[{ name: "posts", list: DummyList }]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/core/useSelect/src/App.tsx
+++ b/examples/core/useSelect/src/App.tsx
@@ -10,7 +10,7 @@ const App: React.FC = () => {
             dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
             routerProvider={routerProvider}
             resources={[{ name: "posts", list: DummyList }]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/customPages/src/App.tsx
+++ b/examples/customPages/src/App.tsx
@@ -76,7 +76,7 @@ const App: React.FC = () => {
             LoginPage={LoginPage}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/customization/customFooter/src/App.tsx
+++ b/examples/customization/customFooter/src/App.tsx
@@ -40,7 +40,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/customization/customLogin/src/App.tsx
+++ b/examples/customization/customLogin/src/App.tsx
@@ -54,7 +54,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/customization/customSider/src/App.tsx
+++ b/examples/customization/customSider/src/App.tsx
@@ -57,7 +57,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/customization/customTheme/antd/src/App.tsx
+++ b/examples/customization/customTheme/antd/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/customization/customTheme/mui/src/App.tsx
+++ b/examples/customization/customTheme/mui/src/App.tsx
@@ -39,7 +39,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ColorModeContextProvider>

--- a/examples/customization/offLayoutArea/src/App.tsx
+++ b/examples/customization/offLayoutArea/src/App.tsx
@@ -57,7 +57,7 @@ const App: React.FC = () => {
             ]}
             notificationProvider={notificationProvider}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/customization/rtl/src/App.tsx
+++ b/examples/customization/rtl/src/App.tsx
@@ -32,7 +32,7 @@ const App: React.FC = () => {
                 notificationProvider={notificationProvider}
                 Layout={Layout}
                 catchAll={<ErrorComponent />}
-                disableTelemetry={true}
+                options={{ disableTelemetry: true }}
             />
         </ConfigProvider>
     );

--- a/examples/customization/topMenuLayout/src/App.tsx
+++ b/examples/customization/topMenuLayout/src/App.tsx
@@ -54,7 +54,7 @@ const App: React.FC = () => {
             ]}
             notificationProvider={notificationProvider}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/dataProvider/airtable/src/App.tsx
+++ b/examples/dataProvider/airtable/src/App.tsx
@@ -39,7 +39,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/dataProvider/altogic/src/App.tsx
+++ b/examples/dataProvider/altogic/src/App.tsx
@@ -55,7 +55,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/dataProvider/appwrite/src/App.tsx
+++ b/examples/dataProvider/appwrite/src/App.tsx
@@ -66,7 +66,7 @@ const App: React.FC = () => {
             liveProvider={liveProvider(appwriteClient, {
                 databaseId: "default",
             })}
-            liveMode="auto"
+            options={{ liveMode: "auto" }}
             authProvider={authProvider}
             routerProvider={routerProvider}
             LoginPage={Login}

--- a/examples/dataProvider/appwrite/src/App.tsx
+++ b/examples/dataProvider/appwrite/src/App.tsx
@@ -57,7 +57,6 @@ const authProvider: AuthProvider = {
 };
 
 const App: React.FC = () => {
-    console.log("render");
     return (
         <Refine
             dataProvider={dataProvider(appwriteClient, {
@@ -66,7 +65,7 @@ const App: React.FC = () => {
             liveProvider={liveProvider(appwriteClient, {
                 databaseId: "default",
             })}
-            options={{ liveMode: "auto" }}
+            options={{ liveMode: "auto", disableTelemetry: true }}
             authProvider={authProvider}
             routerProvider={routerProvider}
             LoginPage={Login}
@@ -85,7 +84,6 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
         />
     );
 };

--- a/examples/dataProvider/hasura/src/App.tsx
+++ b/examples/dataProvider/hasura/src/App.tsx
@@ -44,7 +44,7 @@ const App: React.FC = () => {
             dataProvider={gqlDataProvider}
             // ## Refine supports GraphQL subscriptions as out-of-the-box. For more detailed information, please visit here, https://refine.dev/docs/core/providers/live-provider/
             //liveProvider={liveProvider(gqlWebSocketClient)}
-            //liveMode="auto"
+            //options={{ liveMode: "auto" }}
             resources={[
                 {
                     name: "posts",

--- a/examples/dataProvider/hasura/src/App.tsx
+++ b/examples/dataProvider/hasura/src/App.tsx
@@ -63,7 +63,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/dataProvider/multiple/src/App.tsx
+++ b/examples/dataProvider/multiple/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/dataProvider/nestjsxCrud/src/App.tsx
+++ b/examples/dataProvider/nestjsxCrud/src/App.tsx
@@ -37,7 +37,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/dataProvider/nhost/src/App.tsx
+++ b/examples/dataProvider/nhost/src/App.tsx
@@ -84,7 +84,7 @@ const App: React.FC = () => {
                 dataProvider={dataProvider(nhost)}
                 // Refine supports GraphQL subscriptions as out-of-the-box. For more detailed information, please visit here, https://refine.dev/docs/core/providers/live-provider/
                 // liveProvider={liveProvider(gqlWebSocketClient)}
-                // liveMode="auto"
+                // options={{ liveMode: "auto" }}
                 authProvider={authProvider}
                 resources={[
                     {

--- a/examples/dataProvider/nhost/src/App.tsx
+++ b/examples/dataProvider/nhost/src/App.tsx
@@ -105,7 +105,7 @@ const App: React.FC = () => {
                 Layout={Layout}
                 LoginPage={LoginPage}
                 catchAll={<ErrorComponent />}
-                disableTelemetry={true}
+                options={{ disableTelemetry: true }}
             />
         </NhostAuthProvider>
     );

--- a/examples/dataProvider/strapi-graphql/src/App.tsx
+++ b/examples/dataProvider/strapi-graphql/src/App.tsx
@@ -124,7 +124,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/dataProvider/strapi-v4/src/App.tsx
+++ b/examples/dataProvider/strapi-v4/src/App.tsx
@@ -104,7 +104,7 @@ const App: React.FC = () => {
             LoginPage={LoginPage}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/dataProvider/strapi/src/App.tsx
+++ b/examples/dataProvider/strapi/src/App.tsx
@@ -100,7 +100,7 @@ const App: React.FC = () => {
             LoginPage={LoginPage}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/dataProvider/supabase/src/App.tsx
+++ b/examples/dataProvider/supabase/src/App.tsx
@@ -84,11 +84,10 @@ const App: React.FC = () => {
                     show: PostShow,
                 },
             ]}
-            options={{ liveMode: "auto" }}
+            options={{ liveMode: "auto", disableTelemetry: true }}
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
         />
     );
 };

--- a/examples/dataProvider/supabase/src/App.tsx
+++ b/examples/dataProvider/supabase/src/App.tsx
@@ -84,7 +84,7 @@ const App: React.FC = () => {
                     show: PostShow,
                 },
             ]}
-            liveMode="auto"
+            options={{ liveMode: "auto" }}
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}

--- a/examples/e2e/src/App.tsx
+++ b/examples/e2e/src/App.tsx
@@ -32,7 +32,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/field/useCheckboxGroup/src/App.tsx
+++ b/examples/field/useCheckboxGroup/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/field/useRadioGroup/src/App.tsx
+++ b/examples/field/useRadioGroup/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/field/useSelect/mui/src/App.tsx
+++ b/examples/field/useSelect/mui/src/App.tsx
@@ -36,7 +36,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </SnackbarProvider>
         </ThemeProvider>

--- a/examples/field/useSelect/src/App.tsx
+++ b/examples/field/useSelect/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/fineFoods/admin/antd/src/App.tsx
+++ b/examples/fineFoods/admin/antd/src/App.tsx
@@ -71,8 +71,10 @@ const App: React.FC = () => {
                     Title={Title}
                     Header={Header}
                     Layout={Layout}
-                    syncWithLocation
-                    warnWhenUnsavedChanges
+                    options={{
+                        syncWithLocation: true,
+                        warnWhenUnsavedChanges: true,
+                    }}
                     resources={[
                         {
                             name: "orders",

--- a/examples/fineFoods/admin/antd/src/App.tsx
+++ b/examples/fineFoods/admin/antd/src/App.tsx
@@ -74,6 +74,7 @@ const App: React.FC = () => {
                     options={{
                         syncWithLocation: true,
                         warnWhenUnsavedChanges: true,
+                        disableTelemetry: true,
                     }}
                     resources={[
                         {
@@ -121,8 +122,7 @@ const App: React.FC = () => {
                     ]}
                     notificationProvider={notificationProvider}
                     catchAll={<ErrorComponent />}
-                    disableTelemetry={true}
-                ></Refine>
+                />
             </ConfigProvider>
         </RefineKbarProvider>
     );

--- a/examples/fineFoods/admin/mui/src/App.tsx
+++ b/examples/fineFoods/admin/mui/src/App.tsx
@@ -70,8 +70,10 @@ const App: React.FC = () => {
                         Header={Header}
                         LoginPage={LoginPage}
                         catchAll={<ErrorComponent />}
-                        syncWithLocation
-                        warnWhenUnsavedChanges
+                        options={{
+                            syncWithLocation: true,
+                            warnWhenUnsavedChanges: true,
+                        }}
                         notificationProvider={notificationProvider}
                         OffLayoutArea={OffLayoutArea}
                         resources={[

--- a/examples/fineFoods/admin/mui/src/App.tsx
+++ b/examples/fineFoods/admin/mui/src/App.tsx
@@ -73,6 +73,7 @@ const App: React.FC = () => {
                         options={{
                             syncWithLocation: true,
                             warnWhenUnsavedChanges: true,
+                            disableTelemetry: true,
                         }}
                         notificationProvider={notificationProvider}
                         OffLayoutArea={OffLayoutArea}
@@ -120,7 +121,6 @@ const App: React.FC = () => {
                                 icon: <StarBorderOutlined />,
                             },
                         ]}
-                        disableTelemetry={true}
                     />
                 </RefineSnackbarProvider>
             </ColorModeContextProvider>

--- a/examples/fineFoods/client/pages/_app.tsx
+++ b/examples/fineFoods/client/pages/_app.tsx
@@ -17,7 +17,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
             dataProvider={dataProvider(API_URL)}
             Layout={Layout}
             resources={[{ name: "users" }]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         >
             <Head>
                 <title>finefoods client example - refine</title>

--- a/examples/form/antd/customValidation/src/App.tsx
+++ b/examples/form/antd/customValidation/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/form/antd/useDrawerForm/src/App.tsx
+++ b/examples/form/antd/useDrawerForm/src/App.tsx
@@ -27,7 +27,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/form/antd/useForm/src/App.tsx
+++ b/examples/form/antd/useForm/src/App.tsx
@@ -29,7 +29,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/form/antd/useModalForm/src/App.tsx
+++ b/examples/form/antd/useModalForm/src/App.tsx
@@ -27,7 +27,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/form/antd/useStepsForm/src/App.tsx
+++ b/examples/form/antd/useStepsForm/src/App.tsx
@@ -29,7 +29,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/form/headless/saveAndContinue/src/App.tsx
+++ b/examples/form/headless/saveAndContinue/src/App.tsx
@@ -10,7 +10,7 @@ const App: React.FC = () => {
         <Refine
             dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
             routerProvider={routerProvider}
-            options={{ mutationMode: "pessimistic" }}
+            options={{ mutationMode: "pessimistic", disableTelemetry: true }}
             resources={[
                 {
                     name: "posts",
@@ -19,7 +19,6 @@ const App: React.FC = () => {
                     edit: PostEdit,
                 },
             ]}
-            disableTelemetry={true}
         />
     );
 };

--- a/examples/form/headless/saveAndContinue/src/App.tsx
+++ b/examples/form/headless/saveAndContinue/src/App.tsx
@@ -10,7 +10,7 @@ const App: React.FC = () => {
         <Refine
             dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
             routerProvider={routerProvider}
-            mutationMode="pessimistic"
+            options={{ mutationMode: "pessimistic" }}
             resources={[
                 {
                     name: "posts",

--- a/examples/form/mui/useDrawerForm/src/App.tsx
+++ b/examples/form/mui/useDrawerForm/src/App.tsx
@@ -38,7 +38,7 @@ const App: React.FC = () => {
                             list: PostsList,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/form/mui/useForm/src/App.tsx
+++ b/examples/form/mui/useForm/src/App.tsx
@@ -40,7 +40,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/form/mui/useModalForm/src/App.tsx
+++ b/examples/form/mui/useModalForm/src/App.tsx
@@ -38,7 +38,7 @@ const App: React.FC = () => {
                             list: PostsList,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/form/mui/useStepsForm/src/App.tsx
+++ b/examples/form/mui/useStepsForm/src/App.tsx
@@ -40,7 +40,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/form/reactHookForm/useForm/src/App.tsx
+++ b/examples/form/reactHookForm/useForm/src/App.tsx
@@ -17,7 +17,7 @@ const App: React.FC = () => {
                     edit: PostEdit,
                 },
             ]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/form/reactHookForm/useModalForm/src/App.tsx
+++ b/examples/form/reactHookForm/useModalForm/src/App.tsx
@@ -17,7 +17,7 @@ const App: React.FC = () => {
                     list: PostList,
                 },
             ]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/form/reactHookForm/useStepsForm/src/App.tsx
+++ b/examples/form/reactHookForm/useStepsForm/src/App.tsx
@@ -17,7 +17,7 @@ const App: React.FC = () => {
                     edit: PostEdit,
                 },
             ]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/i18n/nextjs/pages/_app.tsx
+++ b/examples/i18n/nextjs/pages/_app.tsx
@@ -6,7 +6,6 @@ import { appWithTranslation, useTranslation } from "next-i18next";
 
 import {
     notificationProvider,
-    LoginPage,
     Layout,
     ErrorComponent,
 } from "@pankod/refine-antd";
@@ -47,7 +46,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         >
             <Component {...pageProps} />
         </Refine>

--- a/examples/i18n/react/src/App.tsx
+++ b/examples/i18n/react/src/App.tsx
@@ -43,7 +43,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/importExport/antd/src/App.tsx
+++ b/examples/importExport/antd/src/App.tsx
@@ -24,7 +24,7 @@ const App: React.FC = () => {
                     show: PostShow,
                 },
             ]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/importExport/mui/src/App.tsx
+++ b/examples/importExport/mui/src/App.tsx
@@ -37,7 +37,7 @@ const App: React.FC = () => {
                             list: ImportList,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/inputs/customInputs/src/App.tsx
+++ b/examples/inputs/customInputs/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/inputs/datePicker/src/App.tsx
+++ b/examples/inputs/datePicker/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/javascript/src/App.js
+++ b/examples/javascript/src/App.js
@@ -30,8 +30,8 @@ const App = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
-        ></Refine>
+            options={{ disableTelemetry: true }}
+        />
     );
 };
 

--- a/examples/list/useSimpleList/src/App.tsx
+++ b/examples/list/useSimpleList/src/App.tsx
@@ -27,7 +27,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/multi-level-menu/src/App.tsx
+++ b/examples/multi-level-menu/src/App.tsx
@@ -42,7 +42,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/multi-tenancy/appwrite/src/App.tsx
+++ b/examples/multi-tenancy/appwrite/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
                 dataProvider={dataProvider(appwriteClient)}
                 authProvider={authProvider}
                 LoginPage={Login}
-                liveMode="auto"
+                options={{ liveMode: "auto" }}
                 Sider={CustomSider}
                 resources={[
                     {

--- a/examples/multi-tenancy/appwrite/src/App.tsx
+++ b/examples/multi-tenancy/appwrite/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
                 dataProvider={dataProvider(appwriteClient)}
                 authProvider={authProvider}
                 LoginPage={Login}
-                options={{ liveMode: "auto" }}
+                options={{ liveMode: "auto", disableTelemetry: true }}
                 Sider={CustomSider}
                 resources={[
                     {
@@ -54,7 +54,6 @@ function App() {
                 notificationProvider={notificationProvider}
                 Layout={Layout}
                 catchAll={<ErrorComponent />}
-                disableTelemetry={true}
             />
         </StoreProvider>
     );

--- a/examples/multi-tenancy/strapi/src/App.tsx
+++ b/examples/multi-tenancy/strapi/src/App.tsx
@@ -41,7 +41,7 @@ const App: React.FC = () => {
                 LoginPage={LoginPage}
                 Layout={Layout}
                 catchAll={ErrorComponent}
-                disableTelemetry={true}
+                options={{ disableTelemetry: true }}
             />
         </StoreProvider>
     );

--- a/examples/mutationMode/src/App.tsx
+++ b/examples/mutationMode/src/App.tsx
@@ -41,7 +41,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/reactToastify/src/App.tsx
+++ b/examples/reactToastify/src/App.tsx
@@ -29,7 +29,7 @@ const App: React.FC = () => {
                     <ToastContainer />
                 </div>
             )}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/real-world-example/src/App.tsx
+++ b/examples/real-world-example/src/App.tsx
@@ -81,7 +81,7 @@ function App() {
                 { name: "editor", list: EditorPage },
             ]}
             Layout={Layout}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 }

--- a/examples/refine-next/pages/_app.tsx
+++ b/examples/refine-next/pages/_app.tsx
@@ -36,12 +36,11 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
                     canDelete: true,
                 },
             ]}
-            options={{ syncWithLocation: true }}
+            options={{ syncWithLocation: true, disableTelemetry: true }}
             notificationProvider={notificationProvider}
             LoginPage={LoginPage}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
         >
             <Component {...pageProps} />
         </Refine>

--- a/examples/refine-next/pages/_app.tsx
+++ b/examples/refine-next/pages/_app.tsx
@@ -36,7 +36,7 @@ function MyApp({ Component, pageProps }: AppProps): JSX.Element {
                     canDelete: true,
                 },
             ]}
-            warnWhenUnsavedChanges={true}
+            options={{ syncWithLocation: true }}
             notificationProvider={notificationProvider}
             LoginPage={LoginPage}
             Layout={Layout}

--- a/examples/remix/antd/app/root.tsx
+++ b/examples/remix/antd/app/root.tsx
@@ -50,7 +50,7 @@ export default function App() {
                             show: PostShow,
                         },
                     ]}
-                    options={{ syncWithLocation: true }}
+                    options={{ syncWithLocation: true, disableTelemetry: true }}
                 >
                     <Outlet />
                 </Refine>

--- a/examples/remix/antd/app/root.tsx
+++ b/examples/remix/antd/app/root.tsx
@@ -50,7 +50,7 @@ export default function App() {
                             show: PostShow,
                         },
                     ]}
-                    syncWithLocation
+                    options={{ syncWithLocation: true }}
                 >
                     <Outlet />
                 </Refine>

--- a/examples/remix/headless/app/root.tsx
+++ b/examples/remix/headless/app/root.tsx
@@ -42,7 +42,7 @@ export default function App() {
                             edit: PostEdit,
                         },
                     ]}
-                    syncWithLocation
+                    options={{ syncWithLocation: true, disableTelemetry: true }}
                 >
                     <Outlet />
                 </Refine>

--- a/examples/routerProvider/react-location/src/App.tsx
+++ b/examples/routerProvider/react-location/src/App.tsx
@@ -17,8 +17,10 @@ const App: React.FC = () => {
         <Refine
             routerProvider={routerProvider}
             dataProvider={dataProvider(API_URL)}
-            syncWithLocation
-            warnWhenUnsavedChanges
+            options={{
+                syncWithLocation: true,
+                warnWhenUnsavedChanges: true,
+            }}
             resources={[
                 {
                     name: "posts",

--- a/examples/routerProvider/react-location/src/App.tsx
+++ b/examples/routerProvider/react-location/src/App.tsx
@@ -20,6 +20,7 @@ const App: React.FC = () => {
             options={{
                 syncWithLocation: true,
                 warnWhenUnsavedChanges: true,
+                disableTelemetry: true,
             }}
             resources={[
                 {
@@ -34,7 +35,6 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
         />
     );
 };

--- a/examples/search/src/App.tsx
+++ b/examples/search/src/App.tsx
@@ -46,7 +46,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/storybook/antd/.storybook/preview.js
+++ b/examples/storybook/antd/.storybook/preview.js
@@ -33,7 +33,7 @@ export const RefineWithLayout = (Story) => (
         list: Story,
       },
     ]}
-    disableTelemetry={true}
+    options={{ disableTelemetry: true }}
   />
 );
 
@@ -50,6 +50,6 @@ export const RefineWithoutLayout = (Story) => (
         list: Story,
       },
     ]}
-    disableTelemetry={true}
+    options={{ disableTelemetry: true }}
   />
 );

--- a/examples/storybook/antd/src/App.tsx
+++ b/examples/storybook/antd/src/App.tsx
@@ -18,7 +18,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/storybook/mui/.storybook/preview.js
+++ b/examples/storybook/mui/.storybook/preview.js
@@ -53,7 +53,7 @@ export const RefineWithLayout = (Story) => (
                     list: Story,
                 },
             ]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     </ThemeProvider>
 );
@@ -80,7 +80,7 @@ export const RefineWithoutLayout = (Story) => (
                     list: Story,
                 },
             ]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     </ThemeProvider>
 );

--- a/examples/storybook/mui/src/App.tsx
+++ b/examples/storybook/mui/src/App.tsx
@@ -10,7 +10,7 @@ const App: React.FC = () => {
         <Refine
             routerProvider={routerProvider}
             dataProvider={dataProvider(API_URL)}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/table/antd/advancedTable/src/App.tsx
+++ b/examples/table/antd/advancedTable/src/App.tsx
@@ -37,7 +37,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/table/antd/tableFilter/src/App.tsx
+++ b/examples/table/antd/tableFilter/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/table/antd/useDeleteMany/src/App.tsx
+++ b/examples/table/antd/useDeleteMany/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/table/antd/useEditableTable/src/App.tsx
+++ b/examples/table/antd/useEditableTable/src/App.tsx
@@ -27,7 +27,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/table/antd/useTable/src/App.tsx
+++ b/examples/table/antd/useTable/src/App.tsx
@@ -27,7 +27,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/table/antd/useUpdateMany/src/App.tsx
+++ b/examples/table/antd/useUpdateMany/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/table/handson/src/App.tsx
+++ b/examples/table/handson/src/App.tsx
@@ -15,7 +15,7 @@ const App: React.FC = () => {
                     list: PostList,
                 },
             ]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/table/mui/advancedTable/src/App.tsx
+++ b/examples/table/mui/advancedTable/src/App.tsx
@@ -50,7 +50,7 @@ const App: React.FC = () => {
                             options: { route: "data-grid", label: "Data Grid" },
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/table/mui/dataGridPro/src/App.tsx
+++ b/examples/table/mui/dataGridPro/src/App.tsx
@@ -36,7 +36,7 @@ const App: React.FC = () => {
                             list: PostsList,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/table/mui/tableFilter/src/App.tsx
+++ b/examples/table/mui/tableFilter/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
                     ReadyPage={ReadyPage}
                     Layout={Layout}
                     catchAll={<ErrorComponent />}
-                    syncWithLocation
+                    options={{ syncWithLocation: true }}
                     resources={[
                         {
                             name: "posts",

--- a/examples/table/mui/tableFilter/src/App.tsx
+++ b/examples/table/mui/tableFilter/src/App.tsx
@@ -30,14 +30,13 @@ const App: React.FC = () => {
                     ReadyPage={ReadyPage}
                     Layout={Layout}
                     catchAll={<ErrorComponent />}
-                    options={{ syncWithLocation: true }}
+                    options={{ syncWithLocation: true, disableTelemetry: true }}
                     resources={[
                         {
                             name: "posts",
                             list: PostsList,
                         },
                     ]}
-                    disableTelemetry={true}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/table/mui/useDataGrid/src/App.tsx
+++ b/examples/table/mui/useDataGrid/src/App.tsx
@@ -36,7 +36,7 @@ const App: React.FC = () => {
                             list: PostsList,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/table/mui/useDeleteMany/src/App.tsx
+++ b/examples/table/mui/useDeleteMany/src/App.tsx
@@ -38,7 +38,7 @@ const App: React.FC = () => {
                             list: PostsList,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/table/mui/useUpdateMany/src/App.tsx
+++ b/examples/table/mui/useUpdateMany/src/App.tsx
@@ -36,7 +36,7 @@ const App: React.FC = () => {
                             list: PostsList,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/table/reactTable/advanced/src/App.tsx
+++ b/examples/table/reactTable/advanced/src/App.tsx
@@ -17,7 +17,7 @@ const App: React.FC = () => {
                     list: PostList,
                 },
             ]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/table/reactTable/basic/src/App.tsx
+++ b/examples/table/reactTable/basic/src/App.tsx
@@ -11,7 +11,7 @@ const App: React.FC = () => {
             dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
             routerProvider={routerProvider}
             resources={[{ name: "posts", list: PostList }]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/tutorial/antd/src/App.tsx
+++ b/examples/tutorial/antd/src/App.tsx
@@ -31,7 +31,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/tutorial/headless/src/App.tsx
+++ b/examples/tutorial/headless/src/App.tsx
@@ -22,7 +22,7 @@ const App: React.FC = () => {
                 },
             ]}
             Layout={Layout}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/tutorial/mui/src/App.tsx
+++ b/examples/tutorial/mui/src/App.tsx
@@ -39,7 +39,7 @@ const App: React.FC = () => {
                             canDelete: true,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/ui/useModal/src/App.tsx
+++ b/examples/ui/useModal/src/App.tsx
@@ -27,7 +27,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/upload/antd/base64/src/App.tsx
+++ b/examples/upload/antd/base64/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/upload/antd/multipart/src/App.tsx
+++ b/examples/upload/antd/multipart/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/upload/mui/base64/src/App.tsx
+++ b/examples/upload/mui/base64/src/App.tsx
@@ -40,7 +40,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/upload/mui/multipart/src/App.tsx
+++ b/examples/upload/mui/multipart/src/App.tsx
@@ -40,7 +40,7 @@ const App: React.FC = () => {
                             edit: PostEdit,
                         },
                     ]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 />
             </RefineSnackbarProvider>
         </ThemeProvider>

--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -28,7 +28,7 @@ const App: React.FC = () => {
                     canDelete: true,
                 },
             ]}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 };

--- a/examples/web3/ethereumLogin/src/App.tsx
+++ b/examples/web3/ethereumLogin/src/App.tsx
@@ -35,7 +35,7 @@ function App() {
             notificationProvider={notificationProvider}
             Layout={Layout}
             catchAll={<ErrorComponent />}
-            disableTelemetry={true}
+            options={{ disableTelemetry: true }}
         />
     );
 }

--- a/packages/antd/test/index.tsx
+++ b/packages/antd/test/index.tsx
@@ -62,7 +62,7 @@ export const TestWrapper: (
                     resources={resources ?? [{ name: "posts", list: List }]}
                     accessControlProvider={accessControlProvider}
                     DashboardPage={DashboardPage ?? undefined}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 >
                     {children}
                 </Refine>

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -160,7 +160,7 @@ export const Refine: React.FC<RefineProps> = ({
                 },
             },
         });
-    }, [reactQueryClientConfig]);
+    }, [reactQueryClientConfig, options?.reactQuery?.clientConfig]);
 
     const notificationProviderContextValues = React.useMemo(() => {
         return typeof notificationProvider === "function"

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -13,7 +13,7 @@ import { DataContextProvider } from "@contexts/data";
 import { LiveContextProvider } from "@contexts/live";
 import { TranslationContextProvider } from "@contexts/translation";
 import { ResourceContextProvider, IResourceItem } from "@contexts/resource";
-import { defaultRefineConfig, RefineContextProvider } from "@contexts/refine";
+import { defaultRefineOptions, RefineContextProvider } from "@contexts/refine";
 import { UndoableQueueContextProvider } from "@contexts/undoableQueue";
 import { UnsavedWarnContextProvider } from "@contexts/unsavedWarn";
 import { RouterContextProvider } from "@contexts/router";
@@ -86,7 +86,7 @@ export interface RefineProps {
     onLiveEvent?: LiveModeProps["onLiveEvent"];
     children?: React.ReactNode;
     disableTelemetry?: boolean;
-    config?: {
+    options?: {
         mutationMode?: MutationMode;
         syncWithLocation?: boolean;
         warnWhenUnsavedChanges?: boolean;
@@ -138,7 +138,7 @@ export const Refine: React.FC<RefineProps> = ({
     liveMode,
     onLiveEvent,
     disableTelemetry = false,
-    config,
+    options,
 }) => {
     const queryClient = useDeepMemo(() => {
         return new QueryClient({
@@ -248,9 +248,9 @@ export const Refine: React.FC<RefineProps> = ({
                                                         onLiveEvent={
                                                             onLiveEvent
                                                         }
-                                                        config={{
-                                                            ...defaultRefineConfig,
-                                                            ...config,
+                                                        options={{
+                                                            ...defaultRefineOptions,
+                                                            ...options,
                                                         }}
                                                     >
                                                         <UnsavedWarnContextProvider>

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -61,13 +61,13 @@ export interface RefineProps {
     LoginPage?: React.FC;
     DashboardPage?: React.FC;
     ReadyPage?: React.FC;
-    /** @deprecated mutationMode is deprecated. Use config instead. */
+    /** @deprecated mutationMode is deprecated. Use options instead. https://refine.dev/docs/core/components/refine-config/#mutationmode */
     mutationMode?: MutationMode;
-    /** @deprecated mutationMode is deprecated. Use config instead. */
+    /** @deprecated syncWithLocation is deprecated. Use options instead. https://refine.dev/docs/core/components/refine-config/#syncwithlocation */
     syncWithLocation?: boolean;
-    /** @deprecated mutationMode is deprecated. Use config instead. */
+    /** @deprecated warnWhenUnsavedChanges is deprecated. Use options instead. https://refine.dev/docs/core/components/refine-config/#warnwhenunsavedchanges */
     warnWhenUnsavedChanges?: boolean;
-    /** @deprecated mutationMode is deprecated. Use config instead. */
+    /** @deprecated undoableTimeout is deprecated. Use options instead. https://refine.dev/docs/core/components/refine-config/#undoabletimeout */
     undoableTimeout?: number;
     Layout?: React.FC<LayoutProps>;
     Sider?: React.FC;
@@ -75,13 +75,13 @@ export interface RefineProps {
     Footer?: React.FC;
     OffLayoutArea?: React.FC;
     Title?: React.FC<TitleProps>;
-    /** @deprecated mutationMode is deprecated. Use config instead. */
+    /** @deprecated reactQueryClientConfig is deprecated. Use config instead. https://refine.dev/docs/core/components/refine-config/#clientconfig */
     reactQueryClientConfig?: QueryClientConfig;
-    /** @deprecated mutationMode is deprecated. Use config instead. */
+    /** @deprecated reactQueryDevtoolConfig is deprecated. Use config instead. https://refine.dev/docs/core/components/refine-config/#devtoolconfig */
     reactQueryDevtoolConfig?:
         | React.ComponentProps<typeof ReactQueryDevtools>
         | false;
-    /** @deprecated mutationMode is deprecated. Use config instead. */
+    /** @deprecated liveMode is deprecated. Use config instead. https://refine.dev/docs/core/components/refine-config/#livemode */
     liveMode?: LiveModeProps["liveMode"];
     onLiveEvent?: LiveModeProps["onLiveEvent"];
     children?: React.ReactNode;

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -61,9 +61,13 @@ export interface RefineProps {
     LoginPage?: React.FC;
     DashboardPage?: React.FC;
     ReadyPage?: React.FC;
+    /** @deprecated mutationMode is deprecated. Use config instead. */
     mutationMode?: MutationMode;
+    /** @deprecated mutationMode is deprecated. Use config instead. */
     syncWithLocation?: boolean;
+    /** @deprecated mutationMode is deprecated. Use config instead. */
     warnWhenUnsavedChanges?: boolean;
+    /** @deprecated mutationMode is deprecated. Use config instead. */
     undoableTimeout?: number;
     Layout?: React.FC<LayoutProps>;
     Sider?: React.FC;
@@ -71,14 +75,30 @@ export interface RefineProps {
     Footer?: React.FC;
     OffLayoutArea?: React.FC;
     Title?: React.FC<TitleProps>;
+    /** @deprecated mutationMode is deprecated. Use config instead. */
     reactQueryClientConfig?: QueryClientConfig;
+    /** @deprecated mutationMode is deprecated. Use config instead. */
     reactQueryDevtoolConfig?:
         | React.ComponentProps<typeof ReactQueryDevtools>
         | false;
+    /** @deprecated mutationMode is deprecated. Use config instead. */
     liveMode?: LiveModeProps["liveMode"];
     onLiveEvent?: LiveModeProps["onLiveEvent"];
     children?: React.ReactNode;
     disableTelemetry?: boolean;
+    config: {
+        mutationMode?: MutationMode;
+        syncWithLocation?: boolean;
+        warnWhenUnsavedChanges?: boolean;
+        undoableTimeout?: number;
+        liveMode?: LiveModeProps["liveMode"];
+        reactQuery: {
+            clientConfig?: QueryClientConfig;
+            devtoolConfig?:
+                | React.ComponentProps<typeof ReactQueryDevtools>
+                | false;
+        };
+    };
 }
 
 /**
@@ -118,6 +138,7 @@ export const Refine: React.FC<RefineProps> = ({
     liveMode,
     onLiveEvent,
     disableTelemetry = false,
+    config,
 }) => {
     const queryClient = useDeepMemo(() => {
         return new QueryClient({
@@ -227,6 +248,7 @@ export const Refine: React.FC<RefineProps> = ({
                                                         onLiveEvent={
                                                             onLiveEvent
                                                         }
+                                                        config={config}
                                                     >
                                                         <UnsavedWarnContextProvider>
                                                             <RouterComponent>

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -143,12 +143,16 @@ export const Refine: React.FC<RefineProps> = ({
     const queryClient = useDeepMemo(() => {
         return new QueryClient({
             ...reactQueryClientConfig,
+            ...options?.reactQuery?.clientConfig,
             defaultOptions: {
                 ...reactQueryClientConfig?.defaultOptions,
+                ...options?.reactQuery?.clientConfig?.defaultOptions,
                 queries: {
                     refetchOnWindowFocus: false,
                     keepPreviousData: true,
                     ...reactQueryClientConfig?.defaultOptions?.queries,
+                    ...options?.reactQuery?.clientConfig?.defaultOptions
+                        ?.queries,
                 },
             },
         });
@@ -273,11 +277,13 @@ export const Refine: React.FC<RefineProps> = ({
                     </DataContextProvider>
                 </AuthContextProvider>
             </NotificationContextProvider>
-            {reactQueryDevtoolConfig === false ? null : (
+            {reactQueryDevtoolConfig === false ||
+            options?.reactQuery?.devtoolConfig === false ? null : (
                 <ReactQueryDevtools
                     initialIsOpen={false}
                     position="bottom-right"
                     {...(reactQueryDevtoolConfig ?? {})}
+                    {...(options?.reactQuery?.devtoolConfig ?? {})}
                 />
             )}
         </QueryClientProvider>

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -85,6 +85,7 @@ export interface RefineProps {
     liveMode?: LiveModeProps["liveMode"];
     onLiveEvent?: LiveModeProps["onLiveEvent"];
     children?: React.ReactNode;
+    /** @deprecated disableTelemetry is deprecated. Use config instead. */
     disableTelemetry?: boolean;
     options?: {
         mutationMode?: MutationMode;
@@ -92,6 +93,7 @@ export interface RefineProps {
         warnWhenUnsavedChanges?: boolean;
         undoableTimeout?: number;
         liveMode?: LiveModeProps["liveMode"];
+        disableTelemetry?: boolean;
         reactQuery?: {
             clientConfig?: QueryClientConfig;
             devtoolConfig?:
@@ -137,9 +139,11 @@ export const Refine: React.FC<RefineProps> = ({
     reactQueryDevtoolConfig,
     liveMode,
     onLiveEvent,
-    disableTelemetry = false,
+    disableTelemetry,
     options,
 }) => {
+    const optionsDisableTelemetry = options?.disableTelemetry ?? false;
+
     const queryClient = useDeepMemo(() => {
         return new QueryClient({
             ...reactQueryClientConfig,
@@ -260,9 +264,10 @@ export const Refine: React.FC<RefineProps> = ({
                                                         <UnsavedWarnContextProvider>
                                                             <RouterComponent>
                                                                 {children}
-                                                                {!disableTelemetry && (
-                                                                    <Telemetry />
-                                                                )}
+                                                                {!disableTelemetry &&
+                                                                    !optionsDisableTelemetry && (
+                                                                        <Telemetry />
+                                                                    )}
                                                                 <RouteChangeHandler />
                                                             </RouterComponent>
                                                         </UnsavedWarnContextProvider>

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -61,13 +61,29 @@ export interface RefineProps {
     LoginPage?: React.FC;
     DashboardPage?: React.FC;
     ReadyPage?: React.FC;
-    /** @deprecated mutationMode is deprecated. Use options instead. https://refine.dev/docs/core/components/refine-config/#mutationmode */
+    /** 
+        @deprecated `mutationMode` property is deprecated at this level. Use it from within `options` instead.
+        @example  `options={{ mutationMode: "optimistic" }}`
+        @see https://refine.dev/docs/core/components/refine-config/#mutationmode
+     */
     mutationMode?: MutationMode;
-    /** @deprecated syncWithLocation is deprecated. Use options instead. https://refine.dev/docs/core/components/refine-config/#syncwithlocation */
+    /** 
+        @deprecated `syncWithLocation` property is deprecated at this level. Use it from within `options` instead.
+        @example  `options={{ syncWithLocation: true }}`
+        @see https://refine.dev/docs/core/components/refine-config/#syncwithlocation
+     */
     syncWithLocation?: boolean;
-    /** @deprecated warnWhenUnsavedChanges is deprecated. Use options instead. https://refine.dev/docs/core/components/refine-config/#warnwhenunsavedchanges */
+    /** 
+        @deprecated `warnwhenunsavedchanges` property is deprecated at this level. Use it from within `options` instead.
+        @example  `options={{ warnwhenunsavedchanges: true }}`
+        @see https://refine.dev/docs/core/components/refine-config/#warnwhenunsavedchanges
+     */
     warnWhenUnsavedChanges?: boolean;
-    /** @deprecated undoableTimeout is deprecated. Use options instead. https://refine.dev/docs/core/components/refine-config/#undoabletimeout */
+    /** 
+        @deprecated `undoableTimeout` property is deprecated at this level. Use it from within `options` instead.
+        @example  `options={{ undoableTimeout: 5000 }}`
+        @see https://refine.dev/docs/core/components/refine-config/#undoabletimeout
+     */
     undoableTimeout?: number;
     Layout?: React.FC<LayoutProps>;
     Sider?: React.FC;
@@ -75,17 +91,33 @@ export interface RefineProps {
     Footer?: React.FC;
     OffLayoutArea?: React.FC;
     Title?: React.FC<TitleProps>;
-    /** @deprecated reactQueryClientConfig is deprecated. Use config instead. https://refine.dev/docs/core/components/refine-config/#clientconfig */
+    /** 
+        @deprecated `reactQueryClientConfig` property is deprecated. Use `clientConfig` in `reactQuery` in `options` instead.
+        @example  `options={{ reactQuery: { clientConfig: { queryCache: new QueryCache() } } }}`
+        @see https://refine.dev/docs/core/components/refine-config/#clientconfig
+     */
     reactQueryClientConfig?: QueryClientConfig;
-    /** @deprecated reactQueryDevtoolConfig is deprecated. Use config instead. https://refine.dev/docs/core/components/refine-config/#devtoolconfig */
+    /** 
+        @deprecated `reactQueryDevtoolConfig` property is deprecated. Use `devtoolConfig` in `reactQuery` in `options` instead.
+        @example  `options={{ reactQuery: { devtoolConfig: false } }}`
+        @see https://refine.dev/docs/core/components/refine-config/#devtoolConfig
+     */
     reactQueryDevtoolConfig?:
         | React.ComponentProps<typeof ReactQueryDevtools>
         | false;
-    /** @deprecated liveMode is deprecated. Use config instead. https://refine.dev/docs/core/components/refine-config/#livemode */
+
+    /** 
+        @deprecated `liveMode` property is deprecated. Use it from within `options` instead.
+        @example  `options={{ liveMode: "auto" }}`
+        @see https://refine.dev/docs/core/components/refine-config/#livemode
+     */
     liveMode?: LiveModeProps["liveMode"];
     onLiveEvent?: LiveModeProps["onLiveEvent"];
     children?: React.ReactNode;
-    /** @deprecated disableTelemetry is deprecated. Use config instead. */
+    /** 
+        @deprecated `disableTelemetry` property is deprecated. Use it from within `options` instead.
+        @example  `options={{ disableTelemetry: true }}`
+     */
     disableTelemetry?: boolean;
     options?: {
         mutationMode?: MutationMode;
@@ -94,6 +126,7 @@ export interface RefineProps {
         undoableTimeout?: number;
         liveMode?: LiveModeProps["liveMode"];
         disableTelemetry?: boolean;
+        redirect?: {};
         reactQuery?: {
             clientConfig?: QueryClientConfig;
             devtoolConfig?:

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -13,7 +13,7 @@ import { DataContextProvider } from "@contexts/data";
 import { LiveContextProvider } from "@contexts/live";
 import { TranslationContextProvider } from "@contexts/translation";
 import { ResourceContextProvider, IResourceItem } from "@contexts/resource";
-import { RefineContextProvider } from "@contexts/refine";
+import { defaultRefineConfig, RefineContextProvider } from "@contexts/refine";
 import { UndoableQueueContextProvider } from "@contexts/undoableQueue";
 import { UnsavedWarnContextProvider } from "@contexts/unsavedWarn";
 import { RouterContextProvider } from "@contexts/router";
@@ -86,13 +86,13 @@ export interface RefineProps {
     onLiveEvent?: LiveModeProps["onLiveEvent"];
     children?: React.ReactNode;
     disableTelemetry?: boolean;
-    config: {
+    config?: {
         mutationMode?: MutationMode;
         syncWithLocation?: boolean;
         warnWhenUnsavedChanges?: boolean;
         undoableTimeout?: number;
         liveMode?: LiveModeProps["liveMode"];
-        reactQuery: {
+        reactQuery?: {
             clientConfig?: QueryClientConfig;
             devtoolConfig?:
                 | React.ComponentProps<typeof ReactQueryDevtools>
@@ -123,10 +123,10 @@ export const Refine: React.FC<RefineProps> = ({
     children,
     liveProvider,
     i18nProvider,
-    mutationMode = "pessimistic",
-    syncWithLocation = false,
-    warnWhenUnsavedChanges = false,
-    undoableTimeout = 5000,
+    mutationMode,
+    syncWithLocation,
+    warnWhenUnsavedChanges,
+    undoableTimeout,
     Title,
     Layout,
     Sider,
@@ -248,7 +248,10 @@ export const Refine: React.FC<RefineProps> = ({
                                                         onLiveEvent={
                                                             onLiveEvent
                                                         }
-                                                        config={config}
+                                                        config={{
+                                                            ...defaultRefineConfig,
+                                                            ...config,
+                                                        }}
                                                     >
                                                         <UnsavedWarnContextProvider>
                                                             <RouterComponent>

--- a/packages/core/src/components/layoutWrapper/index.spec.tsx
+++ b/packages/core/src/components/layoutWrapper/index.spec.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-import { LayoutWrapper } from "@components/layoutWrapper";
-import { IRefineContextProvider } from "../../contexts/refine/IRefineContext";
-import { render, TestWrapper, MockJSONServer } from "@test";
 import { Route, Routes } from "react-router-dom";
 import "@testing-library/jest-dom/extend-expect";
+
+import { LayoutWrapper } from "@components/layoutWrapper";
+import { render, TestWrapper, MockJSONServer } from "@test";
+import { defaultRefineOptions } from "@contexts/refine";
+import { IRefineContextProvider } from "../../contexts/refine/IRefineContext";
 import { LayoutProps } from "../../interfaces";
 
 const renderWithRefineContext = (
@@ -67,10 +69,6 @@ describe("LayoutWrapper", () => {
                 <div>test </div>
             </LayoutWrapper>,
             {
-                warnWhenUnsavedChanges: false,
-                mutationMode: "pessimistic",
-                syncWithLocation: false,
-                undoableTimeout: 5000,
                 hasDashboard: false,
                 Layout: CustomLayout,
                 Sider: CustomSider,
@@ -78,6 +76,7 @@ describe("LayoutWrapper", () => {
                 Footer: CustomFooter,
                 OffLayoutArea: CustomOffLayoutArea,
                 Title: CustomTitle,
+                options: defaultRefineOptions,
             },
         );
 
@@ -109,16 +108,13 @@ describe("LayoutWrapper", () => {
                 <div>test </div>
             </LayoutWrapper>,
             {
-                warnWhenUnsavedChanges: false,
-                mutationMode: "pessimistic",
-                syncWithLocation: false,
-                undoableTimeout: 5000,
                 hasDashboard: false,
                 Sider: CustomSider,
                 Header: CustomHeader,
                 Footer: CustomFooter,
                 OffLayoutArea: CustomOffLayoutArea,
                 Title: CustomTitle,
+                options: defaultRefineOptions,
             },
         );
 
@@ -174,10 +170,7 @@ describe("LayoutWrapper", () => {
                 <div>test</div>
             </LayoutWrapper>,
             {
-                warnWhenUnsavedChanges: false,
-                mutationMode: "pessimistic",
-                syncWithLocation: false,
-                undoableTimeout: 5000,
+                options: defaultRefineOptions,
                 hasDashboard: false,
             },
         );

--- a/packages/core/src/contexts/refine/IRefineContext.ts
+++ b/packages/core/src/contexts/refine/IRefineContext.ts
@@ -24,6 +24,13 @@ export interface IRefineContext {
     OffLayoutArea?: React.FC;
     liveMode?: LiveModeProps["liveMode"];
     onLiveEvent?: LiveModeProps["onLiveEvent"];
+    config: {
+        mutationMode?: MutationMode;
+        syncWithLocation?: boolean;
+        warnWhenUnsavedChanges?: boolean;
+        undoableTimeout?: number;
+        liveMode?: LiveModeProps["liveMode"];
+    };
 }
 
 export interface IRefineContextProvider {
@@ -43,5 +50,12 @@ export interface IRefineContextProvider {
     OffLayoutArea?: React.FC;
     liveMode?: LiveModeProps["liveMode"];
     onLiveEvent?: LiveModeProps["onLiveEvent"];
+    config: {
+        mutationMode?: MutationMode;
+        syncWithLocation?: boolean;
+        warnWhenUnsavedChanges?: boolean;
+        undoableTimeout?: number;
+        liveMode?: LiveModeProps["liveMode"];
+    };
     children?: ReactNode;
 }

--- a/packages/core/src/contexts/refine/IRefineContext.ts
+++ b/packages/core/src/contexts/refine/IRefineContext.ts
@@ -7,7 +7,7 @@ import {
     LiveModeProps,
 } from "../../interfaces";
 
-export interface IRefineConfig {
+export interface IRefineOptions {
     mutationMode: MutationMode;
     syncWithLocation: boolean;
     warnWhenUnsavedChanges: boolean;
@@ -32,7 +32,7 @@ export interface IRefineContext {
     OffLayoutArea?: React.FC;
     liveMode?: LiveModeProps["liveMode"];
     onLiveEvent?: LiveModeProps["onLiveEvent"];
-    config: IRefineConfig;
+    options: IRefineOptions;
 }
 
 export interface IRefineContextProvider {
@@ -52,6 +52,6 @@ export interface IRefineContextProvider {
     OffLayoutArea?: React.FC;
     liveMode?: LiveModeProps["liveMode"];
     onLiveEvent?: LiveModeProps["onLiveEvent"];
-    config: IRefineConfig;
+    options: IRefineOptions;
     children?: ReactNode;
 }

--- a/packages/core/src/contexts/refine/IRefineContext.ts
+++ b/packages/core/src/contexts/refine/IRefineContext.ts
@@ -7,12 +7,20 @@ import {
     LiveModeProps,
 } from "../../interfaces";
 
+export interface IRefineConfig {
+    mutationMode: MutationMode;
+    syncWithLocation: boolean;
+    warnWhenUnsavedChanges: boolean;
+    undoableTimeout: number;
+    liveMode: LiveModeProps["liveMode"];
+}
+
 export interface IRefineContext {
     hasDashboard: boolean;
-    mutationMode: MutationMode;
-    warnWhenUnsavedChanges: boolean;
-    syncWithLocation: boolean;
-    undoableTimeout: number;
+    mutationMode?: MutationMode;
+    warnWhenUnsavedChanges?: boolean;
+    syncWithLocation?: boolean;
+    undoableTimeout?: number;
     catchAll?: React.ReactNode;
     DashboardPage?: React.FC;
     LoginPage?: React.FC | false;
@@ -24,21 +32,15 @@ export interface IRefineContext {
     OffLayoutArea?: React.FC;
     liveMode?: LiveModeProps["liveMode"];
     onLiveEvent?: LiveModeProps["onLiveEvent"];
-    config: {
-        mutationMode?: MutationMode;
-        syncWithLocation?: boolean;
-        warnWhenUnsavedChanges?: boolean;
-        undoableTimeout?: number;
-        liveMode?: LiveModeProps["liveMode"];
-    };
+    config: IRefineConfig;
 }
 
 export interface IRefineContextProvider {
     hasDashboard: boolean;
-    mutationMode: MutationMode;
-    warnWhenUnsavedChanges: boolean;
-    syncWithLocation: boolean;
-    undoableTimeout: number;
+    mutationMode?: MutationMode;
+    warnWhenUnsavedChanges?: boolean;
+    syncWithLocation?: boolean;
+    undoableTimeout?: number;
     catchAll?: React.ReactNode;
     DashboardPage?: React.FC;
     LoginPage?: React.FC | false;
@@ -50,12 +52,6 @@ export interface IRefineContextProvider {
     OffLayoutArea?: React.FC;
     liveMode?: LiveModeProps["liveMode"];
     onLiveEvent?: LiveModeProps["onLiveEvent"];
-    config: {
-        mutationMode?: MutationMode;
-        syncWithLocation?: boolean;
-        warnWhenUnsavedChanges?: boolean;
-        undoableTimeout?: number;
-        liveMode?: LiveModeProps["liveMode"];
-    };
+    config: IRefineConfig;
     children?: ReactNode;
 }

--- a/packages/core/src/contexts/refine/index.tsx
+++ b/packages/core/src/contexts/refine/index.tsx
@@ -19,6 +19,13 @@ export const RefineContext = React.createContext<IRefineContext>({
     OffLayoutArea: undefined,
     liveMode: "off",
     onLiveEvent: undefined,
+    config: {
+        mutationMode: "pessimistic",
+        syncWithLocation: false,
+        undoableTimeout: 5000,
+        warnWhenUnsavedChanges: false,
+        liveMode: "off",
+    },
 });
 
 export const RefineContextProvider: React.FC<IRefineContextProvider> = ({
@@ -39,6 +46,7 @@ export const RefineContextProvider: React.FC<IRefineContextProvider> = ({
     catchAll,
     liveMode = "off",
     onLiveEvent,
+    config,
 }) => {
     return (
         <RefineContext.Provider
@@ -59,6 +67,7 @@ export const RefineContextProvider: React.FC<IRefineContextProvider> = ({
                 catchAll,
                 liveMode,
                 onLiveEvent,
+                config,
             }}
         >
             {children}

--- a/packages/core/src/contexts/refine/index.tsx
+++ b/packages/core/src/contexts/refine/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import {
-    IRefineConfig,
+    IRefineOptions,
     IRefineContext,
     IRefineContextProvider,
 } from "./IRefineContext";
@@ -9,7 +9,7 @@ import { DefaultLayout } from "@components/layoutWrapper/defaultLayout";
 
 import { LoginPage as DefaultLoginPage } from "@components/pages";
 
-export const defaultRefineConfig: IRefineConfig = {
+export const defaultRefineOptions: IRefineOptions = {
     mutationMode: "pessimistic",
     syncWithLocation: false,
     undoableTimeout: 5000,
@@ -31,7 +31,7 @@ export const RefineContext = React.createContext<IRefineContext>({
     OffLayoutArea: undefined,
     liveMode: "off",
     onLiveEvent: undefined,
-    config: defaultRefineConfig,
+    options: defaultRefineOptions,
 });
 
 export const RefineContextProvider: React.FC<IRefineContextProvider> = ({
@@ -52,7 +52,7 @@ export const RefineContextProvider: React.FC<IRefineContextProvider> = ({
     catchAll,
     liveMode = "off",
     onLiveEvent,
-    config,
+    options,
 }) => {
     return (
         <RefineContext.Provider
@@ -73,7 +73,7 @@ export const RefineContextProvider: React.FC<IRefineContextProvider> = ({
                 catchAll,
                 liveMode,
                 onLiveEvent,
-                config,
+                options,
             }}
         >
             {children}

--- a/packages/core/src/contexts/refine/index.tsx
+++ b/packages/core/src/contexts/refine/index.tsx
@@ -1,9 +1,21 @@
 import React from "react";
 
-import { IRefineContext, IRefineContextProvider } from "./IRefineContext";
+import {
+    IRefineConfig,
+    IRefineContext,
+    IRefineContextProvider,
+} from "./IRefineContext";
 import { DefaultLayout } from "@components/layoutWrapper/defaultLayout";
 
 import { LoginPage as DefaultLoginPage } from "@components/pages";
+
+export const defaultRefineConfig: IRefineConfig = {
+    mutationMode: "pessimistic",
+    syncWithLocation: false,
+    undoableTimeout: 5000,
+    warnWhenUnsavedChanges: false,
+    liveMode: "off",
+};
 
 export const RefineContext = React.createContext<IRefineContext>({
     hasDashboard: false,
@@ -19,13 +31,7 @@ export const RefineContext = React.createContext<IRefineContext>({
     OffLayoutArea: undefined,
     liveMode: "off",
     onLiveEvent: undefined,
-    config: {
-        mutationMode: "pessimistic",
-        syncWithLocation: false,
-        undoableTimeout: 5000,
-        warnWhenUnsavedChanges: false,
-        liveMode: "off",
-    },
+    config: defaultRefineConfig,
 });
 
 export const RefineContextProvider: React.FC<IRefineContextProvider> = ({

--- a/packages/core/src/hooks/data/useList.spec.tsx
+++ b/packages/core/src/hooks/data/useList.spec.tsx
@@ -3,14 +3,12 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { MockJSONServer, TestWrapper } from "@test";
 
 import { useList } from "./useList";
+import { defaultRefineOptions } from "@contexts/refine";
 import { IRefineContextProvider } from "../../interfaces";
 
 const mockRefineProvider: IRefineContextProvider = {
     hasDashboard: false,
-    mutationMode: "pessimistic",
-    warnWhenUnsavedChanges: false,
-    syncWithLocation: false,
-    undoableTimeout: 500,
+    options: defaultRefineOptions,
 };
 
 describe("useList Hook", () => {

--- a/packages/core/src/hooks/data/useMany.spec.tsx
+++ b/packages/core/src/hooks/data/useMany.spec.tsx
@@ -3,14 +3,12 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { MockJSONServer, TestWrapper } from "@test";
 
 import { useMany } from "./useMany";
+import { defaultRefineOptions } from "@contexts/refine";
 import { IRefineContextProvider } from "../../interfaces";
 
 const mockRefineProvider: IRefineContextProvider = {
     hasDashboard: false,
-    mutationMode: "pessimistic",
-    warnWhenUnsavedChanges: false,
-    syncWithLocation: false,
-    undoableTimeout: 500,
+    options: defaultRefineOptions,
 };
 
 describe("useMany Hook", () => {

--- a/packages/core/src/hooks/data/useOne.spec.tsx
+++ b/packages/core/src/hooks/data/useOne.spec.tsx
@@ -3,14 +3,12 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { MockJSONServer, TestWrapper } from "@test";
 
 import { useOne } from "./useOne";
+import { defaultRefineOptions } from "@contexts/refine";
 import { IRefineContextProvider } from "../../interfaces";
 
 const mockRefineProvider: IRefineContextProvider = {
     hasDashboard: false,
-    mutationMode: "pessimistic",
-    warnWhenUnsavedChanges: false,
-    syncWithLocation: false,
-    undoableTimeout: 500,
+    options: defaultRefineOptions,
 };
 
 describe("useOne Hook", () => {

--- a/packages/core/src/hooks/live/useLiveMode/index.spec.ts
+++ b/packages/core/src/hooks/live/useLiveMode/index.spec.ts
@@ -3,14 +3,12 @@ import { renderHook } from "@testing-library/react";
 import { TestWrapper } from "@test";
 
 import { useLiveMode } from "./";
+import { defaultRefineOptions } from "@contexts/refine";
 import { IRefineContextProvider } from "../../../interfaces";
 
 const mockRefineProvider: IRefineContextProvider = {
     hasDashboard: false,
-    mutationMode: "pessimistic",
-    warnWhenUnsavedChanges: false,
-    syncWithLocation: false,
-    undoableTimeout: 500,
+    options: defaultRefineOptions,
 };
 
 describe("useLiveMode Hook", () => {

--- a/packages/core/src/hooks/live/useLiveMode/index.ts
+++ b/packages/core/src/hooks/live/useLiveMode/index.ts
@@ -5,8 +5,8 @@ import { RefineContext } from "@contexts/refine";
 export const useLiveMode = (
     liveMode: LiveModeProps["liveMode"],
 ): LiveModeProps["liveMode"] => {
-    const { liveMode: liveModeFromContext, config } =
+    const { liveMode: liveModeFromContext, options } =
         useContext<IRefineContext>(RefineContext);
 
-    return liveMode ?? liveModeFromContext ?? config.liveMode;
+    return liveMode ?? liveModeFromContext ?? options.liveMode;
 };

--- a/packages/core/src/hooks/live/useLiveMode/index.ts
+++ b/packages/core/src/hooks/live/useLiveMode/index.ts
@@ -5,8 +5,8 @@ import { RefineContext } from "@contexts/refine";
 export const useLiveMode = (
     liveMode: LiveModeProps["liveMode"],
 ): LiveModeProps["liveMode"] => {
-    const { liveMode: liveModeFromContext } =
+    const { liveMode: liveModeFromContext, config } =
         useContext<IRefineContext>(RefineContext);
 
-    return liveMode ?? liveModeFromContext;
+    return liveMode ?? liveModeFromContext ?? config.liveMode;
 };

--- a/packages/core/src/hooks/live/useResourceSubscription/index.spec.ts
+++ b/packages/core/src/hooks/live/useResourceSubscription/index.spec.ts
@@ -3,14 +3,12 @@ import { renderHook } from "@testing-library/react";
 import { TestWrapper } from "@test";
 
 import { useResourceSubscription } from "./";
+import { defaultRefineOptions } from "@contexts/refine";
 import { IRefineContextProvider } from "../../../interfaces";
 
 const mockRefineProvider: IRefineContextProvider = {
     hasDashboard: false,
-    mutationMode: "pessimistic",
-    warnWhenUnsavedChanges: false,
-    syncWithLocation: false,
-    undoableTimeout: 500,
+    options: defaultRefineOptions,
 };
 
 const onLiveEventMock = jest.fn();

--- a/packages/core/src/hooks/refine/useMutationMode.ts
+++ b/packages/core/src/hooks/refine/useMutationMode.ts
@@ -1,11 +1,11 @@
 import { useContext } from "react";
 
 import { RefineContext } from "@contexts/refine";
-import { IRefineContext } from "../../interfaces";
+import { IRefineConfig } from "../../interfaces";
 
 type UseMutationModeType = () => {
-    mutationMode: IRefineContext["mutationMode"];
-    undoableTimeout: IRefineContext["undoableTimeout"];
+    mutationMode: IRefineConfig["mutationMode"];
+    undoableTimeout: IRefineConfig["undoableTimeout"];
 };
 
 /**
@@ -16,7 +16,10 @@ type UseMutationModeType = () => {
  * @see {@link https://refine.dev/docs/guides-and-concepts/mutation-mode} for more details.
  */
 export const useMutationMode: UseMutationModeType = () => {
-    const { mutationMode, undoableTimeout } = useContext(RefineContext);
+    const { mutationMode, undoableTimeout, config } = useContext(RefineContext);
 
-    return { mutationMode, undoableTimeout };
+    const mode = mutationMode ?? config.mutationMode;
+    const timeout = undoableTimeout ?? config.undoableTimeout;
+
+    return { mutationMode: mode, undoableTimeout: timeout };
 };

--- a/packages/core/src/hooks/refine/useMutationMode.ts
+++ b/packages/core/src/hooks/refine/useMutationMode.ts
@@ -1,11 +1,11 @@
 import { useContext } from "react";
 
 import { RefineContext } from "@contexts/refine";
-import { IRefineConfig } from "../../interfaces";
+import { IRefineOptions } from "../../interfaces";
 
 type UseMutationModeType = () => {
-    mutationMode: IRefineConfig["mutationMode"];
-    undoableTimeout: IRefineConfig["undoableTimeout"];
+    mutationMode: IRefineOptions["mutationMode"];
+    undoableTimeout: IRefineOptions["undoableTimeout"];
 };
 
 /**
@@ -16,10 +16,11 @@ type UseMutationModeType = () => {
  * @see {@link https://refine.dev/docs/guides-and-concepts/mutation-mode} for more details.
  */
 export const useMutationMode: UseMutationModeType = () => {
-    const { mutationMode, undoableTimeout, config } = useContext(RefineContext);
+    const { mutationMode, undoableTimeout, options } =
+        useContext(RefineContext);
 
-    const mode = mutationMode ?? config.mutationMode;
-    const timeout = undoableTimeout ?? config.undoableTimeout;
+    const mode = mutationMode ?? options.mutationMode;
+    const timeout = undoableTimeout ?? options.undoableTimeout;
 
     return { mutationMode: mode, undoableTimeout: timeout };
 };

--- a/packages/core/src/hooks/refine/useRefineContex.ts
+++ b/packages/core/src/hooks/refine/useRefineContex.ts
@@ -18,6 +18,7 @@ export const useRefineContext = () => {
         DashboardPage,
         LoginPage,
         catchAll,
+        config,
     } = useContext(RefineContext);
 
     return {
@@ -35,5 +36,6 @@ export const useRefineContext = () => {
         DashboardPage,
         LoginPage,
         catchAll,
+        config,
     };
 };

--- a/packages/core/src/hooks/refine/useRefineContex.ts
+++ b/packages/core/src/hooks/refine/useRefineContex.ts
@@ -29,7 +29,7 @@ export const useRefineContext = () => {
         Sider,
         Title,
         hasDashboard,
-        mutationMode,
+        mutationMode: mutationMode ?? config.mutationMode,
         syncWithLocation,
         undoableTimeout,
         warnWhenUnsavedChanges,

--- a/packages/core/src/hooks/refine/useRefineContex.ts
+++ b/packages/core/src/hooks/refine/useRefineContex.ts
@@ -18,7 +18,7 @@ export const useRefineContext = () => {
         DashboardPage,
         LoginPage,
         catchAll,
-        config,
+        options,
     } = useContext(RefineContext);
 
     return {
@@ -29,13 +29,13 @@ export const useRefineContext = () => {
         Sider,
         Title,
         hasDashboard,
-        mutationMode: mutationMode ?? config.mutationMode,
+        mutationMode: mutationMode ?? options.mutationMode,
         syncWithLocation,
         undoableTimeout,
         warnWhenUnsavedChanges,
         DashboardPage,
         LoginPage,
         catchAll,
-        config,
+        options,
     };
 };

--- a/packages/core/src/hooks/refine/useSyncWithLocation.ts
+++ b/packages/core/src/hooks/refine/useSyncWithLocation.ts
@@ -1,10 +1,10 @@
 import { useContext } from "react";
 
 import { RefineContext } from "@contexts/refine";
-import { IRefineConfig } from "../../interfaces";
+import { IRefineOptions } from "../../interfaces";
 
 type UseSyncWithLocationType = () => {
-    syncWithLocation: IRefineConfig["syncWithLocation"];
+    syncWithLocation: IRefineOptions["syncWithLocation"];
 };
 
 /**
@@ -14,7 +14,7 @@ type UseSyncWithLocationType = () => {
  * @see {@link https://refine.dev/docs/api-references/components/refine-config#syncwithlocation} for more details.
  */
 export const useSyncWithLocation: UseSyncWithLocationType = () => {
-    const { syncWithLocation, config } = useContext(RefineContext);
+    const { syncWithLocation, options } = useContext(RefineContext);
 
-    return { syncWithLocation: syncWithLocation ?? config.syncWithLocation };
+    return { syncWithLocation: syncWithLocation ?? options.syncWithLocation };
 };

--- a/packages/core/src/hooks/refine/useSyncWithLocation.ts
+++ b/packages/core/src/hooks/refine/useSyncWithLocation.ts
@@ -1,10 +1,10 @@
 import { useContext } from "react";
 
 import { RefineContext } from "@contexts/refine";
-import { IRefineContext } from "../../interfaces";
+import { IRefineConfig } from "../../interfaces";
 
 type UseSyncWithLocationType = () => {
-    syncWithLocation: IRefineContext["syncWithLocation"];
+    syncWithLocation: IRefineConfig["syncWithLocation"];
 };
 
 /**
@@ -14,7 +14,7 @@ type UseSyncWithLocationType = () => {
  * @see {@link https://refine.dev/docs/api-references/components/refine-config#syncwithlocation} for more details.
  */
 export const useSyncWithLocation: UseSyncWithLocationType = () => {
-    const { syncWithLocation } = useContext(RefineContext);
+    const { syncWithLocation, config } = useContext(RefineContext);
 
-    return { syncWithLocation };
+    return { syncWithLocation: syncWithLocation ?? config.syncWithLocation };
 };

--- a/packages/core/src/hooks/refine/useWarnAboutChange/index.ts
+++ b/packages/core/src/hooks/refine/useWarnAboutChange/index.ts
@@ -2,10 +2,10 @@ import { useContext } from "react";
 
 import { RefineContext } from "@contexts/refine";
 import { UnsavedWarnContext } from "@contexts/unsavedWarn";
-import { IRefineConfig, IUnsavedWarnContext } from "../../../interfaces";
+import { IRefineOptions, IUnsavedWarnContext } from "../../../interfaces";
 
 type UseWarnAboutChangeType = () => {
-    warnWhenUnsavedChanges: IRefineConfig["warnWhenUnsavedChanges"];
+    warnWhenUnsavedChanges: IRefineOptions["warnWhenUnsavedChanges"];
     warnWhen: NonNullable<IUnsavedWarnContext["warnWhen"]>;
     setWarnWhen: NonNullable<IUnsavedWarnContext["setWarnWhen"]>;
 };
@@ -17,13 +17,13 @@ type UseWarnAboutChangeType = () => {
  * @see {@link https://refine.dev/docs/api-references/components/refine-config#warnwhenunsavedchanges} for more details.
  */
 export const useWarnAboutChange: UseWarnAboutChangeType = () => {
-    const { warnWhenUnsavedChanges, config } = useContext(RefineContext);
+    const { warnWhenUnsavedChanges, options } = useContext(RefineContext);
 
     const { warnWhen, setWarnWhen } = useContext(UnsavedWarnContext);
 
     return {
         warnWhenUnsavedChanges:
-            warnWhenUnsavedChanges ?? config.warnWhenUnsavedChanges,
+            warnWhenUnsavedChanges ?? options.warnWhenUnsavedChanges,
         warnWhen: Boolean(warnWhen),
         setWarnWhen: setWarnWhen ?? (() => undefined),
     };

--- a/packages/core/src/hooks/refine/useWarnAboutChange/index.ts
+++ b/packages/core/src/hooks/refine/useWarnAboutChange/index.ts
@@ -2,10 +2,10 @@ import { useContext } from "react";
 
 import { RefineContext } from "@contexts/refine";
 import { UnsavedWarnContext } from "@contexts/unsavedWarn";
-import { IRefineContext, IUnsavedWarnContext } from "../../../interfaces";
+import { IRefineConfig, IUnsavedWarnContext } from "../../../interfaces";
 
 type UseWarnAboutChangeType = () => {
-    warnWhenUnsavedChanges: IRefineContext["warnWhenUnsavedChanges"];
+    warnWhenUnsavedChanges: IRefineConfig["warnWhenUnsavedChanges"];
     warnWhen: NonNullable<IUnsavedWarnContext["warnWhen"]>;
     setWarnWhen: NonNullable<IUnsavedWarnContext["setWarnWhen"]>;
 };
@@ -17,12 +17,13 @@ type UseWarnAboutChangeType = () => {
  * @see {@link https://refine.dev/docs/api-references/components/refine-config#warnwhenunsavedchanges} for more details.
  */
 export const useWarnAboutChange: UseWarnAboutChangeType = () => {
-    const { warnWhenUnsavedChanges } = useContext(RefineContext);
+    const { warnWhenUnsavedChanges, config } = useContext(RefineContext);
 
     const { warnWhen, setWarnWhen } = useContext(UnsavedWarnContext);
 
     return {
-        warnWhenUnsavedChanges,
+        warnWhenUnsavedChanges:
+            warnWhenUnsavedChanges ?? config.warnWhenUnsavedChanges,
         warnWhen: Boolean(warnWhen),
         setWarnWhen: setWarnWhen ?? (() => undefined),
     };

--- a/packages/kbar/test/index.tsx
+++ b/packages/kbar/test/index.tsx
@@ -79,7 +79,7 @@ export const TestWrapper: (
                         resources={resources ?? [{ name: "posts", list: List }]}
                         accessControlProvider={accessControlProvider}
                         DashboardPage={DashboardPage ?? undefined}
-                        disableTelemetry={true}
+                        options={{ disableTelemetry: true }}
                     >
                         {children}
                     </Refine>

--- a/packages/mui/test/index.tsx
+++ b/packages/mui/test/index.tsx
@@ -76,7 +76,7 @@ export const TestWrapper: (
                     resources={resources ?? [{ name: "posts", list: List }]}
                     accessControlProvider={accessControlProvider}
                     DashboardPage={DashboardPage ?? undefined}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 >
                     {children}
                 </Refine>

--- a/packages/react-hook-form/test/index.tsx
+++ b/packages/react-hook-form/test/index.tsx
@@ -25,13 +25,17 @@ export const TestWrapper: (
                     dataProvider={dataProvider ?? MockJSONServer}
                     routerProvider={MockRouterProvider}
                     resources={resources ?? [{ name: "posts" }]}
-                    disableTelemetry={true}
-                    reactQueryClientConfig={{
-                        defaultOptions: {
-                            queries: {
-                                retry: false,
+                    options={{
+                        reactQuery: {
+                            clientConfig: {
+                                defaultOptions: {
+                                    queries: {
+                                        retry: false,
+                                    },
+                                },
                             },
                         },
+                        disableTelemetry: true,
                     }}
                 >
                     {children}

--- a/packages/react-table/test/index.tsx
+++ b/packages/react-table/test/index.tsx
@@ -25,7 +25,7 @@ export const TestWrapper: (
                     dataProvider={dataProvider ?? MockJSONServer}
                     routerProvider={MockRouterProvider}
                     resources={resources ?? [{ name: "posts" }]}
-                    disableTelemetry={true}
+                    options={{ disableTelemetry: true }}
                 >
                     {children}
                 </Refine>


### PR DESCRIPTION
Add a new `<Refine>` component property: `options`.

Previously, the options were passed as a property to the `<Refine>`. Now, the options are passed to the `<Refine>` via `options` property like this:

```diff
    <Refine
-       mutationMode="undoable"
-       undoableTimeout={5000}
-       warnWhenUnsavedChanges
-       syncWithLocation
-       liveMode="off"
-       disableTelemetry={false}
+       options={{
+           mutationMode: "undoable",
+           undoableTimeout: 5000,
+           warnWhenUnsavedChanges: true,
+           syncWithLocation: true,
+           liveMode: "off",
+           disableTelemetry: false,
+       }}
    />
```
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

### Test plan (required)

All tests passed.

<!-- Make sure tests pass. -->

### Closing issues

fix #2133 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
