### PR TITLE
fix: `useImport` not working properly

### DIFF
--- a/.changeset/quiet-chicken-care.md
+++ b/.changeset/quiet-chicken-care.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Fix `useImport` hook requests with properly invoking requests sequentially and manage progress state.

--- a/packages/core/src/definitions/helpers/index.ts
+++ b/packages/core/src/definitions/helpers/index.ts
@@ -9,3 +9,4 @@ export { createTreeView } from "./treeView/createTreeView";
 export { humanizeString } from "./humanizeString";
 export { handleRefineOptions } from "./handleRefineOptions";
 export { redirectPage } from "./redirectPage";
+export { sequentialPromises } from "./sequentialPromises";

--- a/packages/core/src/definitions/helpers/sequentialPromises/index.ts
+++ b/packages/core/src/definitions/helpers/sequentialPromises/index.ts
@@ -18,6 +18,7 @@ export const sequentialPromises = async <
     onEachReject: EachReject<TReject, TRejectResponse>,
 ): Promise<(TResolveResponse | TRejectResponse)[]> => {
     const results = [];
+    // @ts-expect-error While working on this code, please enable `downLevelIteration`
     for (const [index, promise] of promises.entries()) {
         try {
             const result = await promise();

--- a/packages/core/src/definitions/helpers/sequentialPromises/index.ts
+++ b/packages/core/src/definitions/helpers/sequentialPromises/index.ts
@@ -1,0 +1,31 @@
+type EachResolve<TResolve, Response> = (
+    result: TResolve,
+    index: number,
+) => Response;
+type EachReject<TReject, Response> = (
+    error: TReject,
+    index: number,
+) => Response;
+
+export const sequentialPromises = async <
+    TResolve extends unknown = unknown,
+    TReject extends unknown = unknown,
+    TResolveResponse extends unknown = unknown,
+    TRejectResponse extends unknown = unknown,
+>(
+    promises: (() => Promise<TResolve>)[],
+    onEachResolve: EachResolve<TResolve, TResolveResponse>,
+    onEachReject: EachReject<TReject, TRejectResponse>,
+): Promise<(TResolveResponse | TRejectResponse)[]> => {
+    const results = [];
+    for (const [index, promise] of promises.entries()) {
+        try {
+            const result = await promise();
+
+            results.push(onEachResolve(result, index));
+        } catch (error) {
+            results.push(onEachReject(error as TReject, index));
+        }
+    }
+    return results;
+};

--- a/packages/core/src/definitions/helpers/sequentialPromises/index.ts
+++ b/packages/core/src/definitions/helpers/sequentialPromises/index.ts
@@ -18,7 +18,6 @@ export const sequentialPromises = async <
     onEachReject: EachReject<TReject, TRejectResponse>,
 ): Promise<(TResolveResponse | TRejectResponse)[]> => {
     const results = [];
-    // @ts-expect-error While working on this code, please enable `downLevelIteration`
     for (const [index, promise] of promises.entries()) {
         try {
             const result = await promise();

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,7 +5,6 @@
         "rootDir": "./src",
         "baseUrl": ".",
         "importHelpers": false,
-        "downlevelIteration": true,
         "paths": {
             "@components/*": ["src/components/*"],
             "@components": ["src/components"],

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,66 +1,29 @@
 {
-    "include": [
-        "src",
-        "types"
-    ],
+    "include": ["src", "types"],
     "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "rootDir": "./src",
         "baseUrl": ".",
         "importHelpers": false,
+        "downlevelIteration": true,
         "paths": {
-            "@components/*": [
-                "src/components/*"
-            ],
-            "@components": [
-                "src/components"
-            ],
-            "@containers/*": [
-                "src/containers/*"
-            ],
-            "@containers": [
-                "src/containers"
-            ],
-            "@pages/*": [
-                "src/pages/*"
-            ],
-            "@pages": [
-                "src/pages"
-            ],
-            "@contexts/*": [
-                "src/contexts/*"
-            ],
-            "@contexts": [
-                "src/contexts"
-            ],
-            "@dataProviders/*": [
-                "src/dataProviders/*"
-            ],
-            "@dataProviders": [
-                "src/dataProviders"
-            ],
-            "@hooks/*": [
-                "src/hooks/*"
-            ],
-            "@hooks": [
-                "src/hooks"
-            ],
-            "@test/*": [
-                "test/*"
-            ],
-            "@test": [
-                "test"
-            ],
-            "@definitions/*": [
-                "src/definitions/*"
-            ],
-            "@definitions": [
-                "src/definitions"
-            ]
+            "@components/*": ["src/components/*"],
+            "@components": ["src/components"],
+            "@containers/*": ["src/containers/*"],
+            "@containers": ["src/containers"],
+            "@pages/*": ["src/pages/*"],
+            "@pages": ["src/pages"],
+            "@contexts/*": ["src/contexts/*"],
+            "@contexts": ["src/contexts"],
+            "@dataProviders/*": ["src/dataProviders/*"],
+            "@dataProviders": ["src/dataProviders"],
+            "@hooks/*": ["src/hooks/*"],
+            "@hooks": ["src/hooks"],
+            "@test/*": ["test/*"],
+            "@test": ["test"],
+            "@definitions/*": ["src/definitions/*"],
+            "@definitions": ["src/definitions"]
         },
-        "typeRoots": [
-            "./types",
-            "../../node_modules/@types"
-        ]
+        "typeRoots": ["./types", "../../node_modules/@types"]
     }
 }


### PR DESCRIPTION
Updated `useImport` hook API calls with sequentially resolving Promises and handled progress with resolve/reject statuses.

(Added `sequentialPromises` helper function)

Haven't had a chance to try the updated `useImport` hook in examples yet. 

### Test plan (required)
<img width="794" alt="Screen Shot 2022-09-21 at 21 11 09" src="https://user-images.githubusercontent.com/11361964/191579826-318c6d1c-2eab-4760-a3f0-208809f95bbb.png">

### Closing issues

#2513 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [ ] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
