### PR TITLE
fix: deleteOne function type issue of realworld example

### DIFF
--- a/examples/real-world-example/src/dataProvider.ts
+++ b/examples/real-world-example/src/dataProvider.ts
@@ -93,7 +93,9 @@ export const dataProvider = (axios: AxiosInstance): DataProvider => {
                 ? `${API_URL}/${resource}/${id}/${metaData.URLSuffix}`
                 : `${API_URL}/${resource}/${id}`;
 
-            const { data } = await axios.delete(url, variables);
+            const { data } = await axios.delete(url, {
+                data: variables,
+            });
 
             return {
                 data,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

I updated the `deleteOne` function of dataProvider

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
