### PR TITLE
fix: breadcrumb item spacing

### DIFF
--- a/.changeset/brave-crabs-peel.md
+++ b/.changeset/brave-crabs-peel.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": patch
+---
+
+Fixed the spacing between `icon` and `breadcrumb label` in `Breadcrumb` component.

--- a/packages/antd/src/components/breadcrumb/index.tsx
+++ b/packages/antd/src/components/breadcrumb/index.tsx
@@ -40,7 +40,11 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = ({
                 return (
                     <AntdBreadcrumb.Item key={label}>
                         {!hideIcons && icon}
-                        {href ? <Link to={href}>{label}</Link> : label}
+                        {href ? (
+                            <Link to={href}>{label}</Link>
+                        ) : (
+                            <span>{label}</span>
+                        )}
                     </AntdBreadcrumb.Item>
                 );
             })}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Fixed the spacing between `icon` and `breadcrumb label` in `Breadcrumb` component.

### Test plan (required)

<img width="762" alt="Screen Shot 2022-09-17 at 14 22 48" src="https://user-images.githubusercontent.com/75166276/190854105-2a737624-3127-400d-8781-2f72ec1e758b.png">

### Self Check before Merge

-   [X] Corresponding issues are created/updated or not needed
-   [X] Docs are updated/provided or not needed
-   [X] Examples are updated/provided or not needed
-   [X] TypeScript definitions are updated/provided or not needed
-   [X] Tests are updated/provided or not needed
-   [X] Changesets are provided or not needed
