### PR TITLE
feat(docs): add <PropsTable/> to useCan

### DIFF
--- a/.changeset/cyan-queens-ring.md
+++ b/.changeset/cyan-queens-ring.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+add props table to useCan documentation

--- a/documentation/docs/api-reference/core/hooks/accessControl/useCan.md
+++ b/documentation/docs/api-reference/core/hooks/accessControl/useCan.md
@@ -41,17 +41,12 @@ const { data } = useCan({
 
 ### Properties
 
-| Property                                                                                            | Description                             | Type                                                              | Default |
-| --------------------------------------------------------------------------------------------------- | --------------------------------------- | ----------------------------------------------------------------- | ------- |
-| <div className="required-block"><div>resource</div> <div className=" required">Required</div></div> | Resource name for API data interactions | `string`                                                          |         |
-| action <div className="required">Required</div>                                                     | Intenden action on resource             | `string`                                                          |         |
-| params                                                                                              | Parameters associated with the resource | `any`                                                             |         |
-| queryOptions                                                                                        | `react-query`'s `useQuery` options      | ` UseQueryOptions<`<br/>`{ data: CanReturnType; },`<br/>`TError>` |         |
+<PropsTable module="@pankod/refine-core/useCan"  />
 
 ### Type Parameters
 
-| Property                                                     | Desription                                                            |
-| ------------------------------------------------------------ | --------------------------------------------------------------------- |
+| Property                                                         | Desription                                                                          |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | [CanReturnType](/api-reference/core/interfaces.md#canreturntype) | Result data of the query [`HttpError`](/api-reference/core/interfaces.md#httperror) |
 
 ### Return values

--- a/packages/core/src/contexts/accessControl/IAccessControlContext.ts
+++ b/packages/core/src/contexts/accessControl/IAccessControlContext.ts
@@ -1,8 +1,18 @@
 import { BaseKey, IResourceItem, ITreeMenu } from "../../interfaces";
 
 export type CanParams = {
+    /**
+     * Resource name for API data interactions
+     */
     resource: string;
+    /**
+     * Intenden action on resource
+     */
     action: string;
+    /**
+     * Parameters associated with the resource
+     * @type { resource?: [IResourceItem](https://refine.dev/docs/api-reference/core/interfaceReferences/#canparams), id?: [BaseKey](https://refine.dev/docs/api-reference/core/interfaceReferences/#basekey), [key: string]: any }
+     */
     params?: {
         resource?: IResourceItem & { children?: ITreeMenu[] };
         id?: BaseKey;
@@ -14,6 +24,7 @@ export type CanReturnType = {
     can: boolean;
     reason?: string;
 };
+
 export interface IAccessControlContext {
     can?: ({ resource, action, params }: CanParams) => Promise<CanReturnType>;
 }

--- a/packages/core/src/hooks/accessControl/useCan/index.ts
+++ b/packages/core/src/hooks/accessControl/useCan/index.ts
@@ -9,6 +9,9 @@ import { AccessControlContext } from "@contexts/accessControl";
 import { CanParams, CanReturnType } from "../../../interfaces";
 
 export type UseCanProps = CanParams & {
+    /**
+     * react-query's [useQuery](https://tanstack.com/query/v4/docs/reference/useQuery) options
+     */
     queryOptions?: UseQueryOptions<CanReturnType>;
 };
 


### PR DESCRIPTION
Explain the **details** for making this change. What existing problem does the pull request solve?

`<PropsTable />` added to useCan doc.
[useCan]( https://refine.dev/docs/api-reference/core/hooks/accessControl/useCan/)


-   [ ] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
