### PR TITLE
feat: add an option to hide `resources` from the `Sider` menu

### DIFF
--- a/.changeset/happy-hornets-pump.md
+++ b/.changeset/happy-hornets-pump.md
@@ -1,0 +1,21 @@
+---
+"@pankod/refine-core": patch
+---
+
+Add an option to hide `resources` from the `Sider` menu
+
+```tsx
+<Refine
+    ...
+    ...
+    resources={[
+        {
+            name: "posts",
+            list: PostList,
+            options: {
+                hide: true,
+            },
+        },
+    ]}
+/>
+```

--- a/.changeset/happy-hornets-pump.md
+++ b/.changeset/happy-hornets-pump.md
@@ -1,5 +1,5 @@
 ---
-"@pankod/refine-core": patch
+"@pankod/refine-core": minor
 ---
 
 Add an option to hide `resources` from the `Sider` menu

--- a/documentation/docs/core/components/refine-config.md
+++ b/documentation/docs/core/components/refine-config.md
@@ -130,6 +130,7 @@ These components will receive some properties.
 type OptionsProps<TExtends = { [key: string]: any }> = TExtends & {
     label?: string;
     route?: string;
+    hide?: boolean;
 }
 
 interface IResourceComponentsProps<TCrudData = any, TOptionsPropsExtends = { [key: string]: any }> {
@@ -249,6 +250,10 @@ Name to show in the menu. Plural form of the resource name is shown by default.
 #### `route`
 
 Custom route name
+
+#### `hide`
+
+Can be used to hide a `resource` in `Sider`. This resource is also filtered in the `useMenu` hook.
 
 :::tip
 You can also pass any type of property into the options object. This property you pass can be recieved from the [useResource](/core/hooks/resource/useResource.md) and [useResourceWithRoute](/core/hooks/resource/useResourceWithRoute.md) hooks as well as the components rendered in the `list`, `create`, `edit` and `show` pages.

--- a/documentation/docs/core/hooks/resource/useResource.md
+++ b/documentation/docs/core/hooks/resource/useResource.md
@@ -42,6 +42,10 @@ const { resource } = useResource({
 type OptionsProps<TExtends = { [key: string]: any }> = TExtends & {
     label?: string;
     route?: string;
+    hide?: boolean;
+    auditLog?: {
+        permissions?: AuditLogPermissions[number][] | string[];
+    };
 }
 
 interface IResourceComponentsProps<TCrudData = any, TOptionsPropsExtends = { [key: string]: any }> {

--- a/documentation/docs/core/hooks/ui/useMenu.md
+++ b/documentation/docs/core/hooks/ui/useMenu.md
@@ -270,6 +270,7 @@ interface IResourceItem extends IResourceComponents {
     canShow?: boolean;
     canDelete?: boolean;
     parentName?: string;
+    options?: OptionsProps;
 }
 
 interface IResourceComponents {
@@ -287,6 +288,16 @@ interface IResourceComponentsProps<TCrudData = any> {
     name?: string;
     initialData?: TCrudData;
 }
+
+type OptionsProps<TExtends = { [key: string]: any }> = TExtends & {
+    label?: string;
+    route?: string;
+    auditLog?: {
+        permissions?: AuditLogPermissions[number][] | string[];
+    };
+    hide?: boolean;
+    [key: string]: any;
+};
 
 // highlight-start
 type IMenuItem = IResourceItem & {

--- a/packages/core/src/contexts/resource/IResourceContext.ts
+++ b/packages/core/src/contexts/resource/IResourceContext.ts
@@ -16,6 +16,7 @@ type OptionsProps<TExtends = { [key: string]: any }> = TExtends & {
         permissions?: AuditLogPermissions[number][] | string[];
     };
     [key: string]: any;
+    hide?: boolean;
 };
 
 export interface ResourceProps extends IResourceComponents {

--- a/packages/core/src/definitions/helpers/treeView/createTreeView/index.ts
+++ b/packages/core/src/definitions/helpers/treeView/createTreeView/index.ts
@@ -14,9 +14,6 @@ export const createTreeView = (
 
         const route = parent.route ?? parent.options?.route ?? "";
 
-        if (parent.options?.hide === true) {
-            continue;
-        }
         resourcesRouteObject[route] = parent;
         resourcesRouteObject[route]["children"] = [];
 

--- a/packages/core/src/definitions/helpers/treeView/createTreeView/index.ts
+++ b/packages/core/src/definitions/helpers/treeView/createTreeView/index.ts
@@ -14,6 +14,9 @@ export const createTreeView = (
 
         const route = parent.route ?? parent.options?.route ?? "";
 
+        if (parent.options?.hide === true) {
+            continue;
+        }
         resourcesRouteObject[route] = parent;
         resourcesRouteObject[route]["children"] = [];
 

--- a/packages/core/src/hooks/menu/useMenu.spec.tsx
+++ b/packages/core/src/hooks/menu/useMenu.spec.tsx
@@ -226,12 +226,13 @@ describe("useMenu Hook", () => {
             ]),
         );
 
-      expect(result.current.menuItems).toEqual(
+        expect(result.current.menuItems).toEqual(
             expect.not.arrayContaining([
                 expect.objectContaining({ name: "hidden" }),
                 expect.objectContaining({ name: "posts" }),
             ]),
         );
+    });
 
     it("should hide all necessary resources with nested structure", async () => {
         const { result } = renderHook(() => useMenu(), {
@@ -260,17 +261,14 @@ describe("useMenu Hook", () => {
                         },
                     },
                     {
-                        // this is not hidden but its parent is hidden therefore it should be hidden.
                         name: "Shop-1",
                         parentName: "CMS",
                     },
                     {
-                        // this is not hidden but its parent's parent is hidden therefore it should be hidden.
                         name: "posts",
                         parentName: "Shop-1",
                     },
                     {
-                        // this is not hidden but its parent's parent is hidden therefore it should be hidden.
                         name: "categories",
                         parentName: "Shop-1",
                     },
@@ -293,11 +291,6 @@ describe("useMenu Hook", () => {
         expect(result.current.menuItems).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({ name: "visible" }),
-            ]),
-        );
-
-        expect(result.current.menuItems).toEqual(
-            expect.arrayContaining([
                 expect.objectContaining({ name: "visible-item-2" }),
             ]),
         );
@@ -305,20 +298,17 @@ describe("useMenu Hook", () => {
         expect(result.current.menuItems).toEqual(
             expect.not.arrayContaining([
                 expect.objectContaining({
-                    name: expect.stringContaining("hidden"),
+                    name: "hidden",
                 }),
-            ]),
-        );
-
-        expect(result.current.menuItems).toEqual(
-            expect.not.arrayContaining([
-                expect.objectContaining({ name: "posts" }),
-            ]),
-        );
-
-        expect(result.current.menuItems).toEqual(
-            expect.not.arrayContaining([
-                expect.objectContaining({ name: "categories" }),
+                expect.objectContaining({
+                    name: "Shop-1",
+                }),
+                expect.objectContaining({
+                    name: "posts",
+                }),
+                expect.objectContaining({
+                    name: "categories",
+                }),
             ]),
         );
     });

--- a/packages/core/src/hooks/menu/useMenu.spec.tsx
+++ b/packages/core/src/hooks/menu/useMenu.spec.tsx
@@ -243,4 +243,94 @@ describe("useMenu Hook", () => {
             ]),
         );
     });
+
+    it("should hide all necessary resources with nested structure", async () => {
+        const { result } = renderHook(() => useMenu(), {
+            wrapper: TestWrapper({
+                resources: prepareResources([
+                    {
+                        name: "visible",
+                        list: function list() {
+                            return <div>render me!</div>;
+                        },
+                    },
+                    {
+                        name: "hidden-level-1",
+                        options: {
+                            hide: true,
+                        },
+                    },
+                    {
+                        name: "hidden-child-level-2",
+                        parentName: "hidden-parent-menu",
+                    },
+                    {
+                        name: "hidden-parent-level-1",
+                        options: {
+                            hide: true,
+                        },
+                    },
+                    {
+                        // this is not hidden but its parent is hidden therefore it should be hidden.
+                        name: "Shop-1",
+                        parentName: "CMS",
+                    },
+                    {
+                        // this is not hidden but its parent's parent is hidden therefore it should be hidden.
+                        name: "posts",
+                        parentName: "Shop-1",
+                    },
+                    {
+                        // this is not hidden but its parent's parent is hidden therefore it should be hidden.
+                        name: "categories",
+                        parentName: "Shop-1",
+                    },
+                    {
+                        name: "CMS",
+                        options: {
+                            hide: true,
+                        },
+                    },
+                    {
+                        name: "visible-item-2",
+                        list: function list() {
+                            return <div>render me!</div>;
+                        },
+                    },
+                ]),
+            }),
+        });
+
+        expect(result.current.menuItems).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ name: "visible" }),
+            ]),
+        );
+
+        expect(result.current.menuItems).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ name: "visible-item-2" }),
+            ]),
+        );
+
+        expect(result.current.menuItems).toEqual(
+            expect.not.arrayContaining([
+                expect.objectContaining({
+                    name: expect.stringContaining("hidden"),
+                }),
+            ]),
+        );
+
+        expect(result.current.menuItems).toEqual(
+            expect.not.arrayContaining([
+                expect.objectContaining({ name: "posts" }),
+            ]),
+        );
+
+        expect(result.current.menuItems).toEqual(
+            expect.not.arrayContaining([
+                expect.objectContaining({ name: "categories" }),
+            ]),
+        );
+    });
 });

