### PR TITLE
fix: fix react-router version to 6

### DIFF
--- a/.changeset/heavy-flowers-lay.md
+++ b/.changeset/heavy-flowers-lay.md
@@ -1,0 +1,14 @@
+---
+"@pankod/refine-antd": patch
+"@pankod/refine-cloud": patch
+"@pankod/refine-core": patch
+"@pankod/refine-kbar": patch
+"@pankod/refine-mantine": patch
+"@pankod/refine-mui": patch
+"@pankod/refine-react-hook-form": patch
+"@pankod/refine-react-router-v6": patch
+"@pankod/refine-react-table": patch
+"@pankod/refine-ui-tests": patch
+---
+
+Fixed version of react-router to 6

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -39,7 +39,7 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.5.1",
         "postcss": "^8.1.4",
-        "react-router-dom": "^6.0.0",
+        "react-router-dom": "6.0.0",
         "ts-jest": "^27.1.3",
         "tsup": "^5.11.13",
         "typescript": "^4.7.4"

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -36,7 +36,7 @@
         "@types/lodash": "^4.14.171",
         "@tanstack/react-query": "^4.0.10",
         "jest": "^27.5.1",
-        "react-router-dom": "^6.0.0",
+        "react-router-dom": "6.0.0",
         "ts-jest": "^27.1.3",
         "tslib": "^2.3.1",
         "tsup": "^5.11.13"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
         "@types/testing-library__jest-dom": "^5.14.3",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.5.1",
-        "react-router-dom": "^6.0.0",
+        "react-router-dom": "6.0.0",
         "ts-jest": "^27.1.3",
         "tsup": "^5.11.13",
         "typescript": "^4.7.4"

--- a/packages/kbar/package.json
+++ b/packages/kbar/package.json
@@ -33,7 +33,7 @@
         "@testing-library/react": "^13.1.1",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
-        "react-router-dom": "^6.0.0",
+        "react-router-dom": "6.0.0",
         "jest": "^27.5.1",
         "ts-jest": "^27.1.3",
         "tslib": "^2.3.1",

--- a/packages/mantine/package.json
+++ b/packages/mantine/package.json
@@ -36,7 +36,7 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.5.1",
         "postcss": "^8.1.4",
-        "react-router-dom": "^6.0.0",
+        "react-router-dom": "6.0.0",
         "ts-jest": "^27.1.3",
         "tsup": "^5.11.13",
         "typescript": "^4.7.4"

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -35,7 +35,7 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.5.1",
         "postcss": "^8.1.4",
-        "react-router-dom": "^6.0.0",
+        "react-router-dom": "6.0.0",
         "ts-jest": "^27.1.3",
         "tsup": "^5.11.13",
         "typescript": "^4.7.4"

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -33,7 +33,7 @@
     "@pankod/refine-core": "^3.67.0",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
-    "react-router-dom": "^6.0.0",
+    "react-router-dom": "6.0.0",
     "ts-jest": "^27.1.3",
     "tslib": "^2.3.1",
     "tsup": "^5.11.13"

--- a/packages/react-router-v6/package.json
+++ b/packages/react-router-v6/package.json
@@ -30,11 +30,11 @@
     "tsup": "^5.11.13"
   },
   "dependencies": {
-    "react-router-dom": "^6.0.0"
+    "react-router-dom": "6.0.0"
   },
   "peerDependencies": {
     "@pankod/refine-core": "^3.23.2",
-    "react-router-dom": "^6.0.0",
+    "react-router-dom": "6.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "@types/react": "^17.0.0 || ^18.0.0",

--- a/packages/react-table/package.json
+++ b/packages/react-table/package.json
@@ -32,7 +32,7 @@
     "@pankod/refine-core": "^3.67.0",
     "@esbuild-plugins/node-resolve": "^0.1.4",
     "jest": "^27.5.1",
-    "react-router-dom": "^6.0.0",
+    "react-router-dom": "6.0.0",
     "ts-jest": "^27.1.3",
     "tslib": "^2.3.1",
     "tsup": "^5.11.13"

--- a/packages/ui-tests/package.json
+++ b/packages/ui-tests/package.json
@@ -28,7 +28,7 @@
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "@types/testing-library__jest-dom": "^5.14.3",
-        "react-router-dom": "^6.0.0",
+        "react-router-dom": "6.0.0",
         "jest": "^27.5.1",
         "ts-jest": "^27.1.3",
         "tsup": "^5.11.13",


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

With react-router 6.4 we are not ready for changes yet, we are fixing the version to 6 to avoid errors until it is ready