### PR TITLE
fix: collapsed prop passed to render method of Sider components

### DIFF
--- a/.changeset/nasty-points-breathe.md
+++ b/.changeset/nasty-points-breathe.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": patch
+---
+
+Passed `collapsed` prop to `render` method in `Sider` component of `@pankod/refine-antd`.

--- a/.changeset/nervous-meals-clap.md
+++ b/.changeset/nervous-meals-clap.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-ui-types": patch
+---
+
+Updated `render` method type with `collapsed` prop in `RefineLayoutSiderProps`.

--- a/.changeset/nice-meals-grab.md
+++ b/.changeset/nice-meals-grab.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": patch
+---
+
+Passed `collapsed` prop to `render` method in `Sider` component of `@pankod/refine-mui`.

--- a/packages/antd/src/components/layout/sider/index.tsx
+++ b/packages/antd/src/components/layout/sider/index.tsx
@@ -126,6 +126,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({ render }) => {
                 dashboard,
                 items,
                 logout,
+                collapsed,
             });
         }
         return (

--- a/packages/mui/src/components/layout/sider/index.tsx
+++ b/packages/mui/src/components/layout/sider/index.tsx
@@ -312,6 +312,7 @@ export const Sider: React.FC<RefineLayoutSiderProps> = ({ render }) => {
                 dashboard,
                 logout,
                 items,
+                collapsed,
             });
         }
         return (

--- a/packages/ui-types/src/types/layout.tsx
+++ b/packages/ui-types/src/types/layout.tsx
@@ -4,6 +4,7 @@ export type SiderRenderProps = {
     items: JSX.Element[];
     logout: React.ReactNode;
     dashboard: React.ReactNode;
+    collapsed: boolean;
 };
 
 export type RefineLayoutSiderProps = {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**@pankod/refine-ui-types**
Updated `render` method type with `collapsed` prop in `RefineLayoutSiderProps`.

**@pankod/refine-mui**
Passed `collapsed` prop to `render` method in `Sider` component.

**@pankod/refine-antd**
Passed `collapsed` prop to `render` method in `Sider` component

### Test plan (required)

![Screen Shot 2022-09-13 at 14 16 11](https://user-images.githubusercontent.com/75166276/189888248-e070a008-779b-4939-9abb-49f191c54726.png)
![Screen Shot 2022-09-13 at 14 16 40](https://user-images.githubusercontent.com/75166276/189888262-f21991fd-c905-4c85-bbd3-eda34f0df736.png)

### Closing issues

There is no corresponding issue.

Please check all items below before review.

-   [X] Corresponding issues are created/updated or not needed
-   [ ] Docs are updated/provided or not needed
-   [X] Examples are updated/provided or not needed
-   [X] TypeScript definitions are updated/provided or not needed
-   [X] Tests are updated/provided or not needed
-   [X] Changesets are provided or not needed
