### PR TITLE
docs: add Mantine examples

### DIFF
--- a/documentation/docs/examples/form/mantine/useDrawerForm.md
+++ b/documentation/docs/examples/form/mantine/useDrawerForm.md
@@ -1,0 +1,16 @@
+---
+id: useDrawerForm
+title: useDrawerForm
+---
+
+`useModalForm` hook allows you to manage a form within a modal as well as a drawer. It provides some useful methods to handle the form modal or form drawer. You can view the live example or review the source code to see how it's used with Material UI.
+
+<!-- TODO: When you create useModalForm hook documentation, change the link below. -->
+<!-- [Refer to the useModalForm hook documentation for more information. →](#) -->
+
+[View Drawer Form Example Source](https://github.com/pankod/refine/tree/master/examples/form/mantine/useDrawerForm)
+
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useDrawerForm?embed=1&view=preview&theme=dark&preset=node"
+    style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
+    title="mantine-use-drawer-form-example"
+></iframe>

--- a/documentation/docs/examples/form/mantine/useForm.md
+++ b/documentation/docs/examples/form/mantine/useForm.md
@@ -1,0 +1,16 @@
+---
+id: useForm
+title: useForm
+---
+
+**refine** works integrated with `useForm` of `@mantine/form` library. Using this package, you can use all the features provided by Mantine in your **refine** project in a compatible way. You can view the live example or review the source code to see how it's used with Mantine.
+
+<!-- TODO: When you create useForm hook documentation, change the link below. -->
+<!-- [Refer to the useForm hook documentation for more information. →](#) -->
+
+[View useForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/mantine/useForm)
+
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useForm?embed=1&view=preview&theme=dark&preset=node"
+    style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
+    title="mantine-use-form-example"
+></iframe>

--- a/documentation/docs/examples/form/mantine/useModalForm.md
+++ b/documentation/docs/examples/form/mantine/useModalForm.md
@@ -1,0 +1,18 @@
+---
+id: useModalForm
+title: useModalForm
+---
+
+`useModalForm` hook allows you to manage a form within a modal. It provides some useful methods to handle the form modal. You can view the live example or review the source code to see how it's used with Mantine.
+
+<!-- TODO: When you create useModalForm hook documentation, change the link below. -->
+<!-- [Refer to the useModalForm hook documentation for more information. →](#) -->
+
+[View useModalForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/mantine/useModalForm)
+
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useModalForm?embed=1&view=preview&theme=dark&preset=node"
+  style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
+  title="mantine-use-modal-form-example"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>

--- a/documentation/docs/examples/form/mantine/useStepsForm.md
+++ b/documentation/docs/examples/form/mantine/useStepsForm.md
@@ -1,0 +1,16 @@
+---
+id: useStepsForm
+title: useStepsForm
+---
+
+`useStepsForm` allows you to manage a form with multiple steps. It provides features such as which step is currently active, the ability to go to a specific step and validation when changing steps etc. You can view the live example or review the source code to see how it's used with Mantine.
+
+<!-- TODO: When you create useModalForm hook documentation, change the link below. -->
+<!-- [Refer to the useStepsForm hook documentation for more information. →](/docs/api-reference/mantine/hooks/form/useStepsForm/) -->
+
+[View useStepsForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/mui/useStepsForm)
+
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useStepsForm?embed=1&view=preview&theme=dark&preset=node"
+    style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
+    title="mantine-use-steps-form-example"
+></iframe>

--- a/documentation/docs/examples/form/mantine/useStepsForm.md
+++ b/documentation/docs/examples/form/mantine/useStepsForm.md
@@ -8,7 +8,7 @@ title: useStepsForm
 <!-- TODO: When you create useModalForm hook documentation, change the link below. -->
 <!-- [Refer to the useStepsForm hook documentation for more information. →](/docs/api-reference/mantine/hooks/form/useStepsForm/) -->
 
-[View useStepsForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/mui/useStepsForm)
+[View useStepsForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/mantine/useStepsForm)
 
 <iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useStepsForm?embed=1&view=preview&theme=dark&preset=node"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}

--- a/documentation/docs/examples/form/mui/useDrawerForm.md
+++ b/documentation/docs/examples/form/mui/useDrawerForm.md
@@ -1,6 +1,6 @@
 ---
-id: drawerForm
-title: Drawer Form
+id: useDrawerForm
+title: useDrawerForm
 ---
 
 `useModalForm` hook allows you to manage a form within a modal as well as a drawer. It provides some useful methods to handle the form modal or form drawer. You can view the live example or review the source code to see how it's used with Material UI.
@@ -11,5 +11,5 @@ title: Drawer Form
 
 <iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mui/useDrawerForm?embed=1&view=preview&theme=dark&preset=node"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
-    title="refine-mui-drawer-form-example"
+    title="mui-use-drawer-form"
 ></iframe>

--- a/documentation/docs/examples/form/mui/useForm.md
+++ b/documentation/docs/examples/form/mui/useForm.md
@@ -11,5 +11,5 @@ title: useForm
 
 <iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mui/useForm?embed=1&view=preview&theme=dark&preset=node"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
-    title="refine-mui-use-form-example"
+    title="mui-use-form"
 ></iframe>

--- a/documentation/docs/examples/form/mui/useModalForm.md
+++ b/documentation/docs/examples/form/mui/useModalForm.md
@@ -11,7 +11,7 @@ title: useModalForm
 
 <iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mui/useModalForm?embed=1&view=preview&theme=dark&preset=node"
   style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
-  title="refine-mui-use-modal-form-example"
+  title="mui-use-modal-form"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 ></iframe>

--- a/documentation/docs/examples/form/mui/useStepsForm.md
+++ b/documentation/docs/examples/form/mui/useStepsForm.md
@@ -5,11 +5,11 @@ title: useStepsForm
 
 `useStepsForm` allows you to manage a form with multiple steps. It provides features such as which step is currently active, the ability to go to a specific step and validation when changing steps etc. You can view the live example or review the source code to see how it's used with Material UI.
 
-[Refer to the **refine** useStepsForm hook documentation for more information. →](/docs/api-reference/antd/hooks/form/useStepsForm/)
+[Refer to the useStepsForm hook documentation for more information. →](/docs/api-reference/mui/hooks/form/useStepsForm/)
 
-[View useSteps Example Source](https://github.com/pankod/refine/tree/master/examples/form/mui/useStepsForm)
+[View useStepsForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/mui/useStepsForm)
 
 <iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mui/useStepsForm?embed=1&view=preview&theme=dark&preset=node"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
-    title="refine-use-steps-form-example"
+    title="mui-use-steps-form"
 ></iframe>

--- a/documentation/docs/examples/form/mui/useStepsForm.md
+++ b/documentation/docs/examples/form/mui/useStepsForm.md
@@ -5,7 +5,7 @@ title: useStepsForm
 
 `useStepsForm` allows you to manage a form with multiple steps. It provides features such as which step is currently active, the ability to go to a specific step and validation when changing steps etc. You can view the live example or review the source code to see how it's used with Material UI.
 
-[Refer to the useStepsForm hook documentation for more information. →](/docs/api-reference/mui/hooks/form/useStepsForm/)
+[Refer to the useStepsForm hook documentation for more information. →](/docs/packages/documentation/react-hook-form/useStepsForm/)
 
 [View useStepsForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/mui/useStepsForm)
 

--- a/documentation/docs/examples/table/mantine/advanced.md
+++ b/documentation/docs/examples/table/mantine/advanced.md
@@ -1,0 +1,13 @@
+---
+id: advanced-react-table
+title: Advanced
+---
+
+It is an example of Mantine Advanced [React Table](https://react-table.tanstack.com/) created with **refine**'s `@pankod/refine-react-table` adapter. In addition to the Mantine Basic React Table example, deletion editing and filtering features are used together in your table. For more information, you can view the live example or review the source code to see how it's used with Mantine.
+
+[View Mantine Advanced React Table Example Source](https://github.com/pankod/refine/tree/master/examples/table/mantine/advanced)
+
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mantine/advanced/?embed=1&view=preview&theme=dark&preset=node"
+    style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
+    title="mantine-advanced-react-table-example"
+></iframe>

--- a/documentation/docs/examples/table/mantine/basic.md
+++ b/documentation/docs/examples/table/mantine/basic.md
@@ -1,0 +1,15 @@
+---
+id: basic
+title: Basic
+---
+
+**refine** allows you to use all the features of [React Table](https://react-table.tanstack.com/) with `@pankod/refine-react-table` adapter. In this way, you can manage your server-side data operations. By using this adapter, you can directly use all the features of React Table in your **refine** project. For more information, you can view the live example or review the source code to see how it's used with Mantine.
+
+[Refer to the React Table documentation for more information. →](/docs/packages/documentation/react-table/)
+
+[View Mantine React Table Example Source](https://github.com/pankod/refine/tree/master/examples/table/reactTable/basic)
+
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mantine/basic/?embed=1&view=preview&theme=dark&preset=node"
+    style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
+    title="mantine-basic-react-table-example"
+></iframe>

--- a/documentation/docs/examples/upload/mantine/base64.md
+++ b/documentation/docs/examples/upload/mantine/base64.md
@@ -1,0 +1,13 @@
+---
+id: base64
+title: Base64 Upload
+---
+
+In this example, you'll learn how to do base64 upload in **refine** with `useForm`. For more information, you can view the live example or review the source code.
+
+[View Base64 Upload Example Source](https://github.com/pankod/refine/tree/master/examples/upload/mantine/base64)
+
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/mantine/base64?embed=1&view=preview&theme=dark&preset=node"
+    style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
+    title="mantine-base64-upload"
+></iframe>

--- a/documentation/docs/examples/upload/mantine/multipart.md
+++ b/documentation/docs/examples/upload/mantine/multipart.md
@@ -1,0 +1,13 @@
+---
+id: multipart
+title: Multipart Upload
+---
+
+In this example, you'll learn how to do multipart upload in **refine** with `useForm`. For more information, you can view the live example or review the source code.
+
+[View Multipart Upload Example Source](https://github.com/pankod/refine/tree/master/examples/upload/mantine/multipart)
+
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/mantine/multipart?embed=1&view=preview&theme=dark&preset=node"
+    style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
+    title="mantine-multipart-upload"
+></iframe>

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -581,9 +581,19 @@ module.exports = {
                         },
                         {
                             type: "category",
+                            label: "Mantine",
+                            items: [
+                                "examples/form/mantine/useDrawerForm",
+                                "examples/form/mantine/useForm",
+                                "examples/form/mantine/useModalForm",
+                                "examples/form/mantine/useStepsForm",
+                            ],
+                        },
+                        {
+                            type: "category",
                             label: "Material UI",
                             items: [
-                                "examples/form/mui/drawerForm",
+                                "examples/form/mui/useDrawerForm",
                                 "examples/form/mui/useForm",
                                 "examples/form/mui/useModalForm",
                                 "examples/form/mui/useStepsForm",
@@ -686,6 +696,14 @@ module.exports = {
                         },
                         {
                             type: "category",
+                            label: "Mantine",
+                            items: [
+                                "examples/table/mantine/advanced-react-table",
+                                "examples/table/mantine/basic",
+                            ],
+                        },
+                        {
+                            type: "category",
                             label: "Material UI",
                             items: [
                                 "examples/table/mui/advanced",
@@ -726,6 +744,14 @@ module.exports = {
                             items: [
                                 "examples/upload/antd/base64",
                                 "examples/upload/antd/multipart",
+                            ],
+                        },
+                        {
+                            type: "category",
+                            label: "Mantine",
+                            items: [
+                                "examples/upload/mantine/base64",
+                                "examples/upload/mantine/multipart",
                             ],
                         },
                         {


### PR DESCRIPTION
Mantine examples added to documents.


### Test plan (required)

The tests are not effected.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
