### PR TITLE
fix: react-table export type

### DIFF
--- a/.changeset/fuzzy-elephants-notice.md
+++ b/.changeset/fuzzy-elephants-notice.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-react-table": patch
+---
+
+Fixed type exports for `UseTableProps` and `UseTableReturnType`.

--- a/packages/react-table/src/index.ts
+++ b/packages/react-table/src/index.ts
@@ -1,3 +1,4 @@
-export { useTable, UseTableProps, UseTableReturnType } from "./useTable";
+export { useTable } from "./useTable";
+export type { UseTableProps, UseTableReturnType } from "./useTable";
 
 export * from "@tanstack/react-table";


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:
 
`UseTableProps` and `UseTableReturnType` are exported as `type`. 

### Closing issues

Could potentially solve this problem -> https://discord.com/channels/837692625737613362/1027142928797286411

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