--- a/packages/core/src/hooks/menu/useMenu.spec.tsx
+++ b/packages/core/src/hooks/menu/useMenu.spec.tsx
@@ -165,7 +165,7 @@ describe("useMenu Hook", () => {
         );
     });
 
-    it("should tree view render all except hide true", async () => {
+    fit("should tree view render all except hide true", async () => {
         const { result } = renderHook(() => useMenu(), {
             wrapper: TestWrapper({
                 resources: prepareResources([
@@ -181,6 +181,34 @@ describe("useMenu Hook", () => {
                             hide: true,
                         },
                     },
+                    {
+                        name: "hidden-parent-menu",
+                        options: {
+                            hide: true,
+                        },
+                    },
+                    {
+                        name: "hidden-child",
+                        parentName: "hidden-parent-menu",
+                    },
+                    {
+                        name: "CMS",
+                    },
+                    {
+                        name: "Shop-1",
+                        parentName: "CMS",
+                        options: {
+                            hide: true,
+                        },
+                    },
+                    {
+                        name: "Posts",
+                        parentName: "Shop-1",
+                    },
+                    {
+                        name: "Categories",
+                        parentName: "Shop-1",
+                    },
                 ]),
             }),
         });
@@ -194,6 +222,12 @@ describe("useMenu Hook", () => {
         expect(result.current.menuItems).toEqual(
             expect.not.arrayContaining([
                 expect.objectContaining({ name: "hidden" }),
+            ]),
+        );
+
+        expect(result.current.menuItems).toEqual(
+            expect.not.arrayContaining([
+                expect.objectContaining({ name: "Posts" }),
             ]),
         );
     });

--- a/packages/core/src/hooks/menu/useMenu.spec.tsx
+++ b/packages/core/src/hooks/menu/useMenu.spec.tsx
@@ -222,11 +222,6 @@ describe("useMenu Hook", () => {
         expect(result.current.menuItems).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({ name: "visible" }),
-            ]),
-        );
-
-        expect(result.current.menuItems).toEqual(
-            expect.arrayContaining([
                 expect.objectContaining({ name: "visible-item-2" }),
             ]),
         );

--- a/packages/core/src/hooks/menu/useMenu.spec.tsx
+++ b/packages/core/src/hooks/menu/useMenu.spec.tsx
@@ -231,18 +231,12 @@ describe("useMenu Hook", () => {
             ]),
         );
 
-        expect(result.current.menuItems).toEqual(
+      expect(result.current.menuItems).toEqual(
             expect.not.arrayContaining([
                 expect.objectContaining({ name: "hidden" }),
-            ]),
-        );
-
-        expect(result.current.menuItems).toEqual(
-            expect.not.arrayContaining([
                 expect.objectContaining({ name: "posts" }),
             ]),
         );
-    });
 
     it("should hide all necessary resources with nested structure", async () => {
         const { result } = renderHook(() => useMenu(), {

--- a/packages/core/src/hooks/menu/useMenu.spec.tsx
+++ b/packages/core/src/hooks/menu/useMenu.spec.tsx
@@ -164,4 +164,38 @@ describe("useMenu Hook", () => {
             expect.arrayContaining(["/CMS", "/CMS/categories"]),
         );
     });
+
+    it("should tree view render all except hide true", async () => {
+        const { result } = renderHook(() => useMenu(), {
+            wrapper: TestWrapper({
+                routerInitialEntries: ["/else-new"],
+                resources: prepareResources([
+                    {
+                        name: "visible",
+                        list: function list() {
+                            return <div>render me!</div>;
+                        },
+                    },
+                    {
+                        name: "hidden",
+                        options: {
+                            hide: true,
+                        },
+                    },
+                ]),
+            }),
+        });
+
+        expect(result.current.menuItems).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ name: "visible" }),
+            ]),
+        );
+
+        expect(result.current.menuItems).toEqual(
+            expect.not.arrayContaining([
+                expect.objectContaining({ name: "hidden" }),
+            ]),
+        );
+    });
 });

