### PR TITLE
fix: wrap with CanAccess component to parent sider items

### DIFF
--- a/.changeset/calm-garlics-rush.md
+++ b/.changeset/calm-garlics-rush.md
@@ -1,0 +1,30 @@
+---
+"@pankod/refine-antd": minor
+"@pankod/refine-mui": minor
+---
+
+Fix: Wrap with [`<CanAccess />`](https://refine.dev/docs/core/components/accessControl/can-access/) component to parent sider items
+
+```tsx
+<Refine
+    accessControlProvider={{
+        can: async ({ action, resource }) => {
+            // console.log({ action, resource });
+            // output: {action: "list", resource: "cms" } 
+          
+            return { can: true };
+        },
+    }}
+    resources={[
+        {
+            name: "CMS",
+        },
+        {
+            name: "posts",
+            parentName: "CMS",
+            list: PostList,
+        },
+    ]}
+/>
+
+```

--- a/.changeset/calm-garlics-rush.md
+++ b/.changeset/calm-garlics-rush.md
@@ -1,6 +1,6 @@
 ---
-"@pankod/refine-antd": minor
-"@pankod/refine-mui": minor
+"@pankod/refine-antd": patch
+"@pankod/refine-mui": patch
 ---
 
 Fix: Wrap with [`<CanAccess />`](https://refine.dev/docs/core/components/accessControl/can-access/) component to parent sider items

--- a/packages/antd/src/components/layout/sider/index.tsx
+++ b/packages/antd/src/components/layout/sider/index.tsx
@@ -45,13 +45,22 @@ export const Sider: React.FC<RefineLayoutSiderProps> = () => {
 
             if (children.length > 0) {
                 return (
-                    <SubMenu
+                    <CanAccess
                         key={route}
-                        icon={icon ?? <UnorderedListOutlined />}
-                        title={label}
+                        resource={name.toLowerCase()}
+                        action="list"
+                        params={{
+                            resource: item,
+                        }}
                     >
-                        {renderTreeView(children, selectedKey)}
-                    </SubMenu>
+                        <SubMenu
+                            key={route}
+                            icon={icon ?? <UnorderedListOutlined />}
+                            title={label}
+                        >
+                            {renderTreeView(children, selectedKey)}
+                        </SubMenu>
+                    </CanAccess>
                 );
             }
             const isSelected = route === selectedKey;

--- a/packages/mui/src/components/layout/sider/index.tsx
+++ b/packages/mui/src/components/layout/sider/index.tsx
@@ -87,70 +87,83 @@ export const Sider: React.FC<RefineLayoutSiderProps> = () => {
 
             if (children.length > 0) {
                 return (
-                    <div key={route}>
-                        <Tooltip
-                            title={label ?? name}
-                            placement="right"
-                            disableHoverListener={!collapsed}
-                            arrow
-                        >
-                            <ListItemButton
-                                onClick={() => {
-                                    if (collapsed) {
-                                        setCollapsed(false);
-                                        if (!isOpen) {
+                    <CanAccess
+                        key={route}
+                        resource={name.toLowerCase()}
+                        action="list"
+                        params={{
+                            resource: item,
+                        }}
+                    >
+                        <div key={route}>
+                            <Tooltip
+                                title={label ?? name}
+                                placement="right"
+                                disableHoverListener={!collapsed}
+                                arrow
+                            >
+                                <ListItemButton
+                                    onClick={() => {
+                                        if (collapsed) {
+                                            setCollapsed(false);
+                                            if (!isOpen) {
+                                                handleClick(route || "");
+                                            }
+                                        } else {
                                             handleClick(route || "");
                                         }
-                                    } else {
-                                        handleClick(route || "");
-                                    }
-                                }}
-                                sx={{
-                                    pl: isNested ? 4 : 2,
-                                    justifyContent: "center",
-                                    "&.Mui-selected": {
-                                        "&:hover": {
+                                    }}
+                                    sx={{
+                                        pl: isNested ? 4 : 2,
+                                        justifyContent: "center",
+                                        "&.Mui-selected": {
+                                            "&:hover": {
+                                                backgroundColor: "transparent",
+                                            },
                                             backgroundColor: "transparent",
                                         },
-                                        backgroundColor: "transparent",
-                                    },
-                                }}
-                            >
-                                <ListItemIcon
-                                    sx={{
-                                        justifyContent: "center",
-                                        minWidth: 36,
-                                        color: "primary.contrastText",
                                     }}
                                 >
-                                    {icon ?? <ListOutlined />}
-                                </ListItemIcon>
-                                <ListItemText
-                                    primary={label}
-                                    primaryTypographyProps={{
-                                        noWrap: true,
-                                        fontSize: "14px",
-                                        fontWeight: isSelected
-                                            ? "bold"
-                                            : "normal",
-                                    }}
-                                />
-                                {!collapsed &&
-                                    (isOpen ? <ExpandLess /> : <ExpandMore />)}
-                            </ListItemButton>
-                        </Tooltip>
-                        {!collapsed && (
-                            <Collapse
-                                in={open[route || ""]}
-                                timeout="auto"
-                                unmountOnExit
-                            >
-                                <List component="div" disablePadding>
-                                    {renderTreeView(children, selectedKey)}
-                                </List>
-                            </Collapse>
-                        )}
-                    </div>
+                                    <ListItemIcon
+                                        sx={{
+                                            justifyContent: "center",
+                                            minWidth: 36,
+                                            color: "primary.contrastText",
+                                        }}
+                                    >
+                                        {icon ?? <ListOutlined />}
+                                    </ListItemIcon>
+                                    <ListItemText
+                                        primary={label}
+                                        primaryTypographyProps={{
+                                            noWrap: true,
+                                            fontSize: "14px",
+                                            fontWeight: isSelected
+                                                ? "bold"
+                                                : "normal",
+                                        }}
+                                    />
+                                    {!collapsed &&
+                                        (isOpen ? (
+                                            <ExpandLess />
+                                        ) : (
+                                            <ExpandMore />
+                                        ))}
+                                </ListItemButton>
+                            </Tooltip>
+                            {!collapsed && (
+                                <Collapse
+                                    in={open[route || ""]}
+                                    timeout="auto"
+                                    unmountOnExit
+                                >
+                                    <List component="div" disablePadding>
+                                        {renderTreeView(children, selectedKey)}
+                                    </List>
+                                </Collapse>
+                            )}
+                        </div>
+                    </CanAccess>
                 );
             }
 


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Since parent menu items were not wrapped with `<CanAccess />`, they could not be controlled by the `accessControl Provider`.

Usage:

```tsx
<Refine
    accessControlProvider={{
        can: async ({ action, resource }) => {
            // console.log({ action, resource });
            // output: {action: "list", resource: "cms" } 
          
            return { can: true };
        },
    }}
    resources={[
        {
            name: "CMS",
        },
        {
            name: "posts",
            parentName: "CMS",
            list: PostList,
        },
    ]}
/>
```


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
