### PR TITLE
feat(docs): <PropsTable/> UI improvements

### DIFF
--- a/documentation/src/components/prop-tag/index.tsx
+++ b/documentation/src/components/prop-tag/index.tsx
@@ -26,8 +26,8 @@ const PropTag: React.FC<React.PropsWithChildren<Props>> = ({
 
     if (asterisk) {
         return (
-            <div className="prop--tag prop--tag__required" title={alt}>
-                {children ?? "✱"}
+            <div className="prop--tag__required" title={alt}>
+                {children ?? "﹡"}
             </div>
         );
     }

--- a/documentation/src/components/props-table/index.tsx
+++ b/documentation/src/components/props-table/index.tsx
@@ -5,6 +5,7 @@ import {
     useDynamicImport,
 } from "../../hooks/use-dynamic-import";
 import PropTag from "../prop-tag";
+import Tooltip from "../tooltip";
 
 type Overrides = `${string}-${
     | "hidden"
@@ -37,14 +38,31 @@ const Name = ({
     const deprecation =
         overrides[`${prop.name}-deprecated`] || prop.tags?.deprecated || "";
 
+    const variant = useMemo(() => {
+        const className = "props-table--name";
+
+        if (deprecated) {
+            return `${className} props-table--name__deprecated`;
+        }
+
+        return className;
+    }, [prop, overrides]);
+
+    const tooltipLabel = useMemo(() => {
+        if (deprecation) return <ReactMarkdown>{deprecation}</ReactMarkdown>;
+
+        return null;
+    }, [prop, overrides]);
+
     return (
-        <>
-            <span className="props-table--name">
-                {overrides[`${prop.name}-name`] ?? prop.name}
-            </span>
-            {required && <PropTag asterisk />}
-            {deprecated && <PropTag deprecated alt={deprecation} />}
-        </>
+        <Tooltip label={tooltipLabel}>
+            <>
+                <span className={variant}>
+                    {overrides[`${prop.name}-name`] ?? prop.name}
+                </span>
+                {required && <PropTag asterisk />}
+            </>
+        </Tooltip>
     );
 };
 

--- a/documentation/src/components/props-table/index.tsx
+++ b/documentation/src/components/props-table/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import {
     DeclarationType,
@@ -196,6 +196,22 @@ const PropsTable: React.FC<React.PropsWithChildren<Props>> = ({
 }) => {
     const data = useDynamicImport(module);
 
+    const hideRowDefault = useMemo(() => {
+        if (hideDefaults) return false;
+
+        const keys = Object.keys(overrides);
+        const hasDefaultKey = keys.some((key) => key.endsWith("-default"));
+        if (hasDefaultKey) {
+            return false;
+        }
+
+        const hasDefaultValue = Object.values(data?.props ?? {}).some(
+            (prop) => prop.defaultValue?.value,
+        );
+
+        return !hasDefaultValue;
+    }, [overrides]);
+
     if (!data) {
         return null;
     }
@@ -208,7 +224,7 @@ const PropsTable: React.FC<React.PropsWithChildren<Props>> = ({
                         <th>Property</th>
                         <th>Type</th>
                         <th>Description</th>
-                        {hideDefaults ? null : <th>Default</th>}
+                        {hideRowDefault ? null : <th>Default</th>}
                     </tr>
                 </thead>
                 <tbody>
@@ -224,7 +240,7 @@ const PropsTable: React.FC<React.PropsWithChildren<Props>> = ({
                                     prop={prop}
                                     overrides={overrides}
                                 />
-                                {hideDefaults ? null : (
+                                {hideRowDefault ? null : (
                                     <RowDefault
                                         prop={prop}
                                         overrides={overrides}

--- a/documentation/src/components/props-table/index.tsx
+++ b/documentation/src/components/props-table/index.tsx
@@ -42,7 +42,7 @@ const Name = ({
             <span className="props-table--name">
                 {overrides[`${prop.name}-name`] ?? prop.name}
             </span>
-            {required && <PropTag required />}
+            {required && <PropTag asterisk />}
             {deprecated && <PropTag deprecated alt={deprecation} />}
         </>
     );
@@ -67,7 +67,7 @@ const Type = ({
             {hasLongTypeInUnion && isUnion ? (
                 <>
                     {splitted.map((t, i) => (
-                        <code className="h-min max-w-xs" key={i}>
+                        <code className="max-w-xs h-min" key={i}>
                             <ReactMarkdown>{t}</ReactMarkdown>
                         </code>
                     ))}

--- a/documentation/src/components/tooltip/index.tsx
+++ b/documentation/src/components/tooltip/index.tsx
@@ -1,0 +1,23 @@
+import React, { FC, PropsWithChildren, ReactNode } from "react";
+
+type Props = {
+    label?: ReactNode;
+};
+
+const Tooltip: FC<PropsWithChildren<Props>> = ({ label, children }) => {
+    if (!label) return <>{children}</>;
+
+    return (
+        <div className="relative flex flex-col items-center group">
+            {children}
+            <div className="absolute bottom-0 left-0 flex flex-col items-center invisible mb-6 transition-all ease-out delay-75 group-hover:visible">
+                <span className="relative z-50 p-2 text-white bg-black rounded-sm shadow-2xl w-60">
+                    {label}
+                </span>
+                <div className="w-3 h-3 -mt-2 rotate-45 bg-black" />
+            </div>
+        </div>
+    );
+};
+
+export default Tooltip;

--- a/documentation/src/css/custom.css
+++ b/documentation/src/css/custom.css
@@ -525,7 +525,7 @@ html[data-page="index"] {
 }
 
 #__docusaurus .pagination-item.disabled {
-    @apply cursor-not-allowed text-gray-200 hover:border-gray-200 hover:text-gray-200;
+    @apply text-gray-200 cursor-not-allowed hover:border-gray-200 hover:text-gray-200;
 }
 
 #__docusaurus .pagination-item.active {
@@ -533,7 +533,7 @@ html[data-page="index"] {
 }
 
 #__docusaurus .dots {
-    @apply h-8 cursor-default border-none;
+    @apply h-8 border-none cursor-default;
 }
 
 #__docusaurus .custom-table-of-contents .table-of-contents {
@@ -672,7 +672,8 @@ html[data-customized="true"] #__docusaurus .navbar-theme-toggle {
     display: none;
 }
 
-html[data-customized="true"], html[data-theme="dark"][data-customized="true"] {
+html[data-customized="true"],
+html[data-theme="dark"][data-customized="true"] {
     background: white;
 }
 
@@ -684,7 +685,9 @@ html[data-theme="dark"]:not([data-customized="true"]) #__docusaurus .navbar {
     @apply border-0 border-b border-solid border-b-[#2A2A42] border-opacity-80 bg-[#272729] bg-opacity-80;
 }
 
-html:not([data-theme="dark"]):not([data-customized="true"]) #__docusaurus .navbar {
+html:not([data-theme="dark"]):not([data-customized="true"])
+    #__docusaurus
+    .navbar {
     @apply border-0 border-b border-solid border-b-[#F6F6F9] border-opacity-80 bg-white bg-opacity-80;
 }
 
@@ -733,13 +736,15 @@ html[data-theme="dark"]:not([data-customized="true"])
     @apply pl-0;
 }
 
-
 #__docusaurus .theme-doc-sidebar-menu.menu__list .menu__link--active {
-    color: #1890FF;
+    color: #1890ff;
     position: relative;
 }
 
-#__docusaurus .with-hoverline .navbar-sidebar__items.navbar-sidebar__items--show-secondary .menu__link.menu__link--active::before {
+#__docusaurus
+    .with-hoverline
+    .navbar-sidebar__items.navbar-sidebar__items--show-secondary
+    .menu__link.menu__link--active::before {
     display: none;
 }
 
@@ -753,11 +758,11 @@ html[data-theme="dark"]:not([data-customized="true"])
     width: 4px;
     height: 4px;
     border-radius: 4px;
-    background-color: #1890FF;
+    background-color: #1890ff;
 }
 
 #__docusaurus .theme-doc-sidebar-menu.menu__list .menu__link--active::after {
-	background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24"><path fill="rgba(24,144,255,1)" d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path></svg>');
+    background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24"><path fill="rgba(24,144,255,1)" d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path></svg>');
     filter: none;
 }
 
@@ -816,7 +821,8 @@ html[data-theme="dark"]:not([data-customized="true"])
     font-size: 14px;
 }
 
-.props-table td, .props-table th {
+.props-table td,
+.props-table th {
     padding: 6px 8px;
 }
 
@@ -836,6 +842,10 @@ html[data-theme="dark"]:not([data-customized="true"])
     vertical-align: middle;
 }
 
+.props-table--name__deprecated {
+    text-decoration: line-through;
+}
+
 .props-table__type-cell *,
 .props-table__description-cell *,
 .props-table__default-value-cell *,
@@ -847,4 +857,3 @@ html[data-theme="dark"]:not([data-customized="true"])
     font-size: 14px;
     line-height: 1.5;
 }
-


### PR DESCRIPTION
1. Required prop tag changed to asterisks.
2. Deprecated label removed from prop name, description of deprecation added as a tooltip. text-decoration changed to line-through. [Example page](https://refine.dev/docs/api-reference/antd/components/basic-views/create/#props)
3. When props have no default value, column removed from <TableProps/>

-   [ ] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [ ] Changesets are provided or not needed