--- a/packages/core/src/hooks/menu/useMenu.spec.tsx
+++ b/packages/core/src/hooks/menu/useMenu.spec.tsx
@@ -165,7 +165,7 @@ describe("useMenu Hook", () => {
         );
     });
 
-    fit("should tree view render all except hide true", async () => {
+    it("should tree view render all except hide true", async () => {
         const { result } = renderHook(() => useMenu(), {
             wrapper: TestWrapper({
                 resources: prepareResources([

--- a/packages/core/src/hooks/menu/useMenu.spec.tsx
+++ b/packages/core/src/hooks/menu/useMenu.spec.tsx
@@ -202,12 +202,18 @@ describe("useMenu Hook", () => {
                         },
                     },
                     {
-                        name: "Posts",
+                        name: "posts",
                         parentName: "Shop-1",
                     },
                     {
-                        name: "Categories",
+                        name: "categories",
                         parentName: "Shop-1",
+                    },
+                    {
+                        name: "visible-item-2",
+                        list: function list() {
+                            return <div>render me!</div>;
+                        },
                     },
                 ]),
             }),
@@ -220,6 +226,12 @@ describe("useMenu Hook", () => {
         );
 
         expect(result.current.menuItems).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ name: "visible-item-2" }),
+            ]),
+        );
+
+        expect(result.current.menuItems).toEqual(
             expect.not.arrayContaining([
                 expect.objectContaining({ name: "hidden" }),
             ]),
@@ -227,7 +239,7 @@ describe("useMenu Hook", () => {
 
         expect(result.current.menuItems).toEqual(
             expect.not.arrayContaining([
-                expect.objectContaining({ name: "Posts" }),
+                expect.objectContaining({ name: "posts" }),
             ]),
         );
     });

--- a/packages/core/src/hooks/menu/useMenu.spec.tsx
+++ b/packages/core/src/hooks/menu/useMenu.spec.tsx
@@ -168,7 +168,6 @@ describe("useMenu Hook", () => {
     it("should tree view render all except hide true", async () => {
         const { result } = renderHook(() => useMenu(), {
             wrapper: TestWrapper({
-                routerInitialEntries: ["/else-new"],
                 resources: prepareResources([
                     {
                         name: "visible",

--- a/packages/core/src/hooks/menu/useMenu.tsx
+++ b/packages/core/src/hooks/menu/useMenu.tsx
@@ -56,27 +56,22 @@ export const useMenu: () => useMenuReturnType = () => {
 
     const treeMenuItems: IMenuItem[] = React.useMemo(
         () =>
-            resources
-                .filter((resource) => resource.options?.hide !== true)
-                .map((resource) => {
-                    const route = `/${resource.route}`;
+            resources.map((resource) => {
+                const route = `/${resource.route}`;
 
-                    return {
-                        ...resource,
-                        icon: resource.icon,
-                        route: route,
-                        key: resource.key ?? route,
-                        label:
-                            resource.label ??
-                            translate(
-                                `${resource.name}.${resource.name}`,
-                                userFriendlyResourceName(
-                                    resource.name,
-                                    "plural",
-                                ),
-                            ),
-                    };
-                }),
+                return {
+                    ...resource,
+                    icon: resource.icon,
+                    route: route,
+                    key: resource.key ?? route,
+                    label:
+                        resource.label ??
+                        translate(
+                            `${resource.name}.${resource.name}`,
+                            userFriendlyResourceName(resource.name, "plural"),
+                        ),
+                };
+            }),
         [resources, hasDashboard],
     );
     const menuItems: ITreeMenu[] = React.useMemo(

--- a/packages/core/src/hooks/menu/useMenu.tsx
+++ b/packages/core/src/hooks/menu/useMenu.tsx
@@ -119,14 +119,18 @@ export const useMenu: () => useMenuReturnType = () => {
     );
 
     const values = React.useMemo(() => {
-        const filterMenuItemsByListView = (menus: ITreeMenu[]): ITreeMenu[] => {
+        const filterMenuItemsByListViewAndHideOption = (
+            menus: ITreeMenu[],
+        ): ITreeMenu[] => {
             return menus.reduce((menuItem: ITreeMenu[], obj) => {
                 if (obj.children.length > 0 && obj.options?.hide !== true)
                     return [
                         ...menuItem,
                         {
                             ...obj,
-                            children: filterMenuItemsByListView(obj.children),
+                            children: filterMenuItemsByListViewAndHideOption(
+                                obj.children,
+                            ),
                         },
                     ];
                 else if (
@@ -142,7 +146,7 @@ export const useMenu: () => useMenuReturnType = () => {
         return {
             defaultOpenKeys,
             selectedKey,
-            menuItems: filterMenuItemsByListView(menuItems),
+            menuItems: filterMenuItemsByListViewAndHideOption(menuItems),
         };
     }, [defaultOpenKeys, selectedKey, menuItems]);
 

--- a/packages/core/src/hooks/menu/useMenu.tsx
+++ b/packages/core/src/hooks/menu/useMenu.tsx
@@ -56,22 +56,27 @@ export const useMenu: () => useMenuReturnType = () => {
 
     const treeMenuItems: IMenuItem[] = React.useMemo(
         () =>
-            resources.map((resource) => {
-                const route = `/${resource.route}`;
+            resources
+                .filter((resource) => resource.options?.hide !== true)
+                .map((resource) => {
+                    const route = `/${resource.route}`;
 
-                return {
-                    ...resource,
-                    icon: resource.icon,
-                    route: route,
-                    key: resource.key ?? route,
-                    label:
-                        resource.label ??
-                        translate(
-                            `${resource.name}.${resource.name}`,
-                            userFriendlyResourceName(resource.name, "plural"),
-                        ),
-                };
-            }),
+                    return {
+                        ...resource,
+                        icon: resource.icon,
+                        route: route,
+                        key: resource.key ?? route,
+                        label:
+                            resource.label ??
+                            translate(
+                                `${resource.name}.${resource.name}`,
+                                userFriendlyResourceName(
+                                    resource.name,
+                                    "plural",
+                                ),
+                            ),
+                    };
+                }),
         [resources, hasDashboard],
     );
     const menuItems: ITreeMenu[] = React.useMemo(

--- a/packages/core/src/hooks/menu/useMenu.tsx
+++ b/packages/core/src/hooks/menu/useMenu.tsx
@@ -121,7 +121,7 @@ export const useMenu: () => useMenuReturnType = () => {
     const values = React.useMemo(() => {
         const filterMenuItemsByListView = (menus: ITreeMenu[]): ITreeMenu[] => {
             return menus.reduce((menuItem: ITreeMenu[], obj) => {
-                if (obj.children.length > 0)
+                if (obj.children.length > 0 && obj.options?.hide !== true)
                     return [
                         ...menuItem,
                         {
@@ -129,7 +129,10 @@ export const useMenu: () => useMenuReturnType = () => {
                             children: filterMenuItemsByListView(obj.children),
                         },
                     ];
-                else if (typeof obj.list !== "undefined")
+                else if (
+                    typeof obj.list !== "undefined" &&
+                    obj.options?.hide !== true
+                )
                     return [...menuItem, obj];
 
                 return menuItem;


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Add an option to hide `resources` from the `Sider` menu

### Test plan (required)
![Screen Shot 2022-08-31 at 13 55 14](https://user-images.githubusercontent.com/1110414/187663046-7fa63b08-f44d-49ac-a727-b30698acd018.png)

### Closing issues

- #2388 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
