### PR TITLE
feat: add option to hide resource in the menu

### DIFF
--- a/.changeset/breezy-icons-doubt.md
+++ b/.changeset/breezy-icons-doubt.md
@@ -1,0 +1,8 @@
+---
+"@pankod/refine-antd": minor
+"@pankod/refine-core": minor
+"@pankod/refine-mui": minor
+"@pankod/refine-ui-tests": minor
+---
+
+add an option to hide the source in the menu #2388

--- a/documentation/docs/core/hooks/ui/useMenu.md
+++ b/documentation/docs/core/hooks/ui/useMenu.md
@@ -269,6 +269,7 @@ interface IResourceItem extends IResourceComponents {
     canEdit?: boolean;
     canShow?: boolean;
     canDelete?: boolean;
+    options?: OptionsProps;
     parentName?: string;
 }
 
@@ -287,6 +288,16 @@ interface IResourceComponentsProps<TCrudData = any> {
     name?: string;
     initialData?: TCrudData;
 }
+
+type OptionsProps<TExtends = { [key: string]: any }> = TExtends & {
+    label?: string;
+    route?: string;
+    auditLog?: {
+        permissions?: AuditLogPermissions[number][] | string[];
+    };
+    hide?: boolean;
+    [key: string]: any;
+};
 
 // highlight-start
 type IMenuItem = IResourceItem & {

--- a/packages/antd/src/components/layout/sider/index.tsx
+++ b/packages/antd/src/components/layout/sider/index.tsx
@@ -41,6 +41,8 @@ export const Sider: React.FC<RefineLayoutSiderProps> = () => {
 
     const renderTreeView = (tree: ITreeMenu[], selectedKey: string) => {
         return tree.map((item: ITreeMenu) => {
+            if (item.options?.hide) return null;
+
             const { icon, label, route, name, children, parentName } = item;
 
             if (children.length > 0) {

--- a/packages/core/src/contexts/resource/IResourceContext.ts
+++ b/packages/core/src/contexts/resource/IResourceContext.ts
@@ -15,6 +15,7 @@ type OptionsProps<TExtends = { [key: string]: any }> = TExtends & {
     auditLog?: {
         permissions?: AuditLogPermissions[number][] | string[];
     };
+    hide?: boolean;
     [key: string]: any;
 };
 

--- a/packages/mui/src/components/layout/sider/index.tsx
+++ b/packages/mui/src/components/layout/sider/index.tsx
@@ -79,6 +79,8 @@ export const Sider: React.FC<RefineLayoutSiderProps> = () => {
 
     const renderTreeView = (tree: ITreeMenu[], selectedKey: string) => {
         return tree.map((item: ITreeMenu) => {
+            if (item.options?.hide) return null;
+
             const { icon, label, route, name, children, parentName } = item;
             const isOpen = open[route || ""] || false;
 


### PR DESCRIPTION
"hide" property added to the resource options.
With this way we are able to hide menu items in the <Sider/> while rendering.

`<Refine
    resources={[
        {
            name: "posts",
            options: {
                hide: true
            }
        }
    ]}
/>`

I prefer to use **hide** keyword because it seems to me more easy to use and If we use **visible** keyword, we need to provide default value to true. 

`if(hide) return null`
`if(!visible) return null`


### Test plan (required)
All tests are passed.
<p align="center">
<img src="https://user-images.githubusercontent.com/23058882/187559258-671607f0-53a4-4f3e-a7ac-ff8ff59c8bb9.jpeg" width=30% height=30%>
</p>


### Closing issues
closes #2388


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed