### PR TITLE
refactor: remove `decamelize`

### DIFF
--- a/.changeset/stale-dolls-play.md
+++ b/.changeset/stale-dolls-play.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": minor
+---
+
+Remove `decamelize` dependency from `humanizeString` helper and replace the functionality with regExp.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,6 @@
     },
     "dependencies": {
         "export-to-csv-fix-source-map": "^0.2.1",
-        "decamelize": "^5.0.0",
         "lodash-es": "^4.17.21",
         "lodash": "^4.17.21",
         "papaparse": "^5.3.0",

--- a/packages/core/src/definitions/helpers/humanizeString/index.spec.tsx
+++ b/packages/core/src/definitions/helpers/humanizeString/index.spec.tsx
@@ -5,5 +5,6 @@ describe("humanizeString", () => {
         expect(humanizeString("fooBar")).toBe("Foo bar");
         expect(humanizeString("foo-bar")).toBe("Foo bar");
         expect(humanizeString("foo_bar")).toBe("Foo bar");
+        expect(humanizeString("myFOOBar")).toBe("My foo bar");
     });
 });

--- a/packages/core/src/definitions/helpers/humanizeString/index.ts
+++ b/packages/core/src/definitions/helpers/humanizeString/index.ts
@@ -1,7 +1,7 @@
-import decamelize from "decamelize";
-
 export const humanizeString = (text: string): string => {
-    text = decamelize(text);
+    text = text.replace(/([a-z]{1})([A-Z]{1})/g, "$1-$2");
+    text = text.replace(/([A-Z]{1})([A-Z]{1})([a-z]{1})/g, "$1-$2$3");
+
     text = text
         .toLowerCase()
         .replace(/[_-]+/g, " ")


### PR DESCRIPTION
Remove `decamelize` dependency from `humanizeString` helper and replace the functionality with regExp.

### Test plan (required)

![Screen Shot 2022-09-06 at 12 14 06](https://user-images.githubusercontent.com/75166276/188596551-57a2e77e-0797-46cb-b1b0-121bb4fb9c4b.png)

-   [X] Corresponding issues are created/updated or not needed
-   [X] Docs are updated/provided or not needed
-   [X] Examples are updated/provided or not needed
-   [X] TypeScript definitions are updated/provided or not needed
-   [X] Tests are updated/provided or not needed
-   [X] Changesets are provided or not needed
