### PR TITLE
feat: added render prop to Sider components

### DIFF
--- a/.changeset/curly-mice-kick.md
+++ b/.changeset/curly-mice-kick.md
@@ -2,4 +2,4 @@
 "@pankod/refine-antd": minor
 ---
 
-Added `topSection` and `bottomSection` props to render custom elements rather than `Logout` and `Dashboard` items in `Sider` component.
+Added `top` and `bottom` props to render custom elements rather than `Logout` and `Dashboard` items in `Sider` component.

--- a/.changeset/curly-mice-kick.md
+++ b/.changeset/curly-mice-kick.md
@@ -2,4 +2,4 @@
 "@pankod/refine-antd": minor
 ---
 
-Added `dashboard`, `logout` and `items` props to render customize`Sider` component.
+Added `render` prop to `Sider` component. You can get `dashboard`, `logout` and `items` from `render` props to customize the `Sider` component.

--- a/.changeset/curly-mice-kick.md
+++ b/.changeset/curly-mice-kick.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": minor
+---
+
+Added `topSection` and `bottomSection` props to render custom elements rather than `Logout` and `Dashboard` items in `Sider` component.

--- a/.changeset/curly-mice-kick.md
+++ b/.changeset/curly-mice-kick.md
@@ -2,4 +2,4 @@
 "@pankod/refine-antd": minor
 ---
 
-Added `top` and `bottom` props to render custom elements rather than `Logout` and `Dashboard` items in `Sider` component.
+Added `dashboard`, `logout` and `items` props to render customize`Sider` component.

--- a/.changeset/kind-planets-knock.md
+++ b/.changeset/kind-planets-knock.md
@@ -2,4 +2,4 @@
 "@pankod/refine-mui": minor
 ---
 
-Added `top` and `bottom` props to render custom elements rather than `Logout` and `Dashboard` items in `Sider` component.
+Added `dashboard`, `logout` and `items` props to render customize`Sider` component.

--- a/.changeset/kind-planets-knock.md
+++ b/.changeset/kind-planets-knock.md
@@ -2,4 +2,4 @@
 "@pankod/refine-mui": minor
 ---
 
-Added `dashboard`, `logout` and `items` props to render customize`Sider` component.
+Added `render` prop to `Sider` component. You can get `dashboard`, `logout` and `items` from `render` props to customize the `Sider` component.

--- a/.changeset/kind-planets-knock.md
+++ b/.changeset/kind-planets-knock.md
@@ -2,4 +2,4 @@
 "@pankod/refine-mui": minor
 ---
 
-Added `topSection` and `bottomSection` props to render custom elements rather than `Logout` and `Dashboard` items in `Sider` component.
+Added `top` and `bottom` props to render custom elements rather than `Logout` and `Dashboard` items in `Sider` component.

--- a/.changeset/kind-planets-knock.md
+++ b/.changeset/kind-planets-knock.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": minor
+---
+
+Added `topSection` and `bottomSection` props to render custom elements rather than `Logout` and `Dashboard` items in `Sider` component.

--- a/.changeset/nasty-oranges-sell.md
+++ b/.changeset/nasty-oranges-sell.md
@@ -2,4 +2,4 @@
 "@pankod/refine-ui-tests": minor
 ---
 
-Updated `Sider` test for `topSection` and `bottomSection` props.
+Updated `Sider` test for `top` and `bottom` props.

--- a/.changeset/nasty-oranges-sell.md
+++ b/.changeset/nasty-oranges-sell.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-ui-tests": minor
+---
+
+Updated `Sider` test for `topSection` and `bottomSection` props.

--- a/.changeset/nasty-oranges-sell.md
+++ b/.changeset/nasty-oranges-sell.md
@@ -2,4 +2,4 @@
 "@pankod/refine-ui-tests": minor
 ---
 
-Updated `Sider` test for `dashboard`, `logout` and `items` props.
+Updated `Sider` test for `render` props.

--- a/.changeset/nasty-oranges-sell.md
+++ b/.changeset/nasty-oranges-sell.md
@@ -2,4 +2,4 @@
 "@pankod/refine-ui-tests": minor
 ---
 
-Updated `Sider` test for `top` and `bottom` props.
+Updated `Sider` test for `dashboard`, `logout` and `items` props.

--- a/.changeset/nine-boxes-joke.md
+++ b/.changeset/nine-boxes-joke.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-ui-types": minor
+---
+
+Updated `Sider` type with `topSection` and `bottomSection` props.

--- a/.changeset/nine-boxes-joke.md
+++ b/.changeset/nine-boxes-joke.md
@@ -2,4 +2,4 @@
 "@pankod/refine-ui-types": minor
 ---
 
-Updated `Sider` type with `topSection` and `bottomSection` props.
+Updated `Sider` type with `top` and `bottom` props.

--- a/.changeset/nine-boxes-joke.md
+++ b/.changeset/nine-boxes-joke.md
@@ -2,4 +2,4 @@
 "@pankod/refine-ui-types": minor
 ---
 
-Updated `Sider` type with `dashboard`, `logout` and `items` props.
+Updated `Sider` types for `render` props.

--- a/.changeset/nine-boxes-joke.md
+++ b/.changeset/nine-boxes-joke.md
@@ -2,4 +2,4 @@
 "@pankod/refine-ui-types": minor
 ---
 
-Updated `Sider` type with `top` and `bottom` props.
+Updated `Sider` type with `dashboard`, `logout` and `items` props.

--- a/packages/antd/src/components/layout/sider/index.tsx
+++ b/packages/antd/src/components/layout/sider/index.tsx
@@ -23,11 +23,15 @@ import { antLayoutSider, antLayoutSiderMobile } from "./styles";
 import { RefineLayoutSiderProps } from "@pankod/refine-ui-types";
 const { SubMenu } = Menu;
 
-export const Sider: React.FC<RefineLayoutSiderProps> = ({ bottom, top }) => {
+export const Sider: React.FC<RefineLayoutSiderProps> = ({
+    logout,
+    dashboard,
+    items,
+}) => {
     const [collapsed, setCollapsed] = useState<boolean>(false);
     const isExistAuthentication = useIsExistAuthentication();
     const { Link } = useRouterContext();
-    const { mutate: logout } = useLogout();
+    const { mutate: mutateLogout } = useLogout();
     const Title = useTitle();
     const translate = useTranslate();
     const { menuItems, selectedKey, defaultOpenKeys } = useMenu();
@@ -93,7 +97,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({ bottom, top }) => {
         });
     };
 
