### PR TITLE
fix(material-ui): fix missing header export

### DIFF
--- a/.changeset/sixty-bikes-sit.md
+++ b/.changeset/sixty-bikes-sit.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": patch
+---
+
+fix(material-ui): fix missing `<Header />` component export

--- a/packages/mui/src/components/index.tsx
+++ b/packages/mui/src/components/index.tsx
@@ -2,6 +2,7 @@
 export { Layout } from "./layout";
 export { Sider } from "./layout/sider";
 export { Title } from "./layout/title";
+export { Header } from "./layout/header";
 
 // Pages
 export { LoginPage, ReadyPage, ErrorComponent, AuthPage } from "./pages";


### PR DESCRIPTION
This is a fix for issue #2631 which was preventing me from importing the Header component into a custom layout.