### PR TITLE
feat: object path syntax support for the useSelect hook

### DIFF
--- a/.changeset/soft-queens-thank.md
+++ b/.changeset/soft-queens-thank.md
@@ -2,7 +2,7 @@
 "@pankod/refine-core": minor
 ---
 
-Add object path support for useSelect hook
+Add object path syntax support for useSelect hook
 
 
 ```tsx

--- a/.changeset/soft-queens-thank.md
+++ b/.changeset/soft-queens-thank.md
@@ -1,0 +1,14 @@
+---
+"@pankod/refine-core": minor
+---
+
+Add object path support for useSelect hook
+
+
+```tsx
+useSelect({
+    resource: "posts",
+    optionLabel: "nested.title",
+    optionLabel: "nested.id",
+});
+```

--- a/documentation/docs/core/hooks/useSelect.md
+++ b/documentation/docs/core/hooks/useSelect.md
@@ -111,6 +111,21 @@ const { options } = useSelect({
 
 Allows you to change the values and appearance of your options. Default values are `optionLabel = "title"` and `optionValue = "id"`.
 
+:::tip
+
+Supports use with `optionLabel` and `optionValue` [Object path](https://lodash.com/docs/4.17.15#get) syntax.
+
+```tsx
+const { options } = useSelect({
+    resource: "categories",
+// highlight-start
+    optionLabel: "nested.title",
+    optionValue: "nested.id",
+// highlight-end
+});
+```
+:::
+
 ### `filters`
 
 ```tsx

--- a/documentation/docs/ui-frameworks/antd/hooks/field/useCheckboxGroup.md
+++ b/documentation/docs/ui-frameworks/antd/hooks/field/useCheckboxGroup.md
@@ -108,6 +108,21 @@ const { checkboxGroupProps } = useCheckboxGroup({
 
 `optionLabel` and `optionValue` allows you to change the values and appearances of your options. Default values are `optionLabel = "title"` and `optionValue = "id"`.
 
+:::tip
+
+Supports use with `optionLabel` and `optionValue` [Object path](https://lodash.com/docs/4.17.15#get) syntax.
+
+```tsx
+const { options } = useSelect({
+    resource: "categories",
+// highlight-start
+    optionLabel: "nested.title",
+    optionValue: "nested.id",
+// highlight-end
+});
+```
+:::
+
 ### `filters`
 
 ```tsx

--- a/documentation/docs/ui-frameworks/antd/hooks/field/useRadioGroup.md
+++ b/documentation/docs/ui-frameworks/antd/hooks/field/useRadioGroup.md
@@ -108,6 +108,21 @@ const { radioGroupProps } = useRadioGroup({
 
 `optionLabel` and `optionValue` allows you to change the values and appearances of your options. Default values are `optionLabel = "title"` and `optionValue = "id"`.
 
+:::tip
+
+Supports use with `optionLabel` and `optionValue` [Object path](https://lodash.com/docs/4.17.15#get) syntax.
+
+```tsx
+const { options } = useSelect({
+    resource: "categories",
+// highlight-start
+    optionLabel: "nested.title",
+    optionValue: "nested.id",
+// highlight-end
+});
+```
+:::
+
 ### `filters`
 
 ```tsx

--- a/documentation/docs/ui-frameworks/antd/hooks/field/useSelect.md
+++ b/documentation/docs/ui-frameworks/antd/hooks/field/useSelect.md
@@ -135,6 +135,21 @@ const { selectProps } = useSelect({
 
 Allows you to change the values and appearance of your options. Default values are `optionLabel = "title"` and `optionValue = "id"`.
 
+:::tip
+
+Supports use with `optionLabel` and `optionValue` [Object path](https://lodash.com/docs/4.17.15#get) syntax.
+
+```tsx
+const { options } = useSelect({
+    resource: "categories",
+// highlight-start
+    optionLabel: "nested.title",
+    optionValue: "nested.id",
+// highlight-end
+});
+```
+:::
+
 ### `filters`
 
 ```tsx

--- a/packages/core/src/hooks/useSelect/index.spec.ts
+++ b/packages/core/src/hooks/useSelect/index.spec.ts
@@ -40,6 +40,37 @@ describe("useSelect Hook", () => {
         ]);
     });
 
+    it("with nested optionLabel", async () => {
+        const { result } = renderHook(
+            () =>
+                useSelect({
+                    resource: "posts",
+                    optionLabel: "nested.title",
+                }),
+            {
+                wrapper: TestWrapper({
+                    dataProvider: MockJSONServer,
+                    resources: [{ name: "posts" }],
+                }),
+            },
+        );
+
+        await waitFor(() => {
+            expect(result.current.queryResult.isSuccess).toBeTruthy();
+        });
+
+        const { options } = result.current;
+
+        expect(options).toHaveLength(2);
+        expect(options).toEqual([
+            {
+                label: "Necessitatibus necessitatibus id et cupiditate provident est qui amet.",
+                value: "1",
+            },
+            { label: "Recusandae consectetur aut atque est.", value: "2" },
+        ]);
+    });
+
     it("defaultValue", async () => {
         const { result } = renderHook(
             () =>

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { QueryObserverResult, UseQueryOptions } from "@tanstack/react-query";
 import uniqBy from "lodash/uniqBy";
 import debounce from "lodash/debounce";
+import get from "lodash/get";
 
 import { useList, useMany } from "@hooks";
 import {
@@ -80,8 +81,8 @@ export const useSelect = <
     const defaultValueQueryOnSuccess = (data: GetManyResponse<TData>) => {
         setSelectedOptions(
             data.data.map((item) => ({
-                label: item[optionLabel],
-                value: item[optionValue],
+                label: get(item, optionLabel),
+                value: get(item, optionValue),
             })),
         );
     };
@@ -108,8 +109,8 @@ export const useSelect = <
     const defaultQueryOnSuccess = (data: GetListResponse<TData>) => {
         setOptions(
             data.data.map((item) => ({
-                label: item[optionLabel],
-                value: item[optionValue],
+                label: get(item, optionLabel),
+                value: get(item, optionValue),
             })),
         );
     };

--- a/packages/core/test/dataMocks.ts
+++ b/packages/core/test/dataMocks.ts
@@ -18,6 +18,9 @@ export const posts = [
         status: "active",
         userId: 5,
         tags: [16, 31, 45],
+        nested: {
+            title: "Necessitatibus necessitatibus id et cupiditate provident est qui amet.",
+        },
     },
     {
         id: "2",
@@ -29,6 +32,9 @@ export const posts = [
         status: "active",
         userId: 36,
         tags: [16, 30, 46],
+        nested: {
+            title: "Recusandae consectetur aut atque est.",
+        },
     },
 ];
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Add object path syntax support for the `useSelect` hook

### Test plan (required)

![Screen Shot 2022-08-31 at 16 50 37](https://user-images.githubusercontent.com/1110414/187694882-fbee7860-3449-4733-a88c-5f01b18a4cba.png)

<!-- Make sure tests pass. -->

### Closing issues

- #2376

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
