### PR TITLE
Allows populate auth.getUserIdentity() by changing AuthHelper 

### DIFF
--- a/.changeset/brave-melons-push.md
+++ b/.changeset/brave-melons-push.md
@@ -1,0 +1,15 @@
+---
+"@pankod/refine-strapi-v4": minor
+---
+
+Added `metaData` support for the `/me` request
+
+```tsx
+const strapiAuthHelper = AuthHelper(API_URL + "/api");
+
+strapiAuthHelper.me("token", {
+    metaData: {
+        populate: ["role"],
+    },
+});
+```

--- a/documentation/docs/guides-and-concepts/data-provider/strapi-v4.md
+++ b/documentation/docs/guides-and-concepts/data-provider/strapi-v4.md
@@ -396,6 +396,20 @@ export const PostList: React.FC<IResourceComponentsProps> = () => {
     <img src={category} alt="category" />
 </div>
 
+##### Relations Population for `/me` request
+
+If you need to the population for the `/me` request you can use it like this in your `authProvider`.
+
+```tsx
+const strapiAuthHelper = AuthHelper(API_URL + "/api");
+
+strapiAuthHelper.me("token", {
+    metaData: {
+        populate: ["role"],
+    },
+});
+```
+
 ### Publication State
 
 :::note

--- a/documentation/docs/guides-and-concepts/multi-tenancy/strapi.md
+++ b/documentation/docs/guides-and-concepts/multi-tenancy/strapi.md
@@ -105,6 +105,10 @@ export const authProvider: AuthProvider = {
 ```
 
 </p>
+:::tip
+If you need to populate relations or media fields, you can extend strapiAuthHelper like this: `strapiAuthHelper.me(token, {populate:["role"]})`
+:::
+    
 </details>
 
 ```tsx title="App.tsx"

--- a/documentation/docs/guides-and-concepts/multi-tenancy/strapi.md
+++ b/documentation/docs/guides-and-concepts/multi-tenancy/strapi.md
@@ -105,8 +105,19 @@ export const authProvider: AuthProvider = {
 ```
 
 </p>
+
 :::tip
-If you need to populate relations or media fields, you can extend strapiAuthHelper like this: `strapiAuthHelper.me(token, {populate:["role"]})`
+If you need the population for the `/me` request, you can use it like this in your `authProvider`.
+
+```tsx
+const strapiAuthHelper = AuthHelper(API_URL + "/api");
+
+strapiAuthHelper.me("token", {
+    metaData: {
+        populate: ["role"],
+    },
+});
+```
 :::
     
 </details>

--- a/examples/dataProvider/strapi-v4/src/App.tsx
+++ b/examples/dataProvider/strapi-v4/src/App.tsx
@@ -63,7 +63,12 @@ const App: React.FC = () => {
                 return Promise.reject();
             }
 
-            const { data, status } = await strapiAuthHelper.me(token);
+            const { data, status } = await strapiAuthHelper.me(token, {
+                metaData: {
+                    populate: ["role"],
+                },
+            });
+
             if (status === 200) {
                 const { id, username, email } = data;
                 return Promise.resolve({

--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -55,7 +55,7 @@
         "@mantine/prism": "^5.2.3",
         "@mantine/rte": "^5.2.3",
         "@mantine/spotlight": "^5.2.3",
-        "@pankod/refine-ui-types": "^0.3.0",
+        "@pankod/refine-ui-types": "^0.6.2",
         "@tanstack/react-query": "^4.0.10",
         "dayjs": "^1.10.7",
         "embla-carousel-react": "^7.0.1",

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -41,7 +41,7 @@
         "typescript": "^4.7.4"
     },
     "dependencies": {
-        "@pankod/refine-ui-types": "^0.6.1",
+        "@pankod/refine-ui-types": "^0.6.2",
         "@emotion/react": "^11.8.2",
         "@emotion/styled": "^11.8.1",
         "@mui/icons-material": "^5.8.3",

--- a/packages/strapi-v4/src/dataProvider.ts
+++ b/packages/strapi-v4/src/dataProvider.ts
@@ -5,7 +5,6 @@ import {
     CrudFilters,
     CrudSorting,
     CrudOperators,
-    BaseKey,
 } from "@pankod/refine-core";
 import { stringify, parse } from "qs";
 

--- a/packages/strapi-v4/src/helpers/auth.ts
+++ b/packages/strapi-v4/src/helpers/auth.ts
@@ -33,11 +33,14 @@ export const AuthHelper = (apiUrl: string) => ({
             password,
         });
     },
-    me: async (token: string) => {
-        return await axios.get<IUser>(`${apiUrl}/users/me`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
-        });
-    },
+    me: async (token: string, populate?: any) => {
+    const query = stringify(populate, {
+      encodeValuesOnly: true,
+    });
+    return await axios.get<IUser>(`${apiUrl}/users/me?${query}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  },
 });

--- a/packages/strapi-v4/src/helpers/auth.ts
+++ b/packages/strapi-v4/src/helpers/auth.ts
@@ -1,4 +1,6 @@
+import { MetaDataQuery } from "@pankod/refine-core";
 import axios from "axios";
+import { stringify } from "qs";
 
 interface ILoginResponse {
     jwt: string;
@@ -24,6 +26,10 @@ interface IUser {
     updated_at: string;
 }
 
+export type MeOptions = {
+    metaData?: MetaDataQuery;
+};
+
 export const AuthHelper = (apiUrl: string) => ({
     login: async (identifier: string, password: string) => {
         const url = `${apiUrl}/auth/local`;
@@ -33,14 +39,27 @@ export const AuthHelper = (apiUrl: string) => ({
             password,
         });
     },
-    me: async (token: string, populate?: any) => {
-    const query = stringify(populate, {
-      encodeValuesOnly: true,
-    });
-    return await axios.get<IUser>(`${apiUrl}/users/me?${query}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-  },
+    me: async (token: string, options?: MeOptions) => {
+        const { metaData } = options ?? {};
+        const locale = metaData?.locale;
+        const fields = metaData?.fields;
+        const populate = metaData?.populate;
+
+        const query = {
+            locale,
+            fields,
+            populate,
+        };
+
+        return await axios.get<IUser>(
+            `${apiUrl}/users/me?${stringify(query, {
+                encodeValuesOnly: true,
+            })}`,
+            {
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            },
+        );
+    },
 });

--- a/packages/strapi-v4/test/auth/index.mock.ts
+++ b/packages/strapi-v4/test/auth/index.mock.ts
@@ -61,7 +61,7 @@ nock("http://localhost:1337", { encodedQueryParams: true })
     );
 
 nock("http://localhost:1337", { encodedQueryParams: true })
-    .get("/api/users/me")
+    .get("/api/users/me?")
     .reply(
         200,
         {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

If you have relations on your user-permissions or media files, you need to populate. Here is an example of query url:
https://localhost:1337/api/users/me?populate=*

I propose some changes to the AuthHelper function to allow this behaviour. 
### Self Check before Merge

Please check all items below before review.

-   [X] Corresponding issues are created/updated or not needed
-   [X] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
