### PR TITLE
feat(docs): add props table to `useSelect()` docs

### DIFF
--- a/documentation/docs/api-reference/core/hooks/useSelect.md
+++ b/documentation/docs/api-reference/core/hooks/useSelect.md
@@ -31,16 +31,16 @@ We'll demonstrate how to get data at `/categories` endpoint from `https://api.fa
 }
 ```
 
-```tsx  title="pages/posts/create.tsx"
+```tsx title="pages/posts/create.tsx"
 // highlight-next-line
 import { useSelect } from "@pankod/refine-core";
 
 export const DummyList = () => {
-// highlight-start
+    // highlight-start
     const { options } = useSelect<ICategory>({
         resource: "categories",
     });
-// highlight-end
+    // highlight-end
 
     return (
         <select>
@@ -80,7 +80,7 @@ const { options } = useSelect({
 ```tsx
 const { options } = useSelect({
     resource: "categories",
-// highlight-next-line
+    // highlight-next-line
     defaultValue: "1",
 });
 ```
@@ -102,10 +102,10 @@ Can use `defaultValue` property when edit a record in `Edit` page.
 ```tsx
 const { options } = useSelect({
     resource: "categories",
-// highlight-start
+    // highlight-start
     optionLabel: "title",
     optionValue: "id",
-// highlight-end
+    // highlight-end
 });
 ```
 
@@ -118,12 +118,13 @@ Supports use with `optionLabel` and `optionValue` [Object path](https://lodash.c
 ```tsx
 const { options } = useSelect({
     resource: "categories",
-// highlight-start
+    // highlight-start
     optionLabel: "nested.title",
     optionValue: "nested.id",
-// highlight-end
+    // highlight-end
 });
 ```
+
 :::
 
 ### `filters`
@@ -131,7 +132,7 @@ const { options } = useSelect({
 ```tsx
 const { options } = useSelect({
     resource: "categories",
-// highlight-start
+    // highlight-start
     filters: [
         {
             field: "isActive",
@@ -139,7 +140,7 @@ const { options } = useSelect({
             value: true,
         },
     ],
-// highlight-end
+    // highlight-end
 });
 ```
 
@@ -150,14 +151,14 @@ It allows us to add some filters while fetching the data. For example, if you wa
 ```tsx
 const { options } = useSelect({
     resource: "categories",
-// highlight-start
+    // highlight-start
     sort: [
         {
             field: "title",
             order: "asc",
         },
     ],
-// highlight-end
+    // highlight-end
 });
 ```
 
@@ -168,7 +169,7 @@ It allows us to sort the `options`. For example, if you want to sort your list a
 ```tsx
 const { options } = useSelect({
     resource: "categories",
-// highlight-next-line
+    // highlight-next-line
     fetchSize: 20,
 });
 ```
@@ -182,7 +183,7 @@ It allows us to `AutoComplete` the `options`.
 ```tsx
 const { options } = useSelect({
     resource: "categories",
-// highlight-start
+    // highlight-start
     onSearch: (value) => [
         {
             field: "title",
@@ -190,7 +191,7 @@ const { options } = useSelect({
             value,
         },
     ],
-// highlight-end
+    // highlight-end
 });
 ```
 
@@ -202,16 +203,16 @@ If defined, it allows us to override the filters to use when fetching list of re
 
 ### `queryOptions`
 
-```tsx 
+```tsx
 const { options } = useSelect({
     resource: "categories",
-// highlight-start
+    // highlight-start
     queryOptions: {
         onError: () => {
             console.log("triggers when on query return Error");
         },
     },
-// highlight-end
+    // highlight-end
 });
 ```
 
@@ -224,13 +225,13 @@ When the `defaultValue` property is given, the `useMany` data hook is called for
 ```tsx
 const { options } = useSelect({
     resource: "categories",
-// highlight-start
+    // highlight-start
     defaultValueQueryOptions: {
         onSuccess: (data) => {
             console.log("triggers when on query return on success");
         },
     },
-// highlight-end
+    // highlight-end
 });
 ```
 
@@ -240,24 +241,7 @@ const { options } = useSelect({
 
 ### Properties
 
-| Property                                                     | Description                                                                                                                                                        | Type                                                                           | Default     |
-| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ | ----------- |
-| resource <div className="required">Required</div>            | Resource name for API data interactions                                                                                                                            | `string`                                                                       |             |
-| defaultValue                                                 | Adds extra `options`                                                                                                                                               | [`BaseKey`](/api-reference/core/interfaces.md#basekey)  \| [`BaseKey[]`](/api-reference/core/interfaces.md#basekey)                                                    |             |
-| optionValue                                                  | Set the option's value                                                                                                                                             | `string`                                                                       | `"id"`      |
-| optionLabel                                                  | Set the option's label value                                                                                                                                       | `string`                                                                       | `"title"`   |
-| filters                                                      | Add filters while fetching the data                                                                                                                                | [`CrudFilters`](/api-reference/core/interfaces.md#crudfilters)                               |             |
-| sort                                                         | Allow us to sort the options                                                                                                                                       | [`CrudSorting`](/api-reference/core/interfaces.md#crudsorting)                               |             |
-| debounce                                                     | The number of milliseconds to delay                                                                                                                                | `number`                                                                       | 300         |
-| queryOptions                                                 | react-query [useQuery](https://react-query.tanstack.com/reference/useQuery) options                                                                                | ` UseQueryOptions<GetListResponse<TData>, TError>`                             |             |
-| defaultValueQueryOptions                                     | react-query [useQuery](https://react-query.tanstack.com/reference/useQuery) options                                                                                | ` UseQueryOptions<GetManyResponse<TData>, TError>`                             |             |
-| fetchSize                                                    | Amount of records to fetch in select box list.                                                                                                                     | `number`                                                                       | `undefined` |
-| onSearch                                                     | If defined, this callback allows us to override all filters for every search request.                                                                              | `(value: string) => CrudFilters `\|` Promise<CrudFilters>`                     | `undefined` |
-| metaData                                                     | Metadata query for `dataProvider`                                                                                                                                  | [`MetaDataQuery`](/api-reference/core/interfaces.md#metadataquery)                           | {}          |
-| dataProviderName                                             | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.                                                                 | `string`                                                                       | `default`   |
-| [liveMode](/api-reference/core/providers/live-provider.md#usage-in-a-hook) | Whether to update data automatically (`"auto"`) or not (`"manual"`) if a related live event is received. The "off" value is used to avoid creating a subscription. | [`"auto"` \| `"manual"` \| `"off"`](/api-reference/core/interfaces.md#livemodeprops)         | `"off"`     |
-| liveParams                                                   | Params to pass to `liveProvider`'s `subscribe` method if `liveMode` is enabled.                                                                                    | [`{ ids?: BaseKey[]; [key: string]: any; }`](/api-reference/core/interfaces.md#livemodeprops) | `undefined` |
-| onLiveEvent                                                  | Callback to handle all related live events of this hook.                                                                                                           | [`(event: LiveEvent) => void`](/api-reference/core/interfaces.md#livemodeprops)              | `undefined` |
+<PropsTable module="@pankod/refine-core/useSelect"  />
 
 ### Return values
 

--- a/documentation/plugins/docgen.js
+++ b/documentation/plugins/docgen.js
@@ -123,6 +123,19 @@ const getPackageNamePathMap = async (directory) => {
     const packages = await _fsextra2.default.readdir(directory);
     const packageNamePathMap = {};
 
+    const includedPackages =
+        _optionalChain([
+            process,
+            "access",
+            (_2) => _2.env,
+            "access",
+            (_3) => _3.INCLUDED_PACKAGES,
+            "optionalAccess",
+            (_4) => _4.split,
+            "call",
+            (_5) => _5(","),
+        ]) || [];
+
     await Promise.all(
         packages.map(async (packageName) => {
             const packagePath = _path2.default.join(
@@ -136,10 +149,15 @@ const getPackageNamePathMap = async (directory) => {
                     packagePath,
                 );
 
-                packageNamePathMap[packageJson.name] = _path2.default.join(
-                    packagePath,
-                    "..",
-                );
+                if (
+                    includedPackages.length == 0 ||
+                    includedPackages.some((p) => packageName.includes(p))
+                ) {
+                    packageNamePathMap[packageJson.name] = _path2.default.join(
+                        packagePath,
+                        "..",
+                    );
+                }
             }
 
             return packageName;
@@ -386,11 +404,11 @@ function plugin() {
                             _optionalChain([
                                 config,
                                 "access",
-                                (_2) => _2.resolve,
+                                (_6) => _6.resolve,
                                 "optionalAccess",
-                                (_3) => _3.alias,
+                                (_7) => _7.alias,
                                 "optionalAccess",
-                                (_4) => _4["@generated"],
+                                (_8) => _8["@generated"],
                             ]),
                             "docusaurus-plugin-refine-docgen",
                             "default",

--- a/documentation/plugins/docgen.js
+++ b/documentation/plugins/docgen.js
@@ -107,6 +107,15 @@ const replacementProps = {
         "(value: DeleteOneResponse) => void",
     "{ [key: string]: any; ids?: BaseKey[]; }":
         "{ [key]: any; ids?: BaseKey[]; }",
+    "BaseKey | BaseKey[]":
+        "[BaseKey](/docs/api-reference/core/interfaceReferences/#basekey) | [BaseKey[]](/docs/api-reference/core/interfaceReferences/#basekey)",
+    BaseKey: "[BaseKey](/docs/api-reference/core/interfaceReferences/#basekey)",
+    MetaDataQuery:
+        "[MetaDataQuery](/docs/api-reference/core/interfaceReferences/#metadataquery)",
+    CrudFilters:
+        "[CrudFilters](/docs/api-reference/core/interfaceReferences/#crudfilters)",
+    CrudSorting:
+        "[CrudSorting](/docs/api-reference/core/interfaceReferences/#crudsorting)",
 };
 
 /** HELPERS */
@@ -233,6 +242,12 @@ const createParser = (configPath) => {
     return docgenParser;
 };
 
+const normalizeMarkdownLinks = (value) => {
+    return value.replace(/\[(.*?)\]\s{1}\((.*?)\)/g, (_, p1, p2) => {
+        return `[${p1}](${p2})`;
+    });
+};
+
 const prepareDeclaration = (declaration) => {
     const data = { ...declaration };
     delete data.methods;
@@ -241,6 +256,10 @@ const prepareDeclaration = (declaration) => {
     data.generatedAt = Date.now();
 
     Object.keys(data.props).forEach((prop) => {
+        data.props[prop].type.name = normalizeMarkdownLinks(
+            data.props[prop].type.name,
+        );
+
         delete data.props[prop].parent;
         delete data.props[prop].declarations;
 
@@ -367,11 +386,11 @@ function plugin() {
                             _optionalChain([
                                 config,
                                 "access",
-                                (_) => _.resolve,
+                                (_2) => _2.resolve,
                                 "optionalAccess",
-                                (_2) => _2.alias,
+                                (_3) => _3.alias,
                                 "optionalAccess",
-                                (_3) => _3["@generated"],
+                                (_4) => _4["@generated"],
                             ]),
                             "docusaurus-plugin-refine-docgen",
                             "default",

--- a/documentation/plugins/docgen.ts
+++ b/documentation/plugins/docgen.ts
@@ -84,6 +84,15 @@ const replacementProps: Record<string, string> = {
         "(value: DeleteOneResponse) => void",
     "{ [key: string]: any; ids?: BaseKey[]; }":
         "{ [key]: any; ids?: BaseKey[]; }",
+    "BaseKey | BaseKey[]":
+        "[BaseKey](/docs/api-reference/core/interfaceReferences/#basekey) | [BaseKey[]](/docs/api-reference/core/interfaceReferences/#basekey)",
+    BaseKey: "[BaseKey](/docs/api-reference/core/interfaceReferences/#basekey)",
+    MetaDataQuery:
+        "[MetaDataQuery](/docs/api-reference/core/interfaceReferences/#metadataquery)",
+    CrudFilters:
+        "[CrudFilters](/docs/api-reference/core/interfaceReferences/#crudfilters)",
+    CrudSorting:
+        "[CrudSorting](/docs/api-reference/core/interfaceReferences/#crudsorting)",
 };
 
 /** HELPERS */

--- a/documentation/plugins/docgen.ts
+++ b/documentation/plugins/docgen.ts
@@ -100,6 +100,8 @@ const getPackageNamePathMap = async (directory: string) => {
     const packages = await fs.readdir(directory);
     const packageNamePathMap: Record<string, string> = {};
 
+    const includedPackages = process.env.INCLUDED_PACKAGES?.split(",") || [];
+
     await Promise.all(
         packages.map(async (packageName) => {
             const packagePath = path.join(
@@ -111,10 +113,15 @@ const getPackageNamePathMap = async (directory: string) => {
             if (fs.existsSync(packagePath)) {
                 const packageJson = await fs.readJSON(packagePath);
 
-                packageNamePathMap[packageJson.name] = path.join(
-                    packagePath,
-                    "..",
-                );
+                if (
+                    includedPackages.length == 0 ||
+                    includedPackages.some((p) => packageName.includes(p))
+                ) {
+                    packageNamePathMap[packageJson.name] = path.join(
+                        packagePath,
+                        "..",
+                    );
+                }
             }
 
             return packageName;

--- a/documentation/plugins/docgen.ts
+++ b/documentation/plugins/docgen.ts
@@ -206,6 +206,12 @@ const createParser = (configPath: string) => {
     return docgenParser;
 };
 
+const normalizeMarkdownLinks = (value: string) => {
+    return value.replace(/\[(.*?)\]\s{1}\((.*?)\)/g, (_, p1, p2) => {
+        return `[${p1}](${p2})`;
+    });
+};
+
 const prepareDeclaration = (declaration: ComponentDoc) => {
     const data: DeclarationType = { ...declaration };
     delete data.methods;
@@ -214,6 +220,10 @@ const prepareDeclaration = (declaration: ComponentDoc) => {
     data.generatedAt = Date.now();
 
     Object.keys(data.props).forEach((prop) => {
+        data.props[prop].type.name = normalizeMarkdownLinks(
+            data.props[prop].type.name,
+        );
+
         delete data.props[prop].parent;
         delete data.props[prop].declarations;
 

--- a/documentation/src/components/props-table/index.tsx
+++ b/documentation/src/components/props-table/index.tsx
@@ -82,7 +82,9 @@ const Type = ({
 
     return (
         <>
-            {hasLongTypeInUnion && isUnion ? (
+            {hasBackticks ? (
+                <ReactMarkdown>{typeDef}</ReactMarkdown>
+            ) : hasLongTypeInUnion && isUnion ? (
                 <>
                     {splitted.map((t, i) => (
                         <code className="max-w-xs h-min" key={i}>
@@ -90,8 +92,6 @@ const Type = ({
                         </code>
                     ))}
                 </>
-            ) : hasBackticks ? (
-                <ReactMarkdown>{typeDef}</ReactMarkdown>
             ) : (
                 <code className="max-w-xs h-min">
                     <ReactMarkdown>{typeDef}</ReactMarkdown>

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -20,18 +20,64 @@ import {
 } from "../../interfaces";
 
 export type UseSelectProps<TData, TError> = {
+    /**
+     * Resource name for API data interactions
+     */
     resource: string;
+    /**
+     * Set the option's value
+     * @default `"title"`
+     */
     optionLabel?: string;
+    /**
+     * Set the option's label value
+     * @default `"id"`
+     */
     optionValue?: string;
+    /**
+     * Allow us to sort the options
+     */
     sort?: CrudSorting;
+    /**
+     * Resource name for API data interactions
+     */
     filters?: CrudFilters;
+    /**
+     * Adds extra `options`
+     */
     defaultValue?: BaseKey | BaseKey[];
+    /**
+     * The number of milliseconds to delay
+     * @default `300`
+     */
     debounce?: number;
+    /**
+     * react-query [useQuery](https://react-query.tanstack.com/reference/useQuery) options
+     */
     queryOptions?: UseQueryOptions<GetListResponse<TData>, TError>;
+    /**
+     * Amount of records to fetch in select box list.
+     * @default `undefined`
+     */
     fetchSize?: number;
+    /**
+     * react-query [useQuery](https://react-query.tanstack.com/reference/useQuery) options
+     */
     defaultValueQueryOptions?: UseQueryOptions<GetManyResponse<TData>, TError>;
+    /**
+     * If defined, this callback allows us to override all filters for every search request.
+     * @default `undefined`
+     */
     onSearch?: (value: string) => CrudFilters;
+    /**
+     * Metadata query for `dataProvider`
+     * @default `{}`
+     */
     metaData?: MetaDataQuery;
+    /**
+     * If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.
+     * @default `default`
+     */
     dataProviderName?: string;
 } & SuccessErrorNotification &
     LiveModeProps;

--- a/packages/core/src/interfaces/live/LiveModeProps.ts
+++ b/packages/core/src/interfaces/live/LiveModeProps.ts
@@ -3,15 +3,21 @@ import { BaseKey } from "..";
 
 export type LiveModeProps = {
     /**
-     * Live interaction mode to be used when `liveProvider` is set in `Refine` component
+     * Whether to update data automatically ("auto") or not ("manual") if a related live event is received. The "off" value is used to avoid creating a subscription.
+     * @type  [`"auto" | "manual" | "off"`](/docs/api-reference/core/interfaceReferences/#crudsorting)
+     * @default `"off"`
      */
     liveMode?: "auto" | "manual" | "off";
     /**
-     * Callback function to be called when a related subscription is triggered
+     * Callback to handle all related live events of this hook.
+     * @type [`(event: LiveEvent) => void`](/docs/api-reference/core/interfaceReferences/#livemodeprops)
+     * @default `undefined`
      */
     onLiveEvent?: (event: LiveEvent) => void;
     /**
-     * Additional props to be passed to the live provider subscription
+     * Params to pass to liveProvider's subscribe method if liveMode is enabled.
+     * @type [`{ ids?: BaseKey[]; [key: string]: any; }`](/docs/api-reference/core/interfaceReferences/#livemodeprops)
+     * @default `undefined`
      */
     liveParams?: {
         ids?: BaseKey[];


### PR DESCRIPTION
1. <PropsTable/> added to useSelect doc. [Example page](https://refine.dev/docs/api-reference/core/hooks/useSelect/#properties)
2. [docusaurus](https://docusaurus.io/) don't have cache mechanicsm. because of that hot reload times are very long. To solve this problem, we wrote a function where we can filter out packages we don't need.  Kudos to @aliemir 🚀 .
Simply add the packages you need to the env. Only the ones you need will be built in the hot reload. 
`INCLUDED_PACKAGES=antd,core,ui-types npm run start:docs`




-   [ ] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [ ] Changesets are provided or not needed
