### PR TITLE
feat: add formProps support for AuthPage component

### DIFF
--- a/.changeset/big-guests-move.md
+++ b/.changeset/big-guests-move.md
@@ -1,6 +1,5 @@
 ---
 "@pankod/refine-antd": minor
-"@pankod/refine-ui-types": minor
 ---
 
 Added `formProps` property support for AuthPage component

--- a/.changeset/big-guests-move.md
+++ b/.changeset/big-guests-move.md
@@ -1,0 +1,20 @@
+---
+"@pankod/refine-antd": minor
+"@pankod/refine-ui-types": minor
+---
+
+Added `formProps` property support for AuthPage component
+
+## Usage
+
+```tsx
+<AuthPage
+    type="login"
+    formProps={{
+        initialValues: {
+            email: "demo@refine.dev",
+            password: "demo",
+        },
+    }}
+/>
+```

--- a/.changeset/big-guests-run.md
+++ b/.changeset/big-guests-run.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-ui-types": minor
+---
+
+Added `formProps` property to `RefineAuthPageProps`, `RefineResetPasswordPageProps`, `RefineRegisterPageProps`, and `RefineUpdatePasswordPageProps`

--- a/examples/fineFoods/admin/antd/src/App.tsx
+++ b/examples/fineFoods/admin/antd/src/App.tsx
@@ -66,7 +66,17 @@ const App: React.FC = () => {
                         routes: [
                             {
                                 path: "/register",
-                                element: <AuthPage type="register" />,
+                                element: (
+                                    <AuthPage
+                                        type="register"
+                                        formProps={{
+                                            initialValues: {
+                                                email: "demo@refine.dev",
+                                                password: "demodemo",
+                                            },
+                                        }}
+                                    />
+                                ),
                             },
                             {
                                 path: "/reset-password",
@@ -83,7 +93,17 @@ const App: React.FC = () => {
                     i18nProvider={i18nProvider}
                     OffLayoutArea={OffLayoutArea}
                     DashboardPage={DashboardPage}
-                    LoginPage={() => <AuthPage type="login" />}
+                    LoginPage={() => (
+                        <AuthPage
+                            type="login"
+                            formProps={{
+                                initialValues: {
+                                    email: "demo@refine.dev",
+                                    password: "demodemo",
+                                },
+                            }}
+                        />
+                    )}
                     Title={Title}
                     Header={Header}
                     Layout={Layout}

--- a/examples/fineFoods/admin/antd/src/pages/auth/index.tsx
+++ b/examples/fineFoods/admin/antd/src/pages/auth/index.tsx
@@ -1,4 +1,4 @@
-import { AuthPage as AntdAuthPage } from "@pankod/refine-antd";
+import { AuthPage as AntdAuthPage, FormProps } from "@pankod/refine-antd";
 import { useRouterContext } from "@pankod/refine-core";
 
 const authWrapperProps = {
@@ -34,12 +34,14 @@ const renderAuthContent = (content: React.ReactNode) => {
 
 export const AuthPage: React.FC<{
     type?: "login" | "register" | "resetPassword" | "updatePassword";
-}> = ({ type }) => {
+    formProps?: FormProps;
+}> = ({ type, formProps }) => {
     return (
         <AntdAuthPage
             type={type}
             wrapperProps={authWrapperProps}
             renderContent={renderAuthContent}
+            formProps={formProps}
         />
     );
 };

--- a/packages/antd/src/components/pages/auth/components/login/index.tsx
+++ b/packages/antd/src/components/pages/auth/components/login/index.tsx
@@ -16,6 +16,7 @@ import {
     CardProps,
     LayoutProps,
     Divider,
+    FormProps,
 } from "antd";
 import { useLogin, useTranslate, useRouterContext } from "@pankod/refine-core";
 
@@ -23,7 +24,7 @@ import { layoutStyles, containerStyles, titleStyles } from "../styles";
 
 const { Text, Title } = Typography;
 
-type LoginProps = RefineLoginPageProps<LayoutProps, CardProps>;
+type LoginProps = RefineLoginPageProps<LayoutProps, CardProps, FormProps>;
 
 /**
  * **refine** has a default login page form which is served on `/login` route when the `authProvider` configuration is provided.
@@ -39,6 +40,7 @@ export const LoginPage: React.FC<LoginProps> = ({
     wrapperProps,
     onSubmit,
     renderContent,
+    formProps,
 }) => {
     const [form] = Form.useForm<RefineLoginFormTypes>();
     const translate = useTranslate();
@@ -103,6 +105,7 @@ export const LoginPage: React.FC<LoginProps> = ({
                 initialValues={{
                     remember: false,
                 }}
+                {...formProps}
             >
                 <Form.Item
                     name="email"

--- a/packages/antd/src/components/pages/auth/components/register/index.tsx
+++ b/packages/antd/src/components/pages/auth/components/register/index.tsx
@@ -14,6 +14,7 @@ import {
     Button,
     LayoutProps,
     CardProps,
+    FormProps,
 } from "antd";
 import {
     useTranslate,
@@ -25,7 +26,7 @@ import { layoutStyles, containerStyles, titleStyles } from "../styles";
 
 const { Text, Title } = Typography;
 
-type RegisterProps = RefineRegisterPageProps<LayoutProps, CardProps>;
+type RegisterProps = RefineRegisterPageProps<LayoutProps, CardProps, FormProps>;
 
 /**
  * **refine** has register page form which is served on `/register` route when the `authProvider` configuration is provided.
@@ -38,6 +39,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
     contentProps,
     renderContent,
     onSubmit,
+    formProps,
 }) => {
     const [form] = Form.useForm<RefineRegisterFormTypes>();
     const translate = useTranslate();
@@ -64,6 +66,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
                 form={form}
                 onFinish={(values) => (onSubmit ?? register)(values)}
                 requiredMark={false}
+                {...formProps}
             >
                 <Form.Item
                     name="email"

--- a/packages/antd/src/components/pages/auth/components/resetPassword/index.tsx
+++ b/packages/antd/src/components/pages/auth/components/resetPassword/index.tsx
@@ -14,6 +14,7 @@ import {
     Button,
     LayoutProps,
     CardProps,
+    FormProps,
 } from "antd";
 import {
     useTranslate,
@@ -23,7 +24,11 @@ import {
 
 import { layoutStyles, containerStyles, titleStyles } from "../styles";
 
-type ResetPassworProps = RefineResetPasswordPageProps<LayoutProps, CardProps>;
+type ResetPassworProps = RefineResetPasswordPageProps<
+    LayoutProps,
+    CardProps,
+    FormProps
+>;
 
 const { Text, Title } = Typography;
 
@@ -38,6 +43,7 @@ export const ResetPasswordPage: React.FC<ResetPassworProps> = ({
     wrapperProps,
     contentProps,
     renderContent,
+    formProps,
 }) => {
     const [form] = Form.useForm<RefineResetPasswordFormTypes>();
     const translate = useTranslate();
@@ -64,6 +70,7 @@ export const ResetPasswordPage: React.FC<ResetPassworProps> = ({
                 form={form}
                 onFinish={(values) => (onSubmit ?? resetPassword)(values)}
                 requiredMark={false}
+                {...formProps}
             >
                 <Form.Item
                     name="email"

--- a/packages/antd/src/components/pages/auth/components/updatePassword/index.tsx
+++ b/packages/antd/src/components/pages/auth/components/updatePassword/index.tsx
@@ -14,6 +14,7 @@ import {
     Button,
     LayoutProps,
     CardProps,
+    FormProps,
 } from "antd";
 import { useTranslate, useUpdatePassword } from "@pankod/refine-core";
 
@@ -21,7 +22,11 @@ import { layoutStyles, containerStyles, titleStyles } from "../styles";
 
 const { Title } = Typography;
 
-type UpdatePassworProps = RefineUpdatePasswordPageProps<LayoutProps, CardProps>;
+type UpdatePassworProps = RefineUpdatePasswordPageProps<
+    LayoutProps,
+    CardProps,
+    FormProps
+>;
 
 /**
  * **refine** has update password page form which is served on `/update-password` route when the `authProvider` configuration is provided.
@@ -33,6 +38,7 @@ export const UpdatePasswordPage: React.FC<UpdatePassworProps> = ({
     wrapperProps,
     contentProps,
     renderContent,
+    formProps,
 }) => {
     const [form] = Form.useForm<RefineUpdatePasswordFormTypes>();
     const translate = useTranslate();
@@ -57,6 +63,7 @@ export const UpdatePasswordPage: React.FC<UpdatePassworProps> = ({
                 form={form}
                 onFinish={(values) => (onSubmit ?? updatePassword)(values)}
                 requiredMark={false}
+                {...formProps}
             >
                 <Form.Item
                     name="password"

--- a/packages/antd/src/components/pages/auth/index.tsx
+++ b/packages/antd/src/components/pages/auth/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CardProps, LayoutProps } from "antd";
+import { CardProps, FormProps, LayoutProps } from "antd";
 import { RefineAuthPageProps } from "@pankod/refine-ui-types";
 
 import {
@@ -9,7 +9,7 @@ import {
     UpdatePasswordPage,
 } from "./components";
 
-export type AuthProps = RefineAuthPageProps<LayoutProps, CardProps>;
+export type AuthProps = RefineAuthPageProps<LayoutProps, CardProps, FormProps>;
 
 /**
  * **refine** has a default auth page form served on the `/login` route when the `authProvider` configuration is provided.

--- a/packages/ui-types/src/types/auth.tsx
+++ b/packages/ui-types/src/types/auth.tsx
@@ -33,6 +33,7 @@ export interface RefineUpdatePasswordFormTypes {
 export type RefineAuthPageProps<
     TWrapperProps extends {} = Record<keyof any, unknown>,
     TContentProps extends {} = Record<keyof any, unknown>,
+    TFormProps extends {} = Record<keyof any, unknown>,
 > = (
     | PropsWithChildren<{
           /**
@@ -134,6 +135,11 @@ export type RefineAuthPageProps<
      * @optional
      */
     renderContent?: (content: React.ReactNode) => React.ReactNode;
+    /**
+     * @description Can be used to pass additional properties for the `Form`
+     * @optional
+     */
+    formProps?: TFormProps;
 };
 
 /**
@@ -142,6 +148,7 @@ export type RefineAuthPageProps<
 export type RefineLoginPageProps<
     TWrapperProps extends {} = Record<keyof any, unknown>,
     TContentProps extends {} = Record<keyof any, unknown>,
+    TFormProps extends {} = Record<keyof any, unknown>,
 > = PropsWithChildren<{
     providers?: IProvider[];
     onSubmit?: (formValues: RefineLoginFormTypes) => void;
@@ -151,6 +158,7 @@ export type RefineLoginPageProps<
     wrapperProps?: TWrapperProps;
     renderContent?: (content: React.ReactNode) => React.ReactNode;
     contentProps?: TContentProps;
+    formProps?: TFormProps;
 }>;
 
 /**
@@ -159,12 +167,14 @@ export type RefineLoginPageProps<
 export type RefineRegisterPageProps<
     TWrapperProps extends {} = Record<keyof any, unknown>,
     TContentProps extends {} = Record<keyof any, unknown>,
+    TFormProps extends {} = Record<keyof any, unknown>,
 > = PropsWithChildren<{
     onSubmit?: (formValues: RefineRegisterFormTypes) => void;
     loginLink?: React.ReactNode;
     wrapperProps?: TWrapperProps;
     renderContent?: (content: React.ReactNode) => React.ReactNode;
     contentProps?: TContentProps;
+    formProps?: TFormProps;
 }>;
 
 /**
@@ -173,12 +183,14 @@ export type RefineRegisterPageProps<
 export type RefineResetPasswordPageProps<
     TWrapperProps extends {} = Record<keyof any, unknown>,
     TContentProps extends {} = Record<keyof any, unknown>,
+    TFormProps extends {} = Record<keyof any, unknown>,
 > = PropsWithChildren<{
     onSubmit?: (formValues: RefineResetPasswordFormTypes) => void;
     loginLink?: React.ReactNode;
     wrapperProps?: TWrapperProps;
     renderContent?: (content: React.ReactNode) => React.ReactNode;
     contentProps?: TContentProps;
+    formProps?: TFormProps;
 }>;
 
 /**
@@ -187,9 +199,11 @@ export type RefineResetPasswordPageProps<
 export type RefineUpdatePasswordPageProps<
     TWrapperProps extends {} = Record<keyof any, unknown>,
     TContentProps extends {} = Record<keyof any, unknown>,
+    TFormProps extends {} = Record<keyof any, unknown>,
 > = PropsWithChildren<{
     onSubmit?: (formValues: RefineUpdatePasswordFormTypes) => void;
     wrapperProps?: TWrapperProps;
     renderContent?: (content: React.ReactNode) => React.ReactNode;
     contentProps?: TContentProps;
+    formProps?: TFormProps;
 }>;


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Added `formProps` property support for AuthPage component

## Usage

```tsx
<AuthPage
    type="login"
    formProps={{
        initialValues: {
            email: "demo@refine.dev",
            password: "demo",
        },
    }}
/>
```

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [ ] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
