### PR TITLE
fix: useModalForm & useStepsForm return type

### DIFF
--- a/.changeset/tall-garlics-fly.md
+++ b/.changeset/tall-garlics-fly.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-antd": patch
+---
+
+Fixed `useModalForm` & `useStepsForm` return type

--- a/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
+++ b/packages/antd/src/hooks/form/useModalForm/useModalForm.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from "react";
+import { FormInstance, FormProps, ModalProps } from "antd";
 import {
     useModalForm as useModalFormSF,
     UseModalFormConfig as UseModalFormConfigSF,
@@ -19,7 +20,21 @@ import {
     userFriendlyResourceName,
 } from "@pankod/refine-core";
 import { useForm, UseFormProps, UseFormReturnType } from "../useForm";
-import { useModalFormFromSFReturnType } from "../../../types/sunflower";
+
+export type useModalFormFromSFReturnType<TData, TVariables> = {
+    form: FormInstance<TVariables>;
+    visible: boolean;
+    show: (id?: BaseKey) => void;
+    close: () => void;
+    modalProps: ModalProps;
+    formProps: FormProps<TVariables>;
+    formLoading: boolean;
+    defaultFormValuesLoading: boolean;
+    formValues: {};
+    initialValues: {};
+    formResult: undefined;
+    submit: (values?: TVariables) => Promise<TData>;
+};
 
 type useModalFormConfig = {
     action: "show" | "edit" | "create" | "clone";

--- a/packages/antd/src/hooks/form/useStepsForm/useStepsForm.ts
+++ b/packages/antd/src/hooks/form/useStepsForm/useStepsForm.ts
@@ -2,6 +2,7 @@ import {
     useStepsForm as useStepsFormSF,
     UseStepsFormConfig,
 } from "sunflower-antd";
+import { FormInstance, FormProps } from "antd";
 
 import {
     HttpError,
@@ -10,7 +11,23 @@ import {
 } from "@pankod/refine-core";
 
 import { useForm, UseFormProps, UseFormReturnType } from "../useForm";
-import { useStepsFormFromSFReturnType } from "../../../types/sunflower";
+
+export type useStepsFormFromSFReturnType<TData, TVariables> = {
+    current: number;
+    gotoStep: (step: number) => void;
+    stepsProps: {
+        current: number;
+        onChange: (currentStep: number) => void;
+    };
+    formProps: FormProps<TVariables>;
+    formLoading: boolean;
+    defaultFormValuesLoading: boolean;
+    formValues: {};
+    initialValues: {};
+    formResult: undefined;
+    form: FormInstance<TVariables>;
+    submit: (values?: TVariables) => Promise<TData>;
+};
 
 export type useStepsFormReturnType<
     TData extends BaseRecord = BaseRecord,

--- a/packages/antd/src/index.tsx
+++ b/packages/antd/src/index.tsx
@@ -1,42 +1,7 @@
-import { BaseKey } from "@pankod/refine-core";
-import { FormInstance, FormProps, ModalProps } from "./components/antd";
-
 export * from "./hooks";
 export * from "./providers";
 export * from "./components/antd";
 export * from "./components";
-
-export type useModalFormFromSFReturnType<TData, TVariables> = {
-    form: FormInstance<TVariables>;
-    visible: boolean;
-    show: (id?: BaseKey) => void;
-    close: () => void;
-    modalProps: ModalProps;
-    formProps: FormProps<TVariables>;
-    formLoading: boolean;
-    defaultFormValuesLoading: boolean;
-    formValues: {};
-    initialValues: {};
-    formResult: undefined;
-    submit: (values?: TVariables) => Promise<TData>;
-};
-
-export type useStepsFormFromSFReturnType<TData, TVariables> = {
-    current: number;
-    gotoStep: (step: number) => void;
-    stepsProps: {
-        current: number;
-        onChange: (currentStep: number) => void;
-    };
-    formProps: FormProps<TVariables>;
-    formLoading: boolean;
-    defaultFormValuesLoading: boolean;
-    formValues: {};
-    initialValues: {};
-    formResult: undefined;
-    form: FormInstance<TVariables>;
-    submit: (values?: TVariables) => Promise<TData>;
-};
 
 // antd filterDropDownProps (using for <FilterDropDown> component)
 export type { FilterDropdownProps } from "antd/lib/table/interface";

--- a/packages/antd/src/types/sunflower.d.ts
+++ b/packages/antd/src/types/sunflower.d.ts
@@ -1,46 +1,11 @@
 import { FormInstance, FormProps, ModalProps } from "../components/antd";
 import { UseFormConfig, UseModalFormConfig } from "sunflower-antd";
-import { BaseKey } from "@pankod/refine-core";
-
 export interface UseStepsFormConfig
     extends Omit<UseFormConfig, "defaultFormValues"> {
     defaultCurrent?: number;
     total?: number;
     isBackValidate?: boolean;
 }
-
-export type useModalFormFromSFReturnType<TData, TVariables> = {
-    form: FormInstance<TVariables>;
-    visible: boolean;
-    show: (id?: BaseKey) => void;
-    close: () => void;
-    modalProps: ModalProps;
-    formProps: FormProps<TVariables>;
-    formLoading: boolean;
-    defaultFormValuesLoading: boolean;
-    formValues: {};
-    initialValues: {};
-    formResult: undefined;
-    submit: (values?: TVariables) => Promise<TData>;
-};
-
-export type useStepsFormFromSFReturnType<TData, TVariables> = {
-    current: number;
-    gotoStep: (step: number) => void;
-    stepsProps: {
-        current: number;
-        onChange: (currentStep: number) => void;
-    };
-    formProps: FormProps<TVariables>;
-    formLoading: boolean;
-    defaultFormValuesLoading: boolean;
-    formValues: {};
-    initialValues: {};
-    formResult: undefined;
-    form: FormInstance<TVariables>;
-    submit: (values?: TVariables) => Promise<TData>;
-};
-
 declare module "sunflower-antd" {
     export const useStepsForm: <TData, TVariables>(
         config: UseStepsFormConfig,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Fixed `useModalForm` & `useStepsForm` return type

### Test plan (required)

only type fix

### Closing issues

- #2550 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