-    const defaultTop = hasDashboard ? (
+    const defaultDashboard = hasDashboard ? (
         <CanAccess resource="dashboard" action="list">
             <Menu.Item
                 key="dashboard"
@@ -110,29 +114,20 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({ bottom, top }) => {
         </CanAccess>
     ) : null;
 
-    const renderTop =
-        typeof top !== "undefined"
-            ? typeof top === "function"
-                ? top(defaultTop)
-                : top
-            : defaultTop;
-
-    const defaultBottom = isExistAuthentication && (
+    const defaultLogout = isExistAuthentication && (
         <Menu.Item
             key="logout"
-            onClick={() => logout()}
+            onClick={() => mutateLogout()}
             icon={<LogoutOutlined />}
         >
             {translate("buttons.logout", "Logout")}
         </Menu.Item>
     );
 
-    const renderBottom =
-        typeof bottom !== "undefined"
-            ? typeof bottom === "function"
-                ? bottom(defaultBottom)
-                : bottom
-            : defaultBottom;
+    const logoutButton = typeof logout !== "undefined" ? logout : defaultLogout;
+    const dashboardMenuItem =
+        typeof dashboard !== "undefined" ? dashboard : defaultDashboard;
+    const menuItemsToRender = items ?? renderTreeView(menuItems, selectedKey);
 
     return (
         <Layout.Sider
@@ -154,11 +149,9 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({ bottom, top }) => {
                     }
                 }}
             >
-                {renderTop}
-
-                {renderTreeView(menuItems, selectedKey)}
-
-                {renderBottom}
+                {dashboardMenuItem}
+                {menuItemsToRender}
+                {logoutButton}
             </Menu>
         </Layout.Sider>
     );

--- a/packages/antd/src/components/layout/sider/index.tsx
+++ b/packages/antd/src/components/layout/sider/index.tsx
@@ -23,10 +23,7 @@ import { antLayoutSider, antLayoutSiderMobile } from "./styles";
 import { RefineLayoutSiderProps } from "@pankod/refine-ui-types";
 const { SubMenu } = Menu;
 
-export const Sider: React.FC<RefineLayoutSiderProps> = ({
-    bottomSection,
-    topSection,
-}) => {
+export const Sider: React.FC<RefineLayoutSiderProps> = ({ bottom, top }) => {
     const [collapsed, setCollapsed] = useState<boolean>(false);
     const isExistAuthentication = useIsExistAuthentication();
     const { Link } = useRouterContext();
@@ -97,25 +94,27 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
     };
 
     const defaultTop = hasDashboard ? (
-        <Menu.Item
-            key="dashboard"
-            style={{
-                fontWeight: selectedKey === "/" ? "bold" : "normal",
-            }}
-            icon={<DashboardOutlined />}
-        >
-            <Link to="/">{translate("dashboard.title", "Dashboard")}</Link>
-            {!collapsed && selectedKey === "/" && (
-                <div className="ant-menu-tree-arrow" />
-            )}
-        </Menu.Item>
+        <CanAccess resource="dashboard" action="list">
+            <Menu.Item
+                key="dashboard"
+                style={{
+                    fontWeight: selectedKey === "/" ? "bold" : "normal",
+                }}
+                icon={<DashboardOutlined />}
+            >
+                <Link to="/">{translate("dashboard.title", "Dashboard")}</Link>
+                {!collapsed && selectedKey === "/" && (
+                    <div className="ant-menu-tree-arrow" />
+                )}
+            </Menu.Item>
+        </CanAccess>
     ) : null;
 
     const renderTop =
-        typeof topSection !== "undefined"
-            ? typeof topSection === "function"
-                ? topSection(defaultTop)
-                : topSection
+        typeof top !== "undefined"
+            ? typeof top === "function"
+                ? top(defaultTop)
+                : top
             : defaultTop;
 
     const defaultBottom = isExistAuthentication && (
@@ -129,10 +128,10 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
     );
 
     const renderBottom =
-        typeof bottomSection !== "undefined"
-            ? typeof bottomSection === "function"
-                ? bottomSection(defaultBottom)
-                : bottomSection
+        typeof bottom !== "undefined"
+            ? typeof bottom === "function"
+                ? bottom(defaultBottom)
+                : bottom
             : defaultBottom;
 
     return (

--- a/packages/antd/src/components/layout/sider/index.tsx
+++ b/packages/antd/src/components/layout/sider/index.tsx
@@ -23,7 +23,10 @@ import { antLayoutSider, antLayoutSiderMobile } from "./styles";
 import { RefineLayoutSiderProps } from "@pankod/refine-ui-types";
 const { SubMenu } = Menu;
 
-export const Sider: React.FC<RefineLayoutSiderProps> = () => {
+export const Sider: React.FC<RefineLayoutSiderProps> = ({
+    bottomSection,
+    topSection,
+}) => {
     const [collapsed, setCollapsed] = useState<boolean>(false);
     const isExistAuthentication = useIsExistAuthentication();
     const { Link } = useRouterContext();
@@ -93,6 +96,45 @@ export const Sider: React.FC<RefineLayoutSiderProps> = () => {
         });
     };
 
+    const defaultTop = hasDashboard ? (
+        <Menu.Item
+            key="dashboard"
+            style={{
+                fontWeight: selectedKey === "/" ? "bold" : "normal",
+            }}
+            icon={<DashboardOutlined />}
+        >
+            <Link to="/">{translate("dashboard.title", "Dashboard")}</Link>
+            {!collapsed && selectedKey === "/" && (
+                <div className="ant-menu-tree-arrow" />
+            )}
+        </Menu.Item>
+    ) : null;
+
+    const renderTop =
+        typeof topSection !== "undefined"
+            ? typeof topSection === "function"
+                ? topSection(defaultTop)
+                : topSection
+            : defaultTop;
+
+    const defaultBottom = isExistAuthentication && (
+        <Menu.Item
+            key="logout"
+            onClick={() => logout()}
+            icon={<LogoutOutlined />}
+        >
+            {translate("buttons.logout", "Logout")}
+        </Menu.Item>
+    );
+
+    const renderBottom =
+        typeof bottomSection !== "undefined"
+            ? typeof bottomSection === "function"
+                ? bottomSection(defaultBottom)
+                : bottomSection
+            : defaultBottom;
+
     return (
         <Layout.Sider
             collapsible
@@ -113,34 +155,11 @@ export const Sider: React.FC<RefineLayoutSiderProps> = () => {
                     }
                 }}
             >
-                {hasDashboard ? (
-                    <Menu.Item
-                        key="dashboard"
-                        style={{
-                            fontWeight: selectedKey === "/" ? "bold" : "normal",
-                        }}
-                        icon={<DashboardOutlined />}
-                    >
-                        <Link to="/">
-                            {translate("dashboard.title", "Dashboard")}
-                        </Link>
-                        {!collapsed && selectedKey === "/" && (
-                            <div className="ant-menu-tree-arrow" />
-                        )}
-                    </Menu.Item>
-                ) : null}
+                {renderTop}
 
                 {renderTreeView(menuItems, selectedKey)}
 
-                {isExistAuthentication && (
-                    <Menu.Item
-                        key="logout"
-                        onClick={() => logout()}
-                        icon={<LogoutOutlined />}
-                    >
-                        {translate("buttons.logout", "Logout")}
-                    </Menu.Item>
-                )}
+                {renderBottom}
             </Menu>
         </Layout.Sider>
     );

--- a/packages/antd/src/components/layout/sider/index.tsx
+++ b/packages/antd/src/components/layout/sider/index.tsx
@@ -23,11 +23,7 @@ import { antLayoutSider, antLayoutSiderMobile } from "./styles";
 import { RefineLayoutSiderProps } from "@pankod/refine-ui-types";
 const { SubMenu } = Menu;
 
-export const Sider: React.FC<RefineLayoutSiderProps> = ({
-    logout,
-    dashboard,
-    items,
-}) => {
+export const Sider: React.FC<RefineLayoutSiderProps> = ({ render }) => {
     const [collapsed, setCollapsed] = useState<boolean>(false);
     const isExistAuthentication = useIsExistAuthentication();
     const { Link } = useRouterContext();
@@ -97,24 +93,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
         });
     };
 
