### PR TITLE
feat: Issue #2426 Add nesting sorting

### DIFF
--- a/.changeset/fast-rocks-fly.md
+++ b/.changeset/fast-rocks-fly.md
@@ -1,5 +1,6 @@
 ---
 "@pankod/refine-hasura": patch
+"@pankod/refine-nhost": patch
 ---
 
 Added nested sorting feature 💥

--- a/.changeset/fast-rocks-fly.md
+++ b/.changeset/fast-rocks-fly.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-hasura": patch
+---
+
+Added nested sorting feature 💥

--- a/.changeset/silver-coins-accept.md
+++ b/.changeset/silver-coins-accept.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": minor
+---
+
+Added support nested sorting

--- a/packages/antd/src/definitions/table/index.spec.ts
+++ b/packages/antd/src/definitions/table/index.spec.ts
@@ -126,6 +126,43 @@ describe("definitions/table", () => {
         `);
     });
 
+    it("mapAntdSorterToCrudSorting for nested columnKey and field", () => {
+        expect(
+            mapAntdSorterToCrudSorting([
+                {
+                    columnKey: "category.title",
+                    field: "title",
+                    order: "ascend",
+                    column: {
+                        sorter: {
+                            multiple: 1,
+                        },
+                    },
+                },
+                {
+                    field: ["version", "title"],
+                    order: "descend",
+                    column: {
+                        sorter: {
+                            multiple: 2,
+                        },
+                    },
+                },
+            ]),
+        ).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "field": "category.title",
+                "order": "asc",
+              },
+              Object {
+                "field": "version.title",
+                "order": "desc",
+              },
+            ]
+        `);
+    });
+
     it("mapAntdFilterToCrudFilter", () => {
         expect(
             mapAntdFilterToCrudFilter(

--- a/packages/antd/src/definitions/table/index.ts
+++ b/packages/antd/src/definitions/table/index.ts
@@ -47,16 +47,24 @@ export const mapAntdSorterToCrudSorting = (
             })
             .map((item) => {
                 if (item.field && item.order) {
+                    const field = Array.isArray(item.field)
+                        ? item.field.join(".")
+                        : `${item.field}`;
+
                     crudSorting.push({
-                        field: `${item.columnKey ?? item.field}`,
+                        field: `${item.columnKey ?? field}`,
                         order: item.order.replace("end", "") as "asc" | "desc",
                     });
                 }
             });
     } else {
         if (sorter.field && sorter.order) {
+            const field = Array.isArray(sorter.field)
+                ? sorter.field.join(".")
+                : `${sorter.field}`;
+
             crudSorting.push({
-                field: `${sorter.columnKey ?? sorter.field}`,
+                field: `${sorter.columnKey ?? field}`,
                 order: sorter.order.replace("end", "") as "asc" | "desc",
             });
         }

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -19,10 +19,15 @@ export const generateSorting: GenerateSortingType = (sorting?: CrudSorting) => {
         return undefined;
     }
 
-    const sortingQueryResult: Record<string, "asc" | "desc"> = {};
+    const sortingQueryResult: Record<string, "asc" | "desc" | HasuraSortingType> = {};
 
     sorting.forEach((sortItem) => {
+      if(sortItem.field.indexOf(",") !== -1) {
+        const [field, subField] = sortItem.field.split(",");
+        setWith(sortingQueryResult, `${field}.${subField}`, sortItem.order, Object);
+      } else {
         sortingQueryResult[sortItem.field] = sortItem.order;
+      }
     });
 
     return sortingQueryResult as HasuraSortingType;

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -7,6 +7,7 @@ import {
     DataProvider,
 } from "@pankod/refine-core";
 import setWith from "lodash/setWith";
+import set from "lodash/set";
 
 export type HasuraSortingType = Record<string, "asc" | "desc">;
 
@@ -19,15 +20,13 @@ export const generateSorting: GenerateSortingType = (sorting?: CrudSorting) => {
         return undefined;
     }
 
-    const sortingQueryResult: Record<string, "asc" | "desc" | HasuraSortingType> = {};
+    const sortingQueryResult: Record<
+        string,
+        "asc" | "desc" | HasuraSortingType
+    > = {};
 
     sorting.forEach((sortItem) => {
-      if(sortItem.field.indexOf(",") !== -1) {
-        const [field, subField] = sortItem.field.split(",");
-        setWith(sortingQueryResult, `${field}.${subField}`, sortItem.order, Object);
-      } else {
-        sortingQueryResult[sortItem.field] = sortItem.order;
-      }
+        set(sortingQueryResult, sortItem.field, sortItem.order);
     });
 
     return sortingQueryResult as HasuraSortingType;

--- a/packages/nhost/src/dataProvider/index.ts
+++ b/packages/nhost/src/dataProvider/index.ts
@@ -8,6 +8,7 @@ import {
     HttpError,
 } from "@pankod/refine-core";
 import setWith from "lodash/setWith";
+import set from "lodash/set";
 
 export type HasuraSortingType = Record<string, "asc" | "desc">;
 
@@ -20,10 +21,13 @@ export const generateSorting: GenerateSortingType = (sorting?: CrudSorting) => {
         return undefined;
     }
 
-    const sortingQueryResult: Record<string, "asc" | "desc"> = {};
+    const sortingQueryResult: Record<
+         string,
+         "asc" | "desc" | HasuraSortingType
+     > = {};
 
     sorting.forEach((sortItem) => {
-        sortingQueryResult[sortItem.field] = sortItem.order;
+        set(sortingQueryResult, sortItem.field, sortItem.order);
     });
 
     return sortingQueryResult as HasuraSortingType;


### PR DESCRIPTION
I've split on commas here in order to directly support the `dataIndex` array in table columns. It seems to work for me.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **details** for making this change. What existing problem does the pull request solve?

This is related to Issue 2426 [https://github.com/pankod/refine/issues/2426](url) adding the ability to sort based on nested fields used in array type dataIndex values in table columns

### Test plan (required)

This would require creating a list view with nested data as shown in the feature request and adding a sorter flag

<!-- Make sure tests pass. -->

### Closing issues

closes #2426

### Self Check before Merge

Please check all items below before review.

-   [ ] Corresponding issues are created/updated or not needed
-   [ ] Docs are updated/provided or not needed
-   [ ] Examples are updated/provided or not needed
-   [ x] TypeScript definitions are updated/provided or not needed
-   [ ] Tests are updated/provided or not needed
-   [ ] Changesets are provided or not needed
