### PR TITLE
fix: react-query DevtoolsOptions import

### DIFF
--- a/.changeset/dull-cobras-relax.md
+++ b/.changeset/dull-cobras-relax.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fix import of react-query `DevtoolsOptions` interface

--- a/packages/core/src/definitions/helpers/handleRefineOptions/index.ts
+++ b/packages/core/src/definitions/helpers/handleRefineOptions/index.ts
@@ -1,6 +1,6 @@
 import { QueryClientConfig } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { DevtoolsOptions } from "@tanstack/react-query-devtools/build/types/react-query-devtools/src/devtools";
+import { DevtoolsOptions } from "@tanstack/react-query-devtools/build/lib/devtools";
 
 import { defaultRefineOptions } from "@contexts/refine";
 import {


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Fix import of react-query `DevtoolsOptions` interface