-    const defaultDashboard = hasDashboard ? (
-        <CanAccess resource="dashboard" action="list">
-            <Menu.Item
-                key="dashboard"
-                style={{
-                    fontWeight: selectedKey === "/" ? "bold" : "normal",
-                }}
-                icon={<DashboardOutlined />}
-            >
-                <Link to="/">{translate("dashboard.title", "Dashboard")}</Link>
-                {!collapsed && selectedKey === "/" && (
-                    <div className="ant-menu-tree-arrow" />
-                )}
-            </Menu.Item>
-        </CanAccess>
-    ) : null;
-
-    const defaultLogout = isExistAuthentication && (
+    const logout = isExistAuthentication && (
         <Menu.Item
             key="logout"
             onClick={() => mutateLogout()}
@@ -124,10 +103,39 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
         </Menu.Item>
     );
 
-    const logoutButton = typeof logout !== "undefined" ? logout : defaultLogout;
-    const dashboardMenuItem =
-        typeof dashboard !== "undefined" ? dashboard : defaultDashboard;
-    const menuItemsToRender = items ?? renderTreeView(menuItems, selectedKey);
+    const dashboard = hasDashboard ? (
+        <Menu.Item
+            key="dashboard"
+            style={{
+                fontWeight: selectedKey === "/" ? "bold" : "normal",
+            }}
+            icon={<DashboardOutlined />}
+        >
+            <Link to="/">{translate("dashboard.title", "Dashboard")}</Link>
+            {!collapsed && selectedKey === "/" && (
+                <div className="ant-menu-tree-arrow" />
+            )}
+        </Menu.Item>
+    ) : null;
+
+    const items = renderTreeView(menuItems, selectedKey);
+
+    const renderSider = () => {
+        if (render) {
+            return render({
+                dashboard,
+                items,
+                logout,
+            });
+        }
+        return (
+            <>
+                {dashboard}
+                {items}
+                {logout}
+            </>
+        );
+    };
 
     return (
         <Layout.Sider
@@ -149,9 +157,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
                     }
                 }}
             >
-                {dashboardMenuItem}
-                {menuItemsToRender}
-                {logoutButton}
+                {renderSider()}
             </Menu>
         </Layout.Sider>
     );

