### PR TITLE
docs: perf. fixes on dev mode

### DIFF
--- a/documentation/plugins/docgen.js
+++ b/documentation/plugins/docgen.js
@@ -352,8 +352,12 @@ function plugin() {
             return [packagesDir];
         },
         async loadContent() {
-            console.log("Generating Refine declarations...");
-            return await handleDocgen();
+            if (!process.env.DISABLE_DOCGEN) {
+                console.log("Generating Refine declarations...");
+                return await handleDocgen();
+            }
+
+            return {};
         },
         configureWebpack(config) {
             return {
@@ -377,28 +381,30 @@ function plugin() {
             };
         },
         async contentLoaded({ content, actions }) {
-            console.log("Creating Refine declaration files...");
+            if (!process.env.DISABLE_DOCGEN) {
+                console.log("Creating Refine declaration files...");
 
-            const { createData } = actions;
+                const { createData } = actions;
 
-            const data = [];
+                const data = [];
 
-            Object.entries(content).forEach(
-                ([packageName, packageDeclarations]) => {
-                    Object.entries(packageDeclarations).forEach(
-                        ([componentName, declaration]) => {
-                            data.push(
-                                createData(
-                                    `${packageName}/${componentName}.json`,
-                                    JSON.stringify(declaration),
-                                ),
-                            );
-                        },
-                    );
-                },
-            );
+                Object.entries(content).forEach(
+                    ([packageName, packageDeclarations]) => {
+                        Object.entries(packageDeclarations).forEach(
+                            ([componentName, declaration]) => {
+                                data.push(
+                                    createData(
+                                        `${packageName}/${componentName}.json`,
+                                        JSON.stringify(declaration),
+                                    ),
+                                );
+                            },
+                        );
+                    },
+                );
 
-            await Promise.all(data);
+                await Promise.all(data);
+            }
         },
     };
 }

--- a/documentation/plugins/docgen.ts
+++ b/documentation/plugins/docgen.ts
@@ -325,8 +325,12 @@ export default function plugin(): Plugin<DocgenContent> {
             return [packagesDir];
         },
         async loadContent() {
-            console.log("Generating Refine declarations...");
-            return await handleDocgen();
+            if (!process.env.DISABLE_DOCGEN) {
+                console.log("Generating Refine declarations...");
+                return await handleDocgen();
+            }
+
+            return {};
         },
         configureWebpack(config) {
             return {
@@ -342,28 +346,30 @@ export default function plugin(): Plugin<DocgenContent> {
             };
         },
         async contentLoaded({ content, actions }): Promise<void> {
-            console.log("Creating Refine declaration files...");
+            if (!process.env.DISABLE_DOCGEN) {
+                console.log("Creating Refine declaration files...");
 
-            const { createData } = actions;
+                const { createData } = actions;
 
-            const data: Promise<string>[] = [];
+                const data: Promise<string>[] = [];
 
-            Object.entries(content).forEach(
-                ([packageName, packageDeclarations]) => {
-                    Object.entries(packageDeclarations).forEach(
-                        ([componentName, declaration]) => {
-                            data.push(
-                                createData(
-                                    `${packageName}/${componentName}.json`,
-                                    JSON.stringify(declaration),
-                                ),
-                            );
-                        },
-                    );
-                },
-            );
+                Object.entries(content).forEach(
+                    ([packageName, packageDeclarations]) => {
+                        Object.entries(packageDeclarations).forEach(
+                            ([componentName, declaration]) => {
+                                data.push(
+                                    createData(
+                                        `${packageName}/${componentName}.json`,
+                                        JSON.stringify(declaration),
+                                    ),
+                                );
+                            },
+                        );
+                    },
+                );
 
-            await Promise.all(data);
+                await Promise.all(data);
+            }
         },
     };
 }

--- a/documentation/src/hooks/use-dynamic-import.ts
+++ b/documentation/src/hooks/use-dynamic-import.ts
@@ -38,7 +38,7 @@ export const useDynamicImport = (
                     setProps(props.default);
                 }
             })
-            .catch(console.error);
+            .catch(console.warn);
 
         return () => {
             resolved = true;

--- a/documentation/src/theme/Navbar/Logo/index.js
+++ b/documentation/src/theme/Navbar/Logo/index.js
@@ -12,8 +12,8 @@ export default function NavbarLogo({ className, ...props }) {
                         ? className
                         : "select-none mx-auto pr-6 lg:ml-0 lg:mr-2 lg:pr-0 items-center flex min-w-[110px] max-w-[110px]"
                 }
-                imageClassName="navbar__logo"
-                titleClassName="navbar__title text--truncate"
+                // imageClassName="navbar__logo"
+                // titleClassName="navbar__title text--truncate"
                 {...props}
             />
         </Link>


### PR DESCRIPTION
Added an env flag `DISABLE_DOCGEN` for disabling docgen script to run on dev mode which was slowing down the whole process. Also updated the dynamic import hook for a better catch condition