### PR TITLE
fix: syncWithLocation not tracking when useTable filters were reset

### DIFF
--- a/.changeset/slow-actors-marry.md
+++ b/.changeset/slow-actors-marry.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fixed syncWithLocation not tracking when useTable filters were reset

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -204,9 +204,19 @@ export function useTable<
         }
     }, [search]);
 
+    const currentQueryParams = (): object => {
+        // We get QueryString parameters that are uncontrolled by refine.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { sorter, filters, pageSize, current, ...rest } = qs.parse(
+            search?.slice(1),
+        ); // remove first ? character
+
+        return rest;
+    };
+
     useEffect(() => {
         if (syncWithLocation) {
-            const currentQueryParams = qs.parse(search?.slice(1)); // remove first ? character
+            const queryParams = currentQueryParams();
             const stringifyParams = stringifyTableParams({
                 ...(hasPagination
                     ? {
@@ -218,7 +228,7 @@ export function useTable<
                     : {}),
                 sorter: differenceWith(sorter, permanentSorter, isEqual),
                 filters: differenceWith(filters, permanentFilter, isEqual),
-                ...currentQueryParams,
+                ...queryParams,
             });
 
             // Careful! This triggers render

--- a/packages/core/src/hooks/useTable/index.ts
+++ b/packages/core/src/hooks/useTable/index.ts
@@ -207,9 +207,9 @@ export function useTable<
     const currentQueryParams = (): object => {
         // We get QueryString parameters that are uncontrolled by refine.
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { sorter, filters, pageSize, current, ...rest } = qs.parse(
-            search?.slice(1),
-        ); // remove first ? character
+ const { sorter, filters, pageSize, current, ...rest } = qs.parse(search, {
+        ignoreQueryPrefix: true,
+    });
 
         return rest;
     };


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

- #2432

### Test plan (required)

_coming soon_

### Closing issues

- #2432

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