--- a/packages/mui/src/components/layout/sider/index.tsx
+++ b/packages/mui/src/components/layout/sider/index.tsx
@@ -36,10 +36,7 @@ import {
 
 import { Title as DefaultTitle } from "../title";
 
-export const Sider: React.FC<RefineLayoutSiderProps> = ({
-    bottomSection,
-    topSection,
-}) => {
+export const Sider: React.FC<RefineLayoutSiderProps> = ({ bottom, top }) => {
     const [collapsed, setCollapsed] = useState(false);
     const [opened, setOpened] = useState(false);
 
@@ -227,57 +224,59 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
     };
 
     const defaultTop = hasDashboard ? (
-        <Tooltip
-            title={translate("dashboard.title", "Dashboard")}
-            placement="right"
-            disableHoverListener={!collapsed}
-            arrow
-        >
-            <ListItemButton
-                component={Link}
-                to="/"
-                selected={selectedKey === "/"}
-                onClick={() => {
-                    setOpened(false);
-                }}
-                sx={{
-                    pl: 2,
-                    py: 1,
-                    "&.Mui-selected": {
-                        "&:hover": {
+        <CanAccess resource="dashboard" action="list">
+            <Tooltip
+                title={translate("dashboard.title", "Dashboard")}
+                placement="right"
+                disableHoverListener={!collapsed}
+                arrow
+            >
+                <ListItemButton
+                    component={Link}
+                    to="/"
+                    selected={selectedKey === "/"}
+                    onClick={() => {
+                        setOpened(false);
+                    }}
+                    sx={{
+                        pl: 2,
+                        py: 1,
+                        "&.Mui-selected": {
+                            "&:hover": {
+                                backgroundColor: "transparent",
+                            },
                             backgroundColor: "transparent",
                         },
-                        backgroundColor: "transparent",
-                    },
-                    justifyContent: "center",
-                }}
-            >
-                <ListItemIcon
-                    sx={{
                         justifyContent: "center",
-                        minWidth: 36,
-                        color: "primary.contrastText",
                     }}
                 >
-                    <Dashboard />
-                </ListItemIcon>
-                <ListItemText
-                    primary={translate("dashboard.title", "Dashboard")}
-                    primaryTypographyProps={{
-                        noWrap: true,
-                        fontSize: "14px",
-                        fontWeight: selectedKey === "/" ? "bold" : "normal",
-                    }}
-                />
-            </ListItemButton>
-        </Tooltip>
+                    <ListItemIcon
+                        sx={{
+                            justifyContent: "center",
+                            minWidth: 36,
+                            color: "primary.contrastText",
+                        }}
+                    >
+                        <Dashboard />
+                    </ListItemIcon>
+                    <ListItemText
+                        primary={translate("dashboard.title", "Dashboard")}
+                        primaryTypographyProps={{
+                            noWrap: true,
+                            fontSize: "14px",
+                            fontWeight: selectedKey === "/" ? "bold" : "normal",
+                        }}
+                    />
+                </ListItemButton>
+            </Tooltip>
+        </CanAccess>
     ) : null;
 
     const renderTop =
-        typeof topSection !== "undefined"
-            ? typeof topSection === "function"
-                ? topSection(defaultTop)
-                : topSection
+        typeof top !== "undefined"
+            ? typeof top === "function"
+                ? top(defaultTop)
+                : top
             : defaultTop;
 
     const defaultBottom = isExistAuthentication && (
@@ -313,10 +312,10 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
     );
 
     const renderBottom =
-        typeof bottomSection !== "undefined"
-            ? typeof bottomSection === "function"
-                ? bottomSection(defaultBottom)
-                : bottomSection
+        typeof bottom !== "undefined"
+            ? typeof bottom === "function"
+                ? bottom(defaultBottom)
+                : bottom
             : defaultBottom;
 
     const drawer = (

--- a/packages/mui/src/components/layout/sider/index.tsx
+++ b/packages/mui/src/components/layout/sider/index.tsx
@@ -36,7 +36,11 @@ import {
 
 import { Title as DefaultTitle } from "../title";
 
-export const Sider: React.FC<RefineLayoutSiderProps> = ({ bottom, top }) => {
+export const Sider: React.FC<RefineLayoutSiderProps> = ({
+    logout,
+    dashboard,
+    items,
+}) => {
     const [collapsed, setCollapsed] = useState(false);
     const [opened, setOpened] = useState(false);
 
@@ -52,7 +56,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({ bottom, top }) => {
 
     const { menuItems, selectedKey, defaultOpenKeys } = useMenu();
     const isExistAuthentication = useIsExistAuthentication();
-    const { mutate: logout } = useLogout();
+    const { mutate: mutateLogout } = useLogout();
     const Title = useTitle();
 
     const [open, setOpen] = useState<{ [k: string]: any }>({});
@@ -223,7 +227,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({ bottom, top }) => {
         });
     };
 
-    const defaultTop = hasDashboard ? (
+    const defaultDashboard = hasDashboard ? (
         <CanAccess resource="dashboard" action="list">
             <Tooltip
                 title={translate("dashboard.title", "Dashboard")}
@@ -272,14 +276,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({ bottom, top }) => {
         </CanAccess>
     ) : null;
 
-    const renderTop =
-        typeof top !== "undefined"
-            ? typeof top === "function"
-                ? top(defaultTop)
-                : top
-            : defaultTop;
-
-    const defaultBottom = isExistAuthentication && (
+    const defaultLogout = isExistAuthentication && (
         <Tooltip
             title={t("buttons.logout", "Logout")}
             placement="right"
@@ -288,7 +285,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({ bottom, top }) => {
         >
             <ListItemButton
                 key="logout"
-                onClick={() => logout()}
+                onClick={() => mutateLogout()}
                 sx={{ justifyContent: "center" }}
             >
                 <ListItemIcon
@@ -311,18 +308,16 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({ bottom, top }) => {
         </Tooltip>
     );
 
-    const renderBottom =
-        typeof bottom !== "undefined"
-            ? typeof bottom === "function"
-                ? bottom(defaultBottom)
-                : bottom
-            : defaultBottom;
+    const logoutButton = typeof logout !== "undefined" ? logout : defaultLogout;
+    const dashboardMenuItem =
+        typeof dashboard !== "undefined" ? dashboard : defaultDashboard;
+    const menuItemsToRender = items ?? renderTreeView(menuItems, selectedKey);
 
     const drawer = (
         <List disablePadding sx={{ mt: 1, color: "primary.contrastText" }}>
-            {renderTop}
-            {renderTreeView(menuItems, selectedKey)}
-            {renderBottom}
+            {dashboardMenuItem}
+            {menuItemsToRender}
+            {logoutButton}
         </List>
     );
 

--- a/packages/mui/src/components/layout/sider/index.tsx
+++ b/packages/mui/src/components/layout/sider/index.tsx
@@ -36,7 +36,10 @@ import {
 
 import { Title as DefaultTitle } from "../title";
 
-export const Sider: React.FC<RefineLayoutSiderProps> = () => {
+export const Sider: React.FC<RefineLayoutSiderProps> = ({
+    bottomSection,
+    topSection,
+}) => {
     const [collapsed, setCollapsed] = useState(false);
     const [opened, setOpened] = useState(false);
 
@@ -223,87 +226,104 @@ export const Sider: React.FC<RefineLayoutSiderProps> = () => {
         });
     };
 
+    const defaultTop = hasDashboard ? (
+        <Tooltip
+            title={translate("dashboard.title", "Dashboard")}
+            placement="right"
+            disableHoverListener={!collapsed}
+            arrow
+        >
+            <ListItemButton
+                component={Link}
+                to="/"
+                selected={selectedKey === "/"}
+                onClick={() => {
+                    setOpened(false);
+                }}
+                sx={{
+                    pl: 2,
+                    py: 1,
+                    "&.Mui-selected": {
+                        "&:hover": {
+                            backgroundColor: "transparent",
+                        },
+                        backgroundColor: "transparent",
+                    },
+                    justifyContent: "center",
+                }}
+            >
+                <ListItemIcon
+                    sx={{
+                        justifyContent: "center",
+                        minWidth: 36,
+                        color: "primary.contrastText",
+                    }}
+                >
+                    <Dashboard />
+                </ListItemIcon>
+                <ListItemText
+                    primary={translate("dashboard.title", "Dashboard")}
+                    primaryTypographyProps={{
+                        noWrap: true,
+                        fontSize: "14px",
+                        fontWeight: selectedKey === "/" ? "bold" : "normal",
+                    }}
+                />
+            </ListItemButton>
+        </Tooltip>
+    ) : null;
+
+    const renderTop =
+        typeof topSection !== "undefined"
+            ? typeof topSection === "function"
+                ? topSection(defaultTop)
+                : topSection
+            : defaultTop;
+
+    const defaultBottom = isExistAuthentication && (
+        <Tooltip
+            title={t("buttons.logout", "Logout")}
+            placement="right"
+            disableHoverListener={!collapsed}
+            arrow
+        >
+            <ListItemButton
+                key="logout"
+                onClick={() => logout()}
+                sx={{ justifyContent: "center" }}
+            >
+                <ListItemIcon
+                    sx={{
+                        justifyContent: "center",
+                        minWidth: 36,
+                        color: "primary.contrastText",
+                    }}
+                >
+                    <Logout />
+                </ListItemIcon>
+                <ListItemText
+                    primary={t("buttons.logout", "Logout")}
+                    primaryTypographyProps={{
+                        noWrap: true,
+                        fontSize: "14px",
+                    }}
+                />
+            </ListItemButton>
+        </Tooltip>
+    );
+
+    const renderBottom =
+        typeof bottomSection !== "undefined"
+            ? typeof bottomSection === "function"
+                ? bottomSection(defaultBottom)
+                : bottomSection
+            : defaultBottom;
+
     const drawer = (
         <List disablePadding sx={{ mt: 1, color: "primary.contrastText" }}>
-            {hasDashboard ? (
-                <Tooltip
-                    title={translate("dashboard.title", "Dashboard")}
-                    placement="right"
-                    disableHoverListener={!collapsed}
-                    arrow
-                >
-                    <ListItemButton
-                        component={Link}
-                        to="/"
-                        selected={selectedKey === "/"}
-                        onClick={() => {
-                            setOpened(false);
-                        }}
-                        sx={{
-                            pl: 2,
-                            py: 1,
-                            "&.Mui-selected": {
-                                "&:hover": {
-                                    backgroundColor: "transparent",
-                                },
-                                backgroundColor: "transparent",
-                            },
-                            justifyContent: "center",
-                        }}
-                    >
-                        <ListItemIcon
-                            sx={{
-                                justifyContent: "center",
-                                minWidth: 36,
-                                color: "primary.contrastText",
-                            }}
-                        >
-                            <Dashboard />
-                        </ListItemIcon>
-                        <ListItemText
-                            primary={translate("dashboard.title", "Dashboard")}
-                            primaryTypographyProps={{
-                                noWrap: true,
-                                fontSize: "14px",
-                                fontWeight:
-                                    selectedKey === "/" ? "bold" : "normal",
-                            }}
-                        />
-                    </ListItemButton>
-                </Tooltip>
-            ) : null}
+            {renderTop}
             {renderTreeView(menuItems, selectedKey)}
-            {isExistAuthentication && (
-                <Tooltip
-                    title={t("buttons.logout", "Logout")}
-                    placement="right"
-                    disableHoverListener={!collapsed}
-                    arrow
-                >
-                    <ListItemButton
-                        key="logout"
-                        onClick={() => logout()}
-                        sx={{ justifyContent: "center" }}
-                    >
-                        <ListItemIcon
-                            sx={{
-                                justifyContent: "center",
-                                minWidth: 36,
-                                color: "primary.contrastText",
-                            }}
-                        >
-                            <Logout />
-                        </ListItemIcon>
-                        <ListItemText
-                            primary={t("buttons.logout", "Logout")}
-                            primaryTypographyProps={{
-                                noWrap: true,
-                                fontSize: "14px",
-                            }}
-                        />
-                    </ListItemButton>
-                </Tooltip>
-            )}
+            {renderBottom}
         </List>
     );
 

--- a/packages/mui/src/components/layout/sider/index.tsx
+++ b/packages/mui/src/components/layout/sider/index.tsx
@@ -36,11 +36,7 @@ import {
 
 import { Title as DefaultTitle } from "../title";
 
-export const Sider: React.FC<RefineLayoutSiderProps> = ({
-    logout,
-    dashboard,
-    items,
-}) => {
+export const Sider: React.FC<RefineLayoutSiderProps> = ({ render }) => {
     const [collapsed, setCollapsed] = useState(false);
     const [opened, setOpened] = useState(false);
 
@@ -227,7 +223,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
         });
     };
 
-    const defaultDashboard = hasDashboard ? (
+    const dashboard = hasDashboard ? (
         <CanAccess resource="dashboard" action="list">
             <Tooltip
                 title={translate("dashboard.title", "Dashboard")}
@@ -276,7 +272,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
         </CanAccess>
     ) : null;
 
-    const defaultLogout = isExistAuthentication && (
+    const logout = isExistAuthentication && (
         <Tooltip
             title={t("buttons.logout", "Logout")}
             placement="right"
@@ -308,16 +304,28 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({
         </Tooltip>
     );
 
-    const logoutButton = typeof logout !== "undefined" ? logout : defaultLogout;
-    const dashboardMenuItem =
-        typeof dashboard !== "undefined" ? dashboard : defaultDashboard;
-    const menuItemsToRender = items ?? renderTreeView(menuItems, selectedKey);
+    const items = renderTreeView(menuItems, selectedKey);
+
+    const renderSider = () => {
+        if (render) {
+            return render({
+                dashboard,
+                logout,
+                items,
+            });
+        }
+        return (
+            <>
+                {dashboard}
+                {items}
+                {logout}
+            </>
+        );
+    };
 
     const drawer = (
         <List disablePadding sx={{ mt: 1, color: "primary.contrastText" }}>
-            {dashboardMenuItem}
-            {menuItemsToRender}
-            {logoutButton}
+            {renderSider()}
         </List>
     );
 

--- a/packages/ui-tests/src/tests/layout/sider.tsx
+++ b/packages/ui-tests/src/tests/layout/sider.tsx
@@ -116,44 +116,20 @@ export const layoutSiderTests = function (
             await waitFor(() => expect(queryByText("Users")).toBeNull());
         });
 
-        it("should hides logout button when pass null as prop", async () => {
-            const { getAllByText, queryByText } = render(
-                <SiderElement logout={null} />,
-                {
-                    wrapper: TestWrapper({
-                        authProvider: mockAuthProvider,
-                    }),
-                },
-            );
-
-            await waitFor(() =>
-                expect(getAllByText("Posts").length).toBeGreaterThanOrEqual(1),
-            );
-            expect(queryByText("Logout")).not.toBeInTheDocument();
-        });
-
-        it("should render custom element instead of logout", async () => {
+        it("should render ", async () => {
             const { getAllByText, queryByText, queryAllByText } = render(
-                <SiderElement logout={<div>custom-element</div>} />,
-                {
-                    wrapper: TestWrapper({
-                        authProvider: mockAuthProvider,
-                    }),
-                },
-            );
-
-            await waitFor(() =>
-                expect(getAllByText("Posts").length).toBeGreaterThanOrEqual(1),
-            );
-            expect(queryByText("Logout")).not.toBeInTheDocument();
-            expect(
-                queryAllByText("custom-element").length,
-            ).toBeGreaterThanOrEqual(1);
-        });
-
-        it("should render custom element instead of dashboard", async () => {
-            const { getAllByText, queryByText, queryAllByText } = render(
-                <SiderElement dashboard={<div>custom-element</div>} />,
+                <SiderElement
+                    render={({ logout, dashboard, items }) => {
+                        return (
+                            <>
+                                <div>custom-element</div>
+                                {dashboard}
+                                {items}
+                                {logout}
+                            </>
+                        );
+                    }}
+                />,
                 {
                     wrapper: TestWrapper({
                         authProvider: mockAuthProvider,
@@ -167,32 +143,10 @@ export const layoutSiderTests = function (
             await waitFor(() =>
                 expect(getAllByText("Posts").length).toBeGreaterThanOrEqual(1),
             );
-            expect(queryByText("Dashboard")).not.toBeInTheDocument();
+            expect(queryByText("Logout")).toBeInTheDocument();
+            expect(queryByText("Dashboard")).toBeInTheDocument();
             expect(
                 queryAllByText("custom-element").length,
-            ).toBeGreaterThanOrEqual(1);
-        });
-
-        it("should render custom items instead of menu", async () => {
-            const { queryAllByText } = render(
-                <SiderElement
-                    items={[
-                        <div key={1}>custom-element</div>,
-                        <div key={2}>custom-element2</div>,
-                    ]}
-                />,
-                {
-                    wrapper: TestWrapper({
-                        authProvider: mockAuthProvider,
-                    }),
-                },
-            );
-
-            expect(
-                queryAllByText("custom-element").length,
-            ).toBeGreaterThanOrEqual(1);
-            expect(
-                queryAllByText("custom-element2").length,
             ).toBeGreaterThanOrEqual(1);
         });
     });

--- a/packages/ui-tests/src/tests/layout/sider.tsx
+++ b/packages/ui-tests/src/tests/layout/sider.tsx
@@ -116,9 +116,9 @@ export const layoutSiderTests = function (
             await waitFor(() => expect(queryByText("Users")).toBeNull());
         });
 
-        it("should hides logout button when pass null to bottom", async () => {
+        it("should hides logout button when pass null as prop", async () => {
             const { getAllByText, queryByText } = render(
-                <SiderElement bottom={null} />,
+                <SiderElement logout={null} />,
                 {
                     wrapper: TestWrapper({
                         authProvider: mockAuthProvider,
@@ -132,9 +132,9 @@ export const layoutSiderTests = function (
             expect(queryByText("Logout")).not.toBeInTheDocument();
         });
 
-        it("should render custom element for bottom", async () => {
+        it("should render custom element instead of logout", async () => {
             const { getAllByText, queryByText, queryAllByText } = render(
-                <SiderElement bottom={<div>custom-element</div>} />,
+                <SiderElement logout={<div>custom-element</div>} />,
                 {
                     wrapper: TestWrapper({
                         authProvider: mockAuthProvider,
@@ -151,35 +151,9 @@ export const layoutSiderTests = function (
             ).toBeGreaterThanOrEqual(1);
         });
 
-        it("should render custom element with logout for bottom", async () => {
-            const { getAllByText, queryAllByText } = render(
-                <SiderElement
-                    bottom={(defaultBottom) => (
-                        <>
-                            <div>custom-element</div>
-                            {defaultBottom}
-                        </>
-                    )}
-                />,
-                {
-                    wrapper: TestWrapper({
-                        authProvider: mockAuthProvider,
-                    }),
-                },
-            );
-
-            await waitFor(() =>
-                expect(getAllByText("Posts").length).toBeGreaterThanOrEqual(1),
-            );
-            expect(queryAllByText("Logout").length).toBeGreaterThanOrEqual(1);
-            expect(
-                queryAllByText("custom-element").length,
-            ).toBeGreaterThanOrEqual(1);
-        });
-
-        it("should render custom element for top", async () => {
+        it("should render custom element instead of dashboard", async () => {
             const { getAllByText, queryByText, queryAllByText } = render(
-                <SiderElement top={<div>custom-element</div>} />,
+                <SiderElement dashboard={<div>custom-element</div>} />,
                 {
                     wrapper: TestWrapper({
                         authProvider: mockAuthProvider,
@@ -199,34 +173,26 @@ export const layoutSiderTests = function (
             ).toBeGreaterThanOrEqual(1);
         });
 
-        it("should render custom element with dashboard for top", async () => {
-            const { getAllByText, queryAllByText } = render(
+        it("should render custom items instead of menu", async () => {
+            const { queryAllByText } = render(
                 <SiderElement
-                    bottom={(defaultTop) => (
-                        <>
-                            <div>custom-element</div>
-                            {defaultTop}
-                        </>
-                    )}
+                    items={[
+                        <div key={1}>custom-element</div>,
+                        <div key={2}>custom-element2</div>,
+                    ]}
                 />,
                 {
                     wrapper: TestWrapper({
                         authProvider: mockAuthProvider,
-                        DashboardPage: function Dashboard() {
-                            return <div>Dashboard</div>;
-                        },
                     }),
                 },
             );
 
-            await waitFor(() =>
-                expect(getAllByText("Posts").length).toBeGreaterThanOrEqual(1),
-            );
-            expect(queryAllByText("Dashboard").length).toBeGreaterThanOrEqual(
-                1,
-            );
             expect(
                 queryAllByText("custom-element").length,
+            ).toBeGreaterThanOrEqual(1);
+            expect(
+                queryAllByText("custom-element2").length,
             ).toBeGreaterThanOrEqual(1);
         });
     });

--- a/packages/ui-tests/src/tests/layout/sider.tsx
+++ b/packages/ui-tests/src/tests/layout/sider.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { RefineLayoutSiderProps } from "@pankod/refine-ui-types";
 
-import { act, fireEvent, render, TestWrapper, waitFor } from "@test";
+import { act, render, TestWrapper, waitFor } from "@test";
 
 const mockAuthProvider = {
     login: () => Promise.resolve(),
@@ -114,6 +114,120 @@ export const layoutSiderTests = function (
 
             await waitFor(() => getAllByText("Posts")[0]);
             await waitFor(() => expect(queryByText("Users")).toBeNull());
+        });
+
+        it("should hides logout button when pass null to bottomSection", async () => {
+            const { getAllByText, queryByText } = render(
+                <SiderElement bottomSection={null} />,
+                {
+                    wrapper: TestWrapper({
+                        authProvider: mockAuthProvider,
+                    }),
+                },
+            );
+
+            await waitFor(() =>
+                expect(getAllByText("Posts").length).toBeGreaterThanOrEqual(1),
+            );
+            expect(queryByText("Logout")).not.toBeInTheDocument();
+        });
+
+        it("should render custom element for bottomSection", async () => {
+            const { getAllByText, queryByText, queryAllByText } = render(
+                <SiderElement bottomSection={<div>custom-element</div>} />,
+                {
+                    wrapper: TestWrapper({
+                        authProvider: mockAuthProvider,
+                    }),
+                },
+            );
+
+            await waitFor(() =>
+                expect(getAllByText("Posts").length).toBeGreaterThanOrEqual(1),
+            );
+            expect(queryByText("Logout")).not.toBeInTheDocument();
+            expect(
+                queryAllByText("custom-element").length,
+            ).toBeGreaterThanOrEqual(1);
+        });
+
+        it("should render custom element with logout for bottomSection", async () => {
+            const { getAllByText, queryByText, queryAllByText } = render(
+                <SiderElement
+                    bottomSection={(defaultBottom) => (
+                        <>
+                            <div>custom-element</div>
+                            {defaultBottom}
+                        </>
+                    )}
+                />,
+                {
+                    wrapper: TestWrapper({
+                        authProvider: mockAuthProvider,
+                    }),
+                },
+            );
+
+            await waitFor(() =>
+                expect(getAllByText("Posts").length).toBeGreaterThanOrEqual(1),
+            );
+            expect(queryAllByText("Logout").length).toBeGreaterThanOrEqual(1);
+            expect(
+                queryAllByText("custom-element").length,
+            ).toBeGreaterThanOrEqual(1);
+        });
+
+        it("should render custom element for topSection", async () => {
+            const { getAllByText, queryByText, queryAllByText } = render(
+                <SiderElement topSection={<div>custom-element</div>} />,
+                {
+                    wrapper: TestWrapper({
+                        authProvider: mockAuthProvider,
+                        DashboardPage: function Dashboard() {
+                            return <div>Dashboard</div>;
+                        },
+                    }),
+                },
+            );
+
+            await waitFor(() =>
+                expect(getAllByText("Posts").length).toBeGreaterThanOrEqual(1),
+            );
+            expect(queryByText("Dashboard")).not.toBeInTheDocument();
+            expect(
+                queryAllByText("custom-element").length,
+            ).toBeGreaterThanOrEqual(1);
+        });
+
+        it("should render custom element with dashboard for topSection", async () => {
+            const { getAllByText, queryByText, queryAllByText } = render(
+                <SiderElement
+                    bottomSection={(defaultTop) => (
+                        <>
+                            <div>custom-element</div>
+                            {defaultTop}
+                        </>
+                    )}
+                />,
+                {
+                    wrapper: TestWrapper({
+                        authProvider: mockAuthProvider,
+                        DashboardPage: function Dashboard() {
+                            return <div>Dashboard</div>;
+                        },
+                    }),
+                },
+            );
+
+            await waitFor(() =>
+                expect(getAllByText("Posts").length).toBeGreaterThanOrEqual(1),
+            );
+            expect(queryAllByText("Dashboard").length).toBeGreaterThanOrEqual(
+                1,
+            );
+            expect(
+                queryAllByText("custom-element").length,
+            ).toBeGreaterThanOrEqual(1);
         });
     });
 };

--- a/packages/ui-tests/src/tests/layout/sider.tsx
+++ b/packages/ui-tests/src/tests/layout/sider.tsx
@@ -116,9 +116,9 @@ export const layoutSiderTests = function (
             await waitFor(() => expect(queryByText("Users")).toBeNull());
         });
 
-        it("should hides logout button when pass null to bottomSection", async () => {
+        it("should hides logout button when pass null to bottom", async () => {
             const { getAllByText, queryByText } = render(
-                <SiderElement bottomSection={null} />,
+                <SiderElement bottom={null} />,
                 {
                     wrapper: TestWrapper({
                         authProvider: mockAuthProvider,
@@ -132,9 +132,9 @@ export const layoutSiderTests = function (
             expect(queryByText("Logout")).not.toBeInTheDocument();
         });
 
-        it("should render custom element for bottomSection", async () => {
+        it("should render custom element for bottom", async () => {
             const { getAllByText, queryByText, queryAllByText } = render(
-                <SiderElement bottomSection={<div>custom-element</div>} />,
+                <SiderElement bottom={<div>custom-element</div>} />,
                 {
                     wrapper: TestWrapper({
                         authProvider: mockAuthProvider,
@@ -151,10 +151,10 @@ export const layoutSiderTests = function (
             ).toBeGreaterThanOrEqual(1);
         });
 
-        it("should render custom element with logout for bottomSection", async () => {
-            const { getAllByText, queryByText, queryAllByText } = render(
+        it("should render custom element with logout for bottom", async () => {
+            const { getAllByText, queryAllByText } = render(
                 <SiderElement
-                    bottomSection={(defaultBottom) => (
+                    bottom={(defaultBottom) => (
                         <>
                             <div>custom-element</div>
                             {defaultBottom}
@@ -177,9 +177,9 @@ export const layoutSiderTests = function (
             ).toBeGreaterThanOrEqual(1);
         });
 
-        it("should render custom element for topSection", async () => {
+        it("should render custom element for top", async () => {
             const { getAllByText, queryByText, queryAllByText } = render(
-                <SiderElement topSection={<div>custom-element</div>} />,
+                <SiderElement top={<div>custom-element</div>} />,
                 {
                     wrapper: TestWrapper({
                         authProvider: mockAuthProvider,
@@ -199,10 +199,10 @@ export const layoutSiderTests = function (
             ).toBeGreaterThanOrEqual(1);
         });
 
-        it("should render custom element with dashboard for topSection", async () => {
-            const { getAllByText, queryByText, queryAllByText } = render(
+        it("should render custom element with dashboard for top", async () => {
+            const { getAllByText, queryAllByText } = render(
                 <SiderElement
-                    bottomSection={(defaultTop) => (
+                    bottom={(defaultTop) => (
                         <>
                             <div>custom-element</div>
                             {defaultTop}

--- a/packages/ui-tests/src/tests/layout/sider.tsx
+++ b/packages/ui-tests/src/tests/layout/sider.tsx
@@ -143,8 +143,10 @@ export const layoutSiderTests = function (
             await waitFor(() =>
                 expect(getAllByText("Posts").length).toBeGreaterThanOrEqual(1),
             );
-            expect(queryByText("Logout")).toBeInTheDocument();
-            expect(queryByText("Dashboard")).toBeInTheDocument();
+            expect(queryAllByText("Logout").length).toBeGreaterThanOrEqual(1);
+            expect(queryAllByText("Dashboard").length).toBeGreaterThanOrEqual(
+                1,
+            );
             expect(
                 queryAllByText("custom-element").length,
             ).toBeGreaterThanOrEqual(1);

--- a/packages/ui-tests/src/tests/layout/sider.tsx
+++ b/packages/ui-tests/src/tests/layout/sider.tsx
@@ -116,8 +116,8 @@ export const layoutSiderTests = function (
             await waitFor(() => expect(queryByText("Users")).toBeNull());
         });
 
-        it("should render ", async () => {
-            const { getAllByText, queryByText, queryAllByText } = render(
+        it("should render custom element passed with render prop", async () => {
+            const { getAllByText, queryAllByText } = render(
                 <SiderElement
                     render={({ logout, dashboard, items }) => {
                         return (

--- a/packages/ui-types/src/types/layout.tsx
+++ b/packages/ui-types/src/types/layout.tsx
@@ -3,12 +3,10 @@ import { TitleProps, LayoutProps } from "@pankod/refine-core";
 export type RefineLayoutHeaderProps = {};
 
 export type RefineLayoutSiderProps = {
-    bottomSection?:
+    bottom?:
         | React.ReactNode
         | ((defaultBottom: React.ReactNode) => React.ReactNode);
-    topSection?:
-        | React.ReactNode
-        | ((defaultTop: React.ReactNode) => React.ReactNode);
+    top?: React.ReactNode | ((defaultTop: React.ReactNode) => React.ReactNode);
 };
 
 export type RefineLayoutFooterProps = {};

--- a/packages/ui-types/src/types/layout.tsx
+++ b/packages/ui-types/src/types/layout.tsx
@@ -2,7 +2,14 @@ import { TitleProps, LayoutProps } from "@pankod/refine-core";
 
 export type RefineLayoutHeaderProps = {};
 
-export type RefineLayoutSiderProps = {};
+export type RefineLayoutSiderProps = {
+    bottomSection?:
+        | React.ReactNode
+        | ((defaultBottom: React.ReactNode) => React.ReactNode);
+    topSection?:
+        | React.ReactNode
+        | ((defaultTop: React.ReactNode) => React.ReactNode);
+};
 
 export type RefineLayoutFooterProps = {};
 

--- a/packages/ui-types/src/types/layout.tsx
+++ b/packages/ui-types/src/types/layout.tsx
@@ -1,12 +1,12 @@
-import { TitleProps, LayoutProps } from "@pankod/refine-core";
+import { TitleProps, LayoutProps, ITreeMenu } from "@pankod/refine-core";
+import {} from "@pankod/refine-core";
 
 export type RefineLayoutHeaderProps = {};
 
 export type RefineLayoutSiderProps = {
-    bottom?:
-        | React.ReactNode
-        | ((defaultBottom: React.ReactNode) => React.ReactNode);
-    top?: React.ReactNode | ((defaultTop: React.ReactNode) => React.ReactNode);
+    items?: JSX.Element[];
+    logout?: React.ReactNode;
+    dashboard?: React.ReactNode;
 };
 
 export type RefineLayoutFooterProps = {};

--- a/packages/ui-types/src/types/layout.tsx
+++ b/packages/ui-types/src/types/layout.tsx
@@ -1,13 +1,16 @@
-import { TitleProps, LayoutProps, ITreeMenu } from "@pankod/refine-core";
-import {} from "@pankod/refine-core";
+import { TitleProps, LayoutProps } from "@pankod/refine-core";
 
-export type RefineLayoutHeaderProps = {};
+export type SiderRenderProps = {
+    items: JSX.Element[];
+    logout: React.ReactNode;
+    dashboard: React.ReactNode;
+};
 
 export type RefineLayoutSiderProps = {
-    items?: JSX.Element[];
-    logout?: React.ReactNode;
-    dashboard?: React.ReactNode;
+    render?: (props: SiderRenderProps) => React.ReactNode;
 };
+
+export type RefineLayoutHeaderProps = {};
 
 export type RefineLayoutFooterProps = {};
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

`@pankod/refine-antd` `@pankod/refine-mui`

Added `render` prop to `Sider` component. You can get `dashboard`, `logout` and `items` from `render` props to customize the `Sider` component.

`@pankod/refine-ui-types`

Updated `Sider` types for `render` props.

`@pankod/refine-ui-tests`

Updated `Sider` test for `render` props.

### Test plan (required)

![Screen Shot 2022-09-08 at 17 45 38](https://user-images.githubusercontent.com/75166276/189153007-95980d02-da5e-4b56-920a-63682ef4b0e6.png)
![Screen Shot 2022-09-08 at 17 45 19](https://user-images.githubusercontent.com/75166276/189153015-727db734-5fe3-4dc0-82e1-237a93134ad9.png)

### Closing issues

closes #2453

### Self Check before Merge

-   [X] Corresponding issues are created/updated or not needed
-   [X] Docs are updated/provided or not needed
-   [X] Examples are updated/provided or not needed
-   [X] TypeScript definitions are updated/provided or not needed
-   [X] Tests are updated/provided or not needed
-   [X] Changesets are provided or not needed
