### PR TITLE
fix: check and reflect for `id` from props changes

### DIFF
--- a/.changeset/metal-needles-impress.md
+++ b/.changeset/metal-needles-impress.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Update `useForm` and `useShow` hooks to watch for `id` from `props` and update the query with the new `id` when it changes.

--- a/packages/core/src/hooks/form/useForm.spec.tsx
+++ b/packages/core/src/hooks/form/useForm.spec.tsx
@@ -143,6 +143,30 @@ describe("useForm Hook", () => {
 
     it("correctly return id value which was set with setId after it was set", async () => {
         const { result } = renderHook(
+            ({ id }) =>
+                useForm({
+                    resource: "posts",
+                    id,
+                }),
+            {
+                wrapper: EditWrapperWithRoute,
+                initialProps: {
+                    id: "1",
+                },
+            },
+        );
+
+        expect(result.current.id).toEqual("1");
+
+        await act(async () => {
+            result.current.setId?.("3");
+        });
+
+        expect(result.current.id).toEqual("3");
+    });
+
+    it("correctly return id value after its updated with a new value", async () => {
+        const { result, rerender } = renderHook(
             () =>
                 useForm({
                     resource: "posts",
@@ -155,10 +179,10 @@ describe("useForm Hook", () => {
         expect(result.current.id).toEqual("1");
 
         await act(async () => {
-            result.current.setId?.("3");
+            rerender({ id: "2" });
         });
 
-        expect(result.current.id).toEqual("3");
+        expect(result.current.id).toEqual("2");
     });
 
     it("correctly return id undefined when route and options is different", async () => {

--- a/packages/core/src/hooks/form/useForm.spec.tsx
+++ b/packages/core/src/hooks/form/useForm.spec.tsx
@@ -143,16 +143,12 @@ describe("useForm Hook", () => {
 
     it("correctly return id value which was set with setId after it was set", async () => {
         const { result } = renderHook(
-            ({ id }) =>
+            () =>
                 useForm({
                     resource: "posts",
-                    id,
                 }),
             {
                 wrapper: EditWrapperWithRoute,
-                initialProps: {
-                    id: "1",
-                },
             },
         );
 
@@ -167,22 +163,26 @@ describe("useForm Hook", () => {
 
     it("correctly return id value after its updated with a new value", async () => {
         const { result, rerender } = renderHook(
-            () =>
+            ({ id }) =>
                 useForm({
                     resource: "posts",
+                    id,
                 }),
             {
                 wrapper: EditWrapperWithRoute,
+                initialProps: {
+                    id: "1",
+                },
             },
         );
 
-        expect(result.current.id).toEqual("1");
+        await waitFor(() => expect(result.current.id).toEqual("1"));
 
         await act(async () => {
             rerender({ id: "2" });
         });
 
-        expect(result.current.id).toEqual("2");
+        await waitFor(() => expect(result.current.id).toEqual("2"));
     });
 
     it("correctly return id undefined when route and options is different", async () => {

--- a/packages/core/src/hooks/form/useForm.ts
+++ b/packages/core/src/hooks/form/useForm.ts
@@ -147,7 +147,7 @@ export const useForm = <
     const [id, setId] = React.useState<BaseKey | undefined>(defaultId);
 
     React.useEffect(() => {
-        if (idFromProps !== id) {
+        if (defaultId !== id) {
             setId(idFromProps);
         }
     }, [idFromProps]);

--- a/packages/core/src/hooks/form/useForm.ts
+++ b/packages/core/src/hooks/form/useForm.ts
@@ -146,6 +146,12 @@ export const useForm = <
     // id state is needed to determine selected record in a context for example useModal
     const [id, setId] = React.useState<BaseKey | undefined>(defaultId);
 
+    React.useEffect(() => {
+        if (idFromProps !== id) {
+            setId(idFromProps);
+        }
+    }, [idFromProps]);
+
     const resourceName = resourceFromProps ?? resourceFromRoute;
     const action =
         actionFromProps ??

--- a/packages/core/src/hooks/show/useShow.spec.tsx
+++ b/packages/core/src/hooks/show/useShow.spec.tsx
@@ -142,4 +142,19 @@ describe("useShow Hook", () => {
 
         expect(result.current.showId).toEqual("3");
     });
+
+    it("correctly return id value after its updated with a new value", async () => {
+        const { result, rerender } = renderHook(({ id }) => useShow({ id }), {
+            wrapper: WrapperWithRoute,
+            initialProps: { id: "1" },
+        });
+
+        expect(result.current.showId).toEqual("1");
+
+        await act(async () => {
+            rerender({ id: "2" });
+        });
+
+        expect(result.current.showId).toEqual("2");
+    });
 });

--- a/packages/core/src/hooks/show/useShow.spec.tsx
+++ b/packages/core/src/hooks/show/useShow.spec.tsx
@@ -149,12 +149,12 @@ describe("useShow Hook", () => {
             initialProps: { id: "1" },
         });
 
-        expect(result.current.showId).toEqual("1");
+        await waitFor(() => expect(result.current.showId).toEqual("1"));
 
         await act(async () => {
             rerender({ id: "2" });
         });
 
-        expect(result.current.showId).toEqual("2");
+        await waitFor(() => expect(result.current.showId).toEqual("2"));
     });
 });

--- a/packages/core/src/hooks/show/useShow.ts
+++ b/packages/core/src/hooks/show/useShow.ts
@@ -57,7 +57,7 @@ export const useShow = <TData extends BaseRecord = BaseRecord>({
     const [showId, setShowId] = useState<BaseKey | undefined>(defaultId);
 
     React.useEffect(() => {
-        if (id !== showId) {
+        if (defaultId !== showId) {
             setShowId(defaultId);
         }
     }, [defaultId]);

--- a/packages/core/src/hooks/show/useShow.ts
+++ b/packages/core/src/hooks/show/useShow.ts
@@ -56,6 +56,12 @@ export const useShow = <TData extends BaseRecord = BaseRecord>({
 
     const [showId, setShowId] = useState<BaseKey | undefined>(defaultId);
 
+    React.useEffect(() => {
+        if (id !== showId) {
+            setShowId(defaultId);
+        }
+    }, [defaultId]);
+
     const resourceWithRoute = useResourceWithRoute();
 
     const resource = resourceWithRoute(resourceFromProp ?? routeResourceName);


### PR DESCRIPTION
`id` prop was set to a state at the initial render therefore it was not reflecting the future changes. In cases like dynamic or asynchronous `id` operations, `useShow` and `useForm` was failing to update the query by the new `id` property.

### Test plan (required)

<img width="762" alt="Screen Shot 2022-09-09 at 01 06 23" src="https://user-images.githubusercontent.com/11361964/189234724-89b59810-7b64-4c68-a0af-eb68e5d74b22.png">

### Closing issues

Resolves #2463 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
