### PR TITLE
feat(docs): add <PropsTable/> to core data hooks

### DIFF
--- a/documentation/docs/api-reference/core/hooks/data/useCreate.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCreate.md
@@ -5,16 +5,16 @@ siderbar_label: useCreate
 description: useCreate data hook from refine is a modified version of react-query's useMutation for create mutations
 ---
 
-`useCreate` is a modified version of `react-query`'s [`useMutation`](https://react-query.tanstack.com/reference/useMutation#) for create mutations. 
+`useCreate` is a modified version of `react-query`'s [`useMutation`](https://react-query.tanstack.com/reference/useMutation#) for create mutations.
 
 It uses `create` method as mutation function from the [`dataProvider`](/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
 ## Features
 
-* Shows notifications after the mutation succeeds or fails.
+-   Shows notifications after the mutation succeeds or fails.
 
-* Automatically invalidates the `list` queries after mutation is succesfully run.
-[Refer to React Query docs for detailed information &#8594](https://react-query.tanstack.com/guides/invalidations-from-mutations)
+-   Automatically invalidates the `list` queries after mutation is succesfully run.
+    [Refer to React Query docs for detailed information &#8594](https://react-query.tanstack.com/guides/invalidations-from-mutations)
 
 ## Usage
 
@@ -39,11 +39,11 @@ Let'say we have a resource named `categories`
 }
 ```
 
-```tsx 
+```tsx
 type CategoryMutationResult = {
     id: number;
     title: string;
-}
+};
 
 import { useCreate } from "@pankod/refine-core";
 
@@ -53,14 +53,14 @@ mutate({
     resource: "categories",
     values: {
         title: "New Category",
-    }
+    },
 });
 ```
 
 :::tip
 `mutate` can also accept lifecycle methods like `onSuccess` and `onError`.
 
-```tsx 
+```tsx
 mutate(
     {
         resource: "categories",
@@ -106,6 +106,7 @@ After the mutation runs, `categories` will be updated as below:
     ];
 }
 ```
+
 :::note
 Queries that use `/categories` endpoint will be automatically invalidated to show the updated data. For example, data returned from [useList](useList.md) will be automatically updated.
 :::
@@ -123,33 +124,33 @@ Variables passed to `mutate` must have these types.
     values: TVariables = {};
 }
 ```
+
 :::
 
 ## API
+
 ### Properties
 
-| Property                                                                                           | Description                                                                                        | Type                                                                       | Default                                                              |
-| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| <div className="required-block"><div>resource</div> <div className="required">Required</div></div> | Resource name for API data interactions                                                            | `string`                                                                   |                                                                      |
-| values  <div className=" required">Required</div>                                                  | Values for mutation function                                                                       | `TVariables`                                                               | {}                                                                   |
+| Property                                                                                           | Description                                                                                        | Type                                                                                     | Default                                                              |
+| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| <div className="required-block"><div>resource</div> <div className="required">Required</div></div> | Resource name for API data interactions                                                            | `string`                                                                                 |                                                                      |
+| values <div className=" required">Required</div>                                                   | Values for mutation function                                                                       | `TVariables`                                                                             | {}                                                                   |
 | successNotification                                                                                | Successful Mutation notification                                                                   | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification) | "Successfully created `resource`"                                    |
 | errorNotification                                                                                  | Unsuccessful Mutation notification                                                                 | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification) | "There was an error creating `resource` (status code: `statusCode`)" |
 | metaData                                                                                           | Metadata query for `dataProvider`                                                                  | [`MetaDataQuery`](/api-reference/core/interfaces.md#metadataquery)                       | {}                                                                   |
-| dataProviderName                                                                                   | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use. | `string`                                                                   | `default`                                                            |
-| invalidates                                                                                        | You can use it to manage the invalidations that will occur at the end of the mutation.             | `all`, `resourceAll`, `list`, `many`, `detail`, `false`                    | `["list", "many"]`                                                   |
+| dataProviderName                                                                                   | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use. | `string`                                                                                 | `default`                                                            |
+| invalidates                                                                                        | You can use it to manage the invalidations that will occur at the end of the mutation.             | `all`, `resourceAll`, `list`, `many`, `detail`, `false`                                  | `["list", "many"]`                                                   |
 
 ### Type Parameters
 
-
-| Property   | Desription                                                                          | Type                                           | Default                                        |
-| ---------- | ----------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| Property   | Desription                                                                                        | Type                                                         | Default                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | TData      | Result data of the mutation. Extends [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) |
 | TError     | Custom error object that extends [`HttpError`](/api-reference/core/interfaces.md#httperror)       | [`HttpError`](/api-reference/core/interfaces.md#httperror)   | [`HttpError`](/api-reference/core/interfaces.md#httperror)   |
-| TVariables | Values for mutation function                                                        | `{}`                                           | `{}`                                           |
+| TVariables | Values for mutation function                                                                      | `{}`                                                         | `{}`                                                         |
 
 ### Return value
 
-| Description                               | Type                                                                                                                                                                                   |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Result of the `react-query`'s useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>`  { resource: string; values: TVariables; },`<br/>` unknown>`](https://react-query.tanstack.com/reference/useMutation) |
-
+| Description                               | Type                                                                                                                                                                                  |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Result of the `react-query`'s useMutation | [`UseMutationResult<`<br/>`{ data: TData },`<br/>`TError,`<br/>` { resource: string; values: TVariables; },`<br/>` unknown>`](https://react-query.tanstack.com/reference/useMutation) |

--- a/documentation/docs/api-reference/core/hooks/data/useCustom.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCustom.md
@@ -60,23 +60,16 @@ const { data, isLoading } = useCustom<PostUniqueCheckResponse>({
 
 ### Properties
 
-| Property                                        | Description                                                                                                    | Type                                                                                                                                                           |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| url <div className="required">Required</div>    | URL                                                                                                            | string                                                                                                                                                         |
-| method <div className="required">Required</div> | Method                                                                                                         | `get`, `delete`, `head`, `options`, `post`, `put`, `patch`                                                                                                     |
-| config                                          | The config of your request. You can send `headers`, `payload`, `query`, `filters` and `sort` using this field. | { sort?: [CrudSorting](/api-reference/core/interfaces.md#crudsorting); filters?: [`CrudFilters`](/api-reference/core/interfaces.md#crudfilters); payload?: {}; query?: {}, headers?: {}; } |
-| queryOptions                                    | [useQuery Options](https://react-query.tanstack.com/reference/useQuery)                                        | object                                                                                                                                                         |
-| metaData                                        | Metadata query for `dataProvider`                                                                              | [`MetaDataQuery`](/api-reference/core/interfaces.md#metadataquery)                                                                                                           | {}        |
-| dataProviderName                                | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.             | `string`                                                                                                                                                       | `default` |
+<PropsTable module="@pankod/refine-core/useCustom" />
 
 ### Type Parameters
 
-| Property | Desription                                                                       | Type                                           | Default                                        |
-| -------- | -------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| Property | Desription                                                                                     | Type                                                         | Default                                                      |
+| -------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | TData    | Result data of the query. Extends [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) |
 | TError   | Custom error object that extends [`HttpError`](/api-reference/core/interfaces.md#httperror)    | [`HttpError`](/api-reference/core/interfaces.md#httperror)   | [`HttpError`](/api-reference/core/interfaces.md#httperror)   |
-| TQuery   | Values for query params.                                                         | `TQuery`                                       | unknown                                        |
-| TPayload | Values for params.                                                               | `TPayload`                                     | unknown                                        |
+| TQuery   | Values for query params.                                                                       | `TQuery`                                                     | unknown                                                      |
+| TPayload | Values for params.                                                                             | `TPayload`                                                   | unknown                                                      |
 
 ### Return value
 

--- a/documentation/docs/api-reference/core/hooks/data/useDataProvider.md
+++ b/documentation/docs/api-reference/core/hooks/data/useDataProvider.md
@@ -3,7 +3,7 @@ id: useDataProvider
 title: useDataProvider
 ---
 
-`useDataProvider` lets you access the `dataProvider` that was configured in [`<Refine>`][Refine] component.
+`useDataProvider` lets you access the `dataProvider` that was configured in [`<Refine>`][refine] component.
 
 This hook is useful when you need to access the `dataProvider` [Data Provider] from a child component.
 
@@ -36,20 +36,20 @@ export default App;
 ```
 
 Now we can access the `default` data provider from a child component:
+
 ```tsx
 import {
     // highlight-next-line
-    useDataProvider
+    useDataProvider,
 } from "@pankod/refine-core";
 
 // highlight-start
 const dataProvider = useDataProvider();
 
-const defaultDataProvider= dataProvider(); // return default data provider
-const secondDataProvider= dataProvider("second"); // return second data provider
+const defaultDataProvider = dataProvider(); // return default data provider
+const secondDataProvider = dataProvider("second"); // return second data provider
 // highlight-end
 ```
-
 
 ## API
 
@@ -61,9 +61,9 @@ const secondDataProvider= dataProvider("second"); // return second data provider
 
 ### Return value
 
-| Description   | Type                                                |
-| ------------- | --------------------------------------------------- |
+| Description   | Type                                                              |
+| ------------- | ----------------------------------------------------------------- |
 | Data Provider | [`Data Provider`](/api-reference/core/providers/data-provider.md) |
 
-[Refine]: /api-reference/core/components/refine-config.md
-[Data Provider]: /api-reference/core/providers/data-provider.md
+[refine]: /api-reference/core/components/refine-config.md
+[data provider]: /api-reference/core/providers/data-provider.md

--- a/documentation/docs/api-reference/core/hooks/data/useDelete.md
+++ b/documentation/docs/api-reference/core/hooks/data/useDelete.md
@@ -37,7 +37,7 @@ Let's say that we have a resource named `categories`.
 }
 ```
 
-```tsx 
+```tsx
 import { useDelete } from "@pankod/refine-core";
 
 const { mutate } = useDelete();
@@ -51,7 +51,7 @@ mutate({
 :::tip
 `mutate` can also accept lifecycle methods like `onSuccess` and `onError`.
 
-```tsx 
+```tsx
 mutate(
     {
         resource: "categories",
@@ -174,18 +174,18 @@ After 7.5 seconds the mutation will be executed. The mutation can be cancelled w
 
 ### Properties
 
-| Property                                                                                            | Description                                                                                        | Type                                                                       | Default                             |
-| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ----------------------------------- |
-| <div className="required-block"><div>resource</div> <div className=" required">Required</div></div> | Resource name for API data interactions                                                            | `string`                                                                   |                                     |
+| Property                                                                                            | Description                                                                                        | Type                                                                                     | Default                             |
+| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------- |
+| <div className="required-block"><div>resource</div> <div className=" required">Required</div></div> | Resource name for API data interactions                                                            | `string`                                                                                 |                                     |
 | id <div className=" required">Required</div>                                                        | id for mutation function                                                                           | [`BaseKey`](/api-reference/core/interfaces.md#basekey)                                   |                                     |
-| mutationMode                                                                                        | [Determines when mutations are executed](/advanced-tutorials/mutation-mode.md)                    | ` "pessimistic` \| `"optimistic` \| `"undoable"`                           | `"pessimistic"`\*                   |
-| undoableTimeout                                                                                     | Duration to wait before executing the mutation when `mutationMode = "undoable"`                    | `number`                                                                   | `5000ms`\*                          |
-| onCancel                                                                                            | Callback that runs when undo button is clicked on `mutationMode = "undoable"`                      | `(cancelMutation: () => void) => void`                                     |                                     |
+| mutationMode                                                                                        | [Determines when mutations are executed](/advanced-tutorials/mutation-mode.md)                     | ` "pessimistic` \| `"optimistic` \| `"undoable"`                                         | `"pessimistic"`\*                   |
+| undoableTimeout                                                                                     | Duration to wait before executing the mutation when `mutationMode = "undoable"`                    | `number`                                                                                 | `5000ms`\*                          |
+| onCancel                                                                                            | Callback that runs when undo button is clicked on `mutationMode = "undoable"`                      | `(cancelMutation: () => void) => void`                                                   |                                     |
 | successNotification                                                                                 | Successful Mutation notification                                                                   | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification) | "Successfully deleted a `resource`" |
 | errorNotification                                                                                   | Unsuccessful Mutation notification                                                                 | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification) | "Error (status code: `status`"      |
 | metaData                                                                                            | Metadata query for `dataProvider`                                                                  | [`MetaDataQuery`](/api-reference/core/interfaces.md#metadataquery)                       | {}                                  |
-| dataProviderName                                                                                    | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use. | `string`                                                                   | `default`                           |
-| invalidates                                                                                         | You can use it to manage the invalidations that will occur at the end of the mutation.             | `all`, `resourceAll`, `list`, `many`, `detail`, `false`                    | `["list", "many"]`                  |
+| dataProviderName                                                                                    | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use. | `string`                                                                                 | `default`                           |
+| invalidates                                                                                         | You can use it to manage the invalidations that will occur at the end of the mutation.             | `all`, `resourceAll`, `list`, `many`, `detail`, `false`                                  | `["list", "many"]`                  |
 
 > `*`: These props have default values in `RefineContext` and can also be set on **<[Refine](/api-reference/core/components/refine-config.md)>** component. `useDelete` will use what is passed to `<Refine>` as default but a local value will override it.
 
@@ -193,11 +193,11 @@ After 7.5 seconds the mutation will be executed. The mutation can be cancelled w
 
 ### Type Parameters
 
-| Property   | Desription                                                                          | Type                                           | Default                                        |
-| ---------- | ----------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| Property   | Desription                                                                                        | Type                                                         | Default                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | TData      | Result data of the mutation. Extends [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) |
 | TError     | Custom error object that extends [`HttpError`](/api-reference/core/interfaces.md#httperror)       | [`HttpError`](/api-reference/core/interfaces.md#httperror)   | [`HttpError`](/api-reference/core/interfaces.md#httperror)   |
-| TVariables | Values for mutation function                                                        | `{}`                                           | `{}`                                           |
+| TVariables | Values for mutation function                                                                      | `{}`                                                         | `{}`                                                         |
 
 ### Return value
 

--- a/documentation/docs/api-reference/core/hooks/data/useList.md
+++ b/documentation/docs/api-reference/core/hooks/data/useList.md
@@ -255,18 +255,10 @@ const postListQueryResult = useList<IPost>({
 
 ### Properties
 
-| Property                                                                                           | Description                                                                                                                                                        | Type                                                                            |
-| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- | ----------------------------------- |
-| <div className="required-block"><div>resource</div> <div className="required">Required</div></div> | Resource name for API data interactions                                                                                                                            | `string`                                                                        |
-| config                                                                                             | Configuration for pagination, sorting and filtering                                                                                                                | [`UseListConfig`](#config-parameters)                                           |                                     |
-| queryOptions                                                                                       | `react-query`'s `useQuery` options                                                                                                                                 | ` UseQueryOptions<`<br/>`{ data: TData[]; },`<br/>`TError>`                     |
-| successNotification                                                                                | Successful Query notification                                                                                                                                      | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification)      | `false`                             |
-| errorNotification                                                                                  | Unsuccessful Query notification                                                                                                                                    | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification)      | "Error (status code: `statusCode`)" |
-| metaData                                                                                           | Metadata query for `dataProvider`                                                                                                                                  | [`MetaDataQuery`](/api-reference/core/interfaces.md#metadataquery)                            | {}                                  |
-| dataProviderName                                                                                   | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.                                                                 | `string`                                                                        | `default`                           |
-| [liveMode](/api-reference/core/providers/live-provider.md#usage-in-a-hook)                                       | Whether to update data automatically (`"auto"`) or not (`"manual"`) if a related live event is received. The "off" value is used to avoid creating a subscription. | [`"auto"` \| `"manual"` \| `"off"`](/api-reference/core/interfaces.md#livemodeprops)          | `"off"`                             |
-| liveParams                                                                                         | Params to pass to `liveProvider`'s `subscribe` method if `liveMode` is enabled.                                                                                    | [`{ ids?: BaseKey[]; [key: string]: any; }`](/api-reference/core/interfaces.md#livemodeprops) | `undefined`                         |
-| onLiveEvent                                                                                        | Callback to handle all related live events of this hook.                                                                                                           | [`(event: LiveEvent) => void`](/api-reference/core/interfaces.md#livemodeprops)               | `undefined`                         |
+<PropsTable module="@pankod/refine-core/useList" 
+successNotification-default='`false`'
+errorNotification-default='"Error (status code: `statusCode`)"'
+/>
 
 ### Config parameters
 
@@ -291,8 +283,8 @@ interface UseListConfig {
 
 ### Type Parameters
 
-| Property | Desription                                                                       | Type                                           | Default                                        |
-| -------- | -------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| Property | Desription                                                                                     | Type                                                         | Default                                                      |
+| -------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | TData    | Result data of the query. Extends [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) |
 | TError   | Custom error object that extends [`HttpError`](/api-reference/core/interfaces.md#httperror)    | [`HttpError`](/api-reference/core/interfaces.md#httperror)   | [`HttpError`](/api-reference/core/interfaces.md#httperror)   |
 

--- a/documentation/docs/api-reference/core/hooks/data/useMany.md
+++ b/documentation/docs/api-reference/core/hooks/data/useMany.md
@@ -32,7 +32,7 @@ Let's say that we have a resource named `categories`.
 }
 ```
 
-```tsx 
+```tsx
 import { useMany } from "@pankod/refine-core";
 
 type ICategory = {
@@ -90,23 +90,15 @@ After query runs, the `categoryQueryResult` will include the retrieved data:
 
 ### Properties
 
-| Property                                                                                            | Description                                                                                                                                                        | Type                                                                           | Default                             |
-| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ | ----------------------------------- |
-| <div className="required-block"><div>resource</div> <div className=" required">Required</div></div> | Resource name for API data interactions                                                                                                                            | `string`                                                                       |                                     |
-| ids <div className="required">Required</div>                                                        | ids of the item in the resource                                                                                                                                    | [`BaseKey[]`](/api-reference/core/interfaces.md#basekey)                                                                      |                                     |
-| queryOptions                                                                                        | `react-query`'s `useQuery` options                                                                                                                                 | ` UseQueryOptions<`<br/>`{ data: TData[]; },`<br/>`TError>`                    |                                     |
-| successNotification                                                                                 | Successful Query notification                                                                                                                                      | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification)     | `false`                             |
-| errorNotification                                                                                   | Unsuccessful Query notification                                                                                                                                    | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification)     | "Error (status code: `statusCode`)" |
-| metaData                                                                                            | Metadata query for `dataProvider`                                                                                                                                  | [`MetaDataQuery`](/api-reference/core/interfaces.md#metadataquery)                           | {}                                  |
-| dataProviderName                                                                                    | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.                                                                 | `string`                                                                       | `default`                           |
-| [liveMode](/api-reference/core/providers/live-provider.md#usage-in-a-hook)                                        | Whether to update data automatically (`"auto"`) or not (`"manual"`) if a related live event is received. The "off" value is used to avoid creating a subscription. | [`"auto"` \| `"manual"` \| `"off"`](/api-reference/core/interfaces.md#livemodeprops)         | `"off"`                             |
-| liveParams                                                                                          | Params to pass to `liveProvider`'s `subscribe` method if `liveMode` is enabled.                                                                                    | [`{ ids?: BaseKey[]; [key: string]: any; }`](/api-reference/core/interfaces.md#livemodeprops) | `undefined`                         |
-| onLiveEvent                                                                                         | Callback to handle all related live events of this hook.                                                                                                           | [`(event: LiveEvent) => void`](/api-reference/core/interfaces.md#livemodeprops)              | `undefined`                         |
+<PropsTable module="@pankod/refine-core/useMany" 
+successNotification-default='`false`'
+errorNotification-default='"Error (status code: `statusCode`)"'
+/>
 
 ### Type Parameters
 
-| Property | Desription                                                                       | Type                                           | Default                                        |
-| -------- | -------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| Property | Desription                                                                                     | Type                                                         | Default                                                      |
+| -------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | TData    | Result data of the query. Extends [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) |
 | TError   | Custom error object that extends [`HttpError`](/api-reference/core/interfaces.md#httperror)    | [`HttpError`](/api-reference/core/interfaces.md#httperror)   | [`HttpError`](/api-reference/core/interfaces.md#httperror)   |
 

--- a/documentation/docs/api-reference/core/hooks/data/useOne.md
+++ b/documentation/docs/api-reference/core/hooks/data/useOne.md
@@ -28,7 +28,7 @@ Let's say that we have a resource named `posts`.
 }
 ```
 
-```tsx 
+```tsx
 import { useOne } from "@pankod/refine-core";
 
 type ICategory = {
@@ -82,23 +82,15 @@ After query runs, the `categoryQueryResult` will include the retrieved data:
 
 ### Properties
 
-| Property                                                                                            | Description                                                                                                                                                        | Type                                                                           | Default                             |
-| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ | ----------------------------------- |
-| <div className="required-block"><div>resource</div> <div className=" required">Required</div></div> | Resource name for API data interactions                                                                                                                            | `string`                                                                       |                                     |
-| id <div className="required">Required</div>                                                         | id of the item in the resource                                                                                                                                     | [`BaseKey`](/api-reference/core/interfaces.md#basekey)                                                                       |                                     |
-| queryOptions                                                                                        | `react-query`'s `useQuery` options                                                                                                                                 | ` UseQueryOptions<`<br/>`{ data: TData; },`<br/>`TError>`                      |                                     |
-| successNotification                                                                                 | Successful Query notification                                                                                                                                      | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification)     | `false`                             |
-| errorNotification                                                                                   | Unsuccessful Query notification                                                                                                                                    | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification)     | "Error (status code: `statusCode`)" |
-| metaData                                                                                            | Metadata query for `dataProvider`                                                                                                                                  | [`MetaDataQuery`](/api-reference/core/interfaces.md#metadataquery)                           | {}                                  |
-| dataProviderName                                                                                    | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.                                                                 | `string`                                                                       | `default`                           |
-| [liveMode](/api-reference/core/providers/live-provider.md#usage-in-a-hook)                                        | Whether to update data automatically (`"auto"`) or not (`"manual"`) if a related live event is received. The "off" value is used to avoid creating a subscription. | [`"auto"` \| `"manual"` \| `"off"`](/api-reference/core/interfaces.md#livemodeprops)         | `"off"`                             |
-| liveParams                                                                                          | Params to pass to `liveProvider`'s `subscribe` method if `liveMode` is enabled.                                                                                    | [`{ ids?: BaseKey; [key: string]: any; }`](/api-reference/core/interfaces.md#livemodeprops) | `undefined`                         |
-| onLiveEvent                                                                                         | Callback to handle all related live events of this hook.                                                                                                           | [`(event: LiveEvent) => void`](/api-reference/core/interfaces.md#livemodeprops)              | `undefined`                         |
+<PropsTable module="@pankod/refine-core/useOne" 
+successNotification-default='`false`'
+errorNotification-default='"Error (status code: `statusCode`)"'
+/>
 
 ### Type Parameters
 
-| Property | Desription                                                                       | Type                                           | Default                                        |
-| -------- | -------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| Property | Desription                                                                                     | Type                                                         | Default                                                      |
+| -------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | TData    | Result data of the query. Extends [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) |
 | TError   | Custom error object that extends [`HttpError`](/api-reference/core/interfaces.md#httperror)    | [`HttpError`](/api-reference/core/interfaces.md#httperror)   | [`HttpError`](/api-reference/core/interfaces.md#httperror)   |
 

--- a/documentation/docs/api-reference/core/hooks/data/useUpdate.md
+++ b/documentation/docs/api-reference/core/hooks/data/useUpdate.md
@@ -37,7 +37,7 @@ Let's say that we have a resource named `categories`.
 }
 ```
 
-```tsx 
+```tsx
 type CategoryMutationResult = {
     id: number;
     title: string;
@@ -55,9 +55,9 @@ mutate({
 ```
 
 :::tip
-`mutate` can also accept lifecycle methods like `onSuccess` and `onError`.  
+`mutate` can also accept lifecycle methods like `onSuccess` and `onError`.
 
-```tsx 
+```tsx
 mutate(
     {
         resource: "categories",
@@ -91,7 +91,7 @@ After mutation runs, `categories` will be updated as below:
         },
         {
             id: 2,
-// highlight-next-line
+            // highlight-next-line
             title: "New Category Title",
         },
     ];
@@ -188,19 +188,19 @@ After 7.5 seconds the mutation will be executed. The mutation can be cancelled w
 
 ### Properties
 
-| Property                                                                                            | Description                                                                                        | Type                                                                       | Default                                                      |
-| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| <div className="required-block"><div>resource</div> <div className=" required">Required</div></div> | Resource name for API data interactions                                                            | `string`                                                                   |                                                              |
+| Property                                                                                            | Description                                                                                        | Type                                                                                     | Default                                                      |
+| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| <div className="required-block"><div>resource</div> <div className=" required">Required</div></div> | Resource name for API data interactions                                                            | `string`                                                                                 |                                                              |
 | id <div className=" required">Required</div>                                                        | id for mutation function                                                                           | [`BaseKey`](/api-reference/core/interfaces.md#basekey)                                   |                                                              |
-| values <div className=" required">Required</div>                                                    | Values for mutation function                                                                       | `TVariables`                                                               | {}                                                           |
-| mutationMode                                                                                        | [Determines when mutations are executed](/advanced-tutorials/mutation-mode.md)                    | ` "pessimistic` \| `"optimistic` \| `"undoable"`                           | `"pessimistic"`\*                                            |
-| undoableTimeout                                                                                     | Duration to wait before executing the mutation when `mutationMode = "undoable"`                    | `number`                                                                   | `5000ms`\*                                                   |
-| onCancel                                                                                            | Callback that runs when undo button is clicked on `mutationMode = "undoable"`                      | `(cancelMutation: () => void) => void`                                     |                                                              |
+| values <div className=" required">Required</div>                                                    | Values for mutation function                                                                       | `TVariables`                                                                             | {}                                                           |
+| mutationMode                                                                                        | [Determines when mutations are executed](/advanced-tutorials/mutation-mode.md)                     | ` "pessimistic` \| `"optimistic` \| `"undoable"`                                         | `"pessimistic"`\*                                            |
+| undoableTimeout                                                                                     | Duration to wait before executing the mutation when `mutationMode = "undoable"`                    | `number`                                                                                 | `5000ms`\*                                                   |
+| onCancel                                                                                            | Callback that runs when undo button is clicked on `mutationMode = "undoable"`                      | `(cancelMutation: () => void) => void`                                                   |                                                              |
 | successNotification                                                                                 | Successful Mutation notification                                                                   | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification) | "Successfully updated `resource`"                            |
 | errorNotification                                                                                   | Unsuccessful Mutation notification                                                                 | [`SuccessErrorNotification`](/api-reference/core/interfaces.md#successerrornotification) | "Error when updating `resource` (status code: `statusCode`)" |
 | metaData                                                                                            | Metadata query for `dataProvider`                                                                  | [`MetaDataQuery`](/api-reference/core/interfaces.md#metadataquery)                       | {}                                                           |
-| dataProviderName                                                                                    | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use. | `string`                                                                   | `default`                                                    |
-| invalidates                                                                                         | You can use it to manage the invalidations that will occur at the end of the mutation.             | `all`, `resourceAll`, `list`, `many`, `detail`, `false`                    | `["list", "many", "detail"]`                                 |
+| dataProviderName                                                                                    | If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use. | `string`                                                                                 | `default`                                                    |
+| invalidates                                                                                         | You can use it to manage the invalidations that will occur at the end of the mutation.             | `all`, `resourceAll`, `list`, `many`, `detail`, `false`                                  | `["list", "many", "detail"]`                                 |
 
 > `*`: These props have default values in `RefineContext` and can also be set on **<[Refine](/api-reference/core/components/refine-config.md)>** component. `useUpdate` will use what's passed to `<Refine>` as default, but a local value will override it.
 
@@ -208,11 +208,11 @@ After 7.5 seconds the mutation will be executed. The mutation can be cancelled w
 
 ### Type Parameters
 
-| Property   | Desription                                                                          | Type                                           | Default                                        |
-| ---------- | ----------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| Property   | Desription                                                                                        | Type                                                         | Default                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | TData      | Result data of the mutation. Extends [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) | [`BaseRecord`](/api-reference/core/interfaces.md#baserecord) |
 | TError     | Custom error object that extends [`HttpError`](/api-reference/core/interfaces.md#httperror)       | [`HttpError`](/api-reference/core/interfaces.md#httperror)   | [`HttpError`](/api-reference/core/interfaces.md#httperror)   |
-| TVariables | Values for mutation function                                                        | `{}`                                           | `{}`                                           |
+| TVariables | Values for mutation function                                                                      | `{}`                                                         | `{}`                                                         |
 
 ### Return value
 

--- a/documentation/docs/api-reference/core/hooks/useTable.md
+++ b/documentation/docs/api-reference/core/hooks/useTable.md
@@ -219,7 +219,9 @@ console.log(filters);
 
 ### Properties
 
-<PropsTable module="@pankod/refine-core/useTable" />
+<PropsTable module="@pankod/refine-core/useTable" 
+successNotification-default='"Successfully created `resource`" or "Successfully updated `resource`"'
+errorNotification-default='"There was an error creating resource (status code: `statusCode`)" or "Error when updating resource (status code:statusCode)"'      />
 
 ### Type Parameters
 

--- a/documentation/plugins/docgen.js
+++ b/documentation/plugins/docgen.js
@@ -116,9 +116,6 @@ const replacementProps = {
         "[CrudFilters](/docs/api-reference/core/interfaceReferences/#crudfilters)",
     CrudSorting:
         "[CrudSorting](/docs/api-reference/core/interfaceReferences/#crudsorting)",
-    queryOptions:
-        "react-query's [useQuery](https://tanstack.com/query/v4/docs/reference/useQuery) options",
-    paparseOptions: "https://www.papaparse.com/docs",
 };
 
 /** HELPERS */

--- a/documentation/plugins/docgen.ts
+++ b/documentation/plugins/docgen.ts
@@ -93,9 +93,6 @@ const replacementProps: Record<string, string> = {
         "[CrudFilters](/docs/api-reference/core/interfaceReferences/#crudfilters)",
     CrudSorting:
         "[CrudSorting](/docs/api-reference/core/interfaceReferences/#crudsorting)",
-    queryOptions:
-        "react-query's [useQuery](https://tanstack.com/query/v4/docs/reference/useQuery) options",
-    paparseOptions: "https://www.papaparse.com/docs",
 };
 
 /** HELPERS */

--- a/packages/core/src/hooks/data/useCreate.ts
+++ b/packages/core/src/hooks/data/useCreate.ts
@@ -20,10 +20,25 @@ import {
 } from "@hooks";
 
 type useCreateParams<TVariables> = {
+    /**
+     * Resource name for API data interactions
+     */
     resource: string;
+    /**
+     * Values for mutation function
+     */
     values: TVariables;
+    /**
+     *  Metadata query for `dataProvider`
+     */
     metaData?: MetaDataQuery;
+    /**
+     * If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.
+     */
     dataProviderName?: string;
+    /**
+     * You can use it to manage the invalidations that will occur at the end of the mutation.
+     */
     invalidates?: Array<keyof IQueryKeys>;
 } & SuccessErrorNotification;
 

--- a/packages/core/src/hooks/data/useCustom.ts
+++ b/packages/core/src/hooks/data/useCustom.ts
@@ -30,7 +30,7 @@ interface UseCustomConfig<TQuery, TPayload> {
 
 export type UseCustomProps<TData, TError, TQuery, TPayload> = {
     /**
-     * URL
+     * request's URL
      */
     url: string;
     /**

--- a/packages/core/src/hooks/data/useCustom.ts
+++ b/packages/core/src/hooks/data/useCustom.ts
@@ -29,11 +29,29 @@ interface UseCustomConfig<TQuery, TPayload> {
 }
 
 export type UseCustomProps<TData, TError, TQuery, TPayload> = {
+    /**
+     * URL
+     */
     url: string;
+    /**
+     * request's method (`GET`, `POST`, etc.)
+     */
     method: "get" | "delete" | "head" | "options" | "post" | "put" | "patch";
+    /**
+     * The config of your request. You can send headers, payload, query, filters and sort using this field
+     */
     config?: UseCustomConfig<TQuery, TPayload>;
+    /**
+     * react-query's [useQuery](https://tanstack.com/query/v4/docs/reference/useQuery) options"
+     */
     queryOptions?: UseQueryOptions<CustomResponse<TData>, TError>;
+    /**
+     * Metadata query for `dataProvider`
+     */
     metaData?: MetaDataQuery;
+    /**
+     * If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.
+     */
     dataProviderName?: string;
 } & SuccessErrorNotification;
 

--- a/packages/core/src/hooks/data/useDataProvider.tsx
+++ b/packages/core/src/hooks/data/useDataProvider.tsx
@@ -7,6 +7,9 @@ import {
 } from "../../interfaces";
 
 export const useDataProvider = (): ((
+    /**
+     * The name of the `data provider` you want to access
+     */
     dataProviderName?: string,
 ) => IDataContextProvider) => {
     const context = useContext<IDataMultipleContextProvider>(DataContext);

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -31,10 +31,26 @@ export interface UseListConfig {
 }
 
 export type UseListProps<TData, TError> = {
+    /**
+     * Resource name for API data interactions
+     */
     resource: string;
+    /**
+     * Configuration for pagination, sorting and filtering
+     * @type [`UseListConfig`](docs/api-reference/core/hooks/data/useList/#config-parameters)
+     */
     config?: UseListConfig;
+    /**
+     * react-query's [useQuery](https://tanstack.com/query/v4/docs/reference/useQuery) options,
+     */
     queryOptions?: UseQueryOptions<GetListResponse<TData>, TError>;
+    /**
+     *  Metadata query for `dataProvider`
+     */
     metaData?: MetaDataQuery;
+    /**
+     * If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.
+     */
     dataProviderName?: string;
 } & SuccessErrorNotification &
     LiveModeProps;

--- a/packages/core/src/hooks/data/useMany.ts
+++ b/packages/core/src/hooks/data/useMany.ts
@@ -23,10 +23,27 @@ import {
 import { queryKeys } from "@definitions/helpers";
 
 export type UseManyProps<TData, TError> = {
+    /**
+     * Resource name for API data interactions
+     */
     resource: string;
+    /**
+     * ids of the item in the resource
+     * @type [`BaseKey[]`](/docs/api-reference/core/interfaceReferences/#basekey)
+     */
     ids: BaseKey[];
+    /**
+     * react-query's [useQuery](https://tanstack.com/query/v4/docs/reference/useQuery) options
+     */
     queryOptions?: UseQueryOptions<GetManyResponse<TData>, TError>;
+    /**
+     * Metadata query for `dataProvider`,
+     */
     metaData?: MetaDataQuery;
+    /**
+     * If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.
+     * @default "default"
+     */
     dataProviderName?: string;
 } & SuccessErrorNotification &
     LiveModeProps;

--- a/packages/core/src/hooks/data/useOne.ts
+++ b/packages/core/src/hooks/data/useOne.ts
@@ -23,10 +23,27 @@ import {
 import { queryKeys } from "@definitions";
 
 export type UseOneProps<TData, TError> = {
+    /**
+     * Resource name for API data interactions
+     */
     resource: string;
+    /**
+     * id of the item in the resource
+     * @type [`BaseKey`](/docs/api-reference/core/interfaceReferences/#basekey)
+     */
     id: BaseKey;
+    /**
+     * react-query's [useQuery](https://tanstack.com/query/v4/docs/reference/useQuery) options
+     */
     queryOptions?: UseQueryOptions<GetOneResponse<TData>, TError>;
+    /**
+     * Metadata query for `dataProvider`,
+     */
     metaData?: MetaDataQuery;
+    /**
+     * If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.
+     * @default `"default"``
+     */
     dataProviderName?: string;
 } & SuccessErrorNotification &
     LiveModeProps;

--- a/packages/core/src/hooks/data/useUpdate.ts
+++ b/packages/core/src/hooks/data/useUpdate.ts
@@ -33,14 +33,42 @@ import {
 import { queryKeys } from "@definitions/helpers";
 
 export type UpdateParams<TVariables> = {
-    id: BaseKey;
+    /**
+     * Resource name for API data interactions
+     */
     resource: string;
+    /**
+     * id for mutation function
+     */
+    id: BaseKey;
+    /**
+     * [Determines when mutations are executed](/advanced-tutorials/mutation-mode.md)
+     */
     mutationMode?: MutationMode;
+    /**
+     * Duration to wait before executing the mutation when `mutationMode = "undoable"`
+     */
     undoableTimeout?: number;
+    /**
+     * Callback that runs when undo button is clicked on `mutationMode = "undoable"`
+     */
     onCancel?: (cancelMutation: () => void) => void;
+    /**
+     * Values for mutation function
+     */
     values: TVariables;
+    /**
+     * Metadata query for `dataProvider`,
+     */
     metaData?: MetaDataQuery;
+    /**
+     * If there is more than one `dataProvider`, you should use the `dataProviderName` that you will use.
+     * @default "default"
+     */
     dataProviderName?: string;
+    /**
+     *  You can use it to manage the invalidations that will occur at the end of the mutation.
+     */
     invalidates?: Array<keyof IQueryKeys>;
 } & SuccessErrorNotification;
 

--- a/packages/core/src/hooks/import/index.tsx
+++ b/packages/core/src/hooks/import/index.tsx
@@ -57,6 +57,7 @@ export type ImportOptions<
     mapData?: MapDataFn<TItem, TVariables>;
     /**
      * Custom Papa Parse options.
+     * @type [`ParseConfig`](https://www.papaparse.com/docs)
      */
     paparseOptions?: ParseConfig;
     /**


### PR DESCRIPTION
<PropsTable/> added to following docs.
1. [useCreate](https://refine.dev/docs/api-reference/core/hooks/useCreate/)
2. [useCustom](https://refine.dev/docs/api-reference/core/hooks/useCustom/)
5. [useMany](https://refine.dev/docs/api-reference/core/hooks/useMany/)
6. [useOne](https://refine.dev/docs/api-reference/core/hooks/useOne/)



-   [ ] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [ ] Changesets are provided or not needed
