### PR TITLE
build: update `tsup` config and remove `data-testid` properties

### DIFF
--- a/packages/antd/tsup.config.ts
+++ b/packages/antd/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "tsup";
+import * as fs from "fs";
 import copyStaticFiles from "esbuild-copy-static-files";
 import { NodeResolvePlugin } from "@esbuild-plugins/node-resolve";
 
@@ -9,6 +10,32 @@ export default defineConfig({
     clean: false,
     platform: "browser",
     esbuildPlugins: [
+        {
+            name: "react-remove-testids",
+            setup(build) {
+                build.onEnd(async (args) => {
+                    // data-testid regexp
+                    const regexp = /("data-testid":)(.*?)(?:(,)|(}))/gi;
+
+                    // output files with `*.js`
+                    const jsOutputFiles =
+                        args.outputFiles?.filter((el) =>
+                            el.path.endsWith(".js"),
+                        ) ?? [];
+
+                    // replace data-testid in output files
+                    for (const jsOutputFile of jsOutputFiles) {
+                        const str = new TextDecoder("utf-8").decode(
+                            jsOutputFile.contents,
+                        );
+                        const newStr = str.replace(regexp, "$4");
+                        jsOutputFile.contents = new TextEncoder().encode(
+                            newStr,
+                        );
+                    }
+                });
+            },
+        },
         copyStaticFiles({
             src: "./src/assets/styles/styles.min.css",
             dest: "./dist/styles.min.css",

--- a/packages/mui/tsup.config.ts
+++ b/packages/mui/tsup.config.ts
@@ -14,6 +14,32 @@ export default defineConfig({
     platform: "browser",
     esbuildPlugins: [
         {
+            name: "react-remove-testids",
+            setup(build) {
+                build.onEnd(async (args) => {
+                    // data-testid regexp
+                    const regexp = /("data-testid":)(.*?)(?:(,)|(}))/gi;
+
+                    // output files with `*.js`
+                    const jsOutputFiles =
+                        args.outputFiles?.filter((el) =>
+                            el.path.endsWith(".js"),
+                        ) ?? [];
+
+                    // replace data-testid in output files
+                    for (const jsOutputFile of jsOutputFiles) {
+                        const str = new TextDecoder("utf-8").decode(
+                            jsOutputFile.contents,
+                        );
+                        const newStr = str.replace(regexp, "$4");
+                        jsOutputFile.contents = new TextEncoder().encode(
+                            newStr,
+                        );
+                    }
+                });
+            },
+        },
+        {
             name: "textReplace",
             setup: (build) => {
                 // original code: https://github.com/josteph/esbuild-plugin-lodash


### PR DESCRIPTION
Since we're using test ids to handle the UI components in the tests (Unified for both UI framework integrations) we're not removing those in the build phase. Added a custom `esbuild` plugin to remove `data-testid` properties from the `*.js` outputs of `refine-antd` and `refine-mui` packages.

Not sure If we should update the versions by adding a changeset or should we wait until the next release to see the plugin in action 🤔 

💡 We can also consider releasing this plugin as an external package for `esbuild`

### Test plan (required)

Tests are not affected from the build script.

### Closing issues

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [ ] Changesets are provided or not needed
