### PR TITLE
Fix/auth page focus

### DIFF
--- a/.changeset/light-toys-wait.md
+++ b/.changeset/light-toys-wait.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fixed, `loginLink` and `registerLink` texts and remove unnecessary props from forms

--- a/packages/core/src/components/pages/auth/components/login/index.tsx
+++ b/packages/core/src/components/pages/auth/components/login/index.tsx
@@ -96,7 +96,6 @@ export const Login: React.FC<IAuthCommonProps> = ({
                         autoCorrect="off"
                         spellCheck={false}
                         autoCapitalize="off"
-                        autoFocus
                         required
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
@@ -134,7 +133,10 @@ export const Login: React.FC<IAuthCommonProps> = ({
                     {registerLink &&
                         renderLink(
                             registerLink,
-                            translate("pages.login.register", "Go to register"),
+                            translate(
+                                "pages.login.register",
+                                "Don't have an account? Register",
+                            ),
                         )}
                     {backLink &&
                         renderLink(

--- a/packages/core/src/components/pages/auth/components/register/index.tsx
+++ b/packages/core/src/components/pages/auth/components/register/index.tsx
@@ -57,7 +57,6 @@ export const Register: React.FC<IAuthCommonProps> = ({
                         autoCorrect="off"
                         spellCheck={false}
                         autoCapitalize="off"
-                        autoFocus
                         required
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
@@ -106,7 +105,7 @@ export const Register: React.FC<IAuthCommonProps> = ({
                             loginLink,
                             translate(
                                 "pages.register.loginLink",
-                                "Go to Login",
+                                "Have an account? Login",
                             ),
                         )}
                     {backLink &&

--- a/packages/core/src/components/pages/auth/components/resetPassword/index.tsx
+++ b/packages/core/src/components/pages/auth/components/resetPassword/index.tsx
@@ -49,7 +49,6 @@ export const ResetPassword: React.FC<IAuthCommonProps> = ({
                         autoCorrect="off"
                         spellCheck={false}
                         autoCapitalize="off"
-                        autoFocus
                         required
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}


### PR DESCRIPTION
Fixed, `<AuthAge>` `loginLink` and `registerLink` rendering texts and remove unnecessary props from forms
