### PR TITLE
fix(core): return given props if redirect false

### DIFF
--- a/.changeset/few-dragons-swim.md
+++ b/.changeset/few-dragons-swim.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+fix redirectPage return value #2377

--- a/packages/core/src/definitions/helpers/redirectPage/index.spec.ts
+++ b/packages/core/src/definitions/helpers/redirectPage/index.spec.ts
@@ -1,23 +1,28 @@
-import { IRefineContextOptions } from "../../../../src/interfaces";
+import {
+    IRefineContextOptions,
+    RedirectionTypes,
+} from "../../../../src/interfaces";
 import { redirectPage } from ".";
 
 describe("redirectPath", () => {
-    it("should return redirectFromProps if it is provided", () => {
-        const redirectFromProps = "edit";
-        const action = "create";
-        const redirectOptions: IRefineContextOptions["redirect"] = {
-            afterClone: "edit",
-            afterCreate: "list",
-            afterEdit: "show",
-        };
+    it.each(["edit", "list", "show", false] as RedirectionTypes[])(
+        "should return redirectFromProps if it is provided %s",
+        (redirectFromProps) => {
+            const action = "create";
+            const redirectOptions: IRefineContextOptions["redirect"] = {
+                afterClone: "edit",
+                afterCreate: "list",
+                afterEdit: "show",
+            };
 
-        const result = redirectPage({
-            redirectFromProps,
-            action,
-            redirectOptions,
-        });
-        expect(result).toEqual(redirectFromProps);
-    });
+            const result = redirectPage({
+                redirectFromProps,
+                action,
+                redirectOptions,
+            });
+            expect(result).toEqual(redirectFromProps);
+        },
+    );
 
     it.each(["edit", "create", "clone"] as const)(
         "should return redirect option according to action %s",

--- a/packages/core/src/definitions/helpers/redirectPage/index.ts
+++ b/packages/core/src/definitions/helpers/redirectPage/index.ts
@@ -11,7 +11,7 @@ export const redirectPage = ({
     action,
     redirectOptions,
 }: RedirectPageProps): RedirectionTypes => {
-    if (redirectFromProps) {
+    if (redirectFromProps || redirectFromProps === false) {
         return redirectFromProps;
     }
 


### PR DESCRIPTION
when redirect prop is **false** on **useForm**, **redirectPage()** function returns **list** because of **falsy** value.

### Test plan (required)
**False** test case added.

### Closing issues
closes #2378

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed