### PR TITLE
fix: undoable mutation is called many times

### DIFF
--- a/.changeset/tall-bugs-boil.md
+++ b/.changeset/tall-bugs-boil.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fixed undoable mutation is called many times - #2556

--- a/packages/core/src/components/undoableQueue/index.spec.tsx
+++ b/packages/core/src/components/undoableQueue/index.spec.tsx
@@ -13,18 +13,15 @@ const closeMock = jest.fn();
 
 const notificationDispatch = jest.fn();
 
-const mockNotification = [
-    {
-        id: "1",
-        resource: "posts",
-        cancelMutation,
-        doMutation,
-        seconds: 5000,
-        isRunning: true,
-        isSilent: false,
-    },
-];
-
+const mockNotification = {
+    id: "1",
+    resource: "posts",
+    cancelMutation,
+    doMutation,
+    seconds: 5000,
+    isRunning: true,
+    isSilent: false,
+};
 describe("Cancel Notification", () => {
     beforeEach(() => {
         jest.useFakeTimers();
@@ -34,10 +31,10 @@ describe("Cancel Notification", () => {
             <UndoableQueueContext.Provider
                 value={{
                     notificationDispatch,
-                    notifications: mockNotification,
+                    notifications: [mockNotification],
                 }}
             >
-                <UndoableQueue notifications={mockNotification} />
+                <UndoableQueue notification={mockNotification} />
             </UndoableQueueContext.Provider>,
             {
                 wrapper: TestWrapper({
@@ -72,8 +69,8 @@ describe("Cancel Notification", () => {
     });
 
     it("should call doMutation on seconds zero", async () => {
-        mockNotification[0].seconds = 0;
-        render(<UndoableQueue notifications={mockNotification} />);
+        mockNotification.seconds = 0;
+        render(<UndoableQueue notification={mockNotification} />);
 
         expect(doMutation).toBeCalledTimes(1);
     });


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:
When updating multiple records at the same time whose mutationMode is undoable, the doMutation() method is called multiple times leading to duplicate API calls for the dataProvider.

for more details #2556 

### Test plan (required)

![Screen Shot 2022-09-21 at 19 42 43](https://user-images.githubusercontent.com/1110414/191563033-cdcdd47e-5b43-43e3-a599-946b13a05b7c.png)

### Closing issues

- #2556 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
