### PR TITLE
fix: cannot override useStepsForm's submit function

### DIFF
--- a/.changeset/rich-points-explode.md
+++ b/.changeset/rich-points-explode.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": patch
+---
+
+Fix: `submit` function of `useStepsForm` can be overridden

--- a/.changeset/rich-points-explode.md
+++ b/.changeset/rich-points-explode.md
@@ -2,4 +2,4 @@
 "@pankod/refine-antd": patch
 ---
 
-Fix: `submit` function of `useStepsForm` can be overridden
+Fix: `useStepsForm`'s `submit` function can be overridden

--- a/packages/antd/src/hooks/form/useStepsForm/useStepsForm.ts
+++ b/packages/antd/src/hooks/form/useStepsForm/useStepsForm.ts
@@ -50,11 +50,11 @@ export const useStepsForm = <
 
     const stepsPropsSunflower = useStepsFormSF<TData, TVariables>({
         isBackValidate: false,
-        ...props,
         form: form,
         submit: (values: any) => {
-            formProps && formProps.onFinish && formProps.onFinish(values);
+            formProps?.onFinish?.(values);
         },
+        ...props,
     });
 
     return {


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

useStepsForm's submit function must be overridable

### Closing issues

- #2407

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
