### PR TITLE
fix(core): data hooks type errors

### DIFF
--- a/.changeset/wet-dots-shave.md
+++ b/.changeset/wet-dots-shave.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+fix core data hooks type errors

--- a/packages/core/src/contexts/data/IDataContext.ts
+++ b/packages/core/src/contexts/data/IDataContext.ts
@@ -265,7 +265,11 @@ export interface IDataContextProvider {
         metaData?: MetaDataQuery;
     }) => Promise<DeleteManyResponse<TData>>;
     getApiUrl: () => string;
-    custom?: <TData extends BaseRecord = BaseRecord>(params: {
+    custom?: <
+        TData extends BaseRecord = BaseRecord,
+        TQuery = unknown,
+        TPayload = unknown,
+    >(params: {
         url: string;
         method:
             | "get"
@@ -277,8 +281,8 @@ export interface IDataContextProvider {
             | "patch";
         sort?: CrudSorting;
         filters?: CrudFilter[];
-        payload?: {};
-        query?: {};
+        payload?: TPayload;
+        query?: TQuery;
         headers?: {};
         metaData?: MetaDataQuery;
     }) => Promise<CustomResponse<TData>>;

--- a/packages/core/src/hooks/data/useCustom.ts
+++ b/packages/core/src/hooks/data/useCustom.ts
@@ -69,7 +69,7 @@ export type UseCustomProps<TData, TError, TQuery, TPayload> = {
  *
  */
 export const useCustom = <
-    TData = BaseRecord,
+    TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
     TQuery = unknown,
     TPayload = unknown,

--- a/packages/core/src/hooks/data/useDelete.ts
+++ b/packages/core/src/hooks/data/useDelete.ts
@@ -112,7 +112,10 @@ export const useDelete = <
                 undoableTimeout ?? undoableTimeoutContext;
 
             if (!(mutationModePropOrContext === "undoable")) {
-                return dataProvider(dataProviderName).deleteOne<TData>({
+                return dataProvider(dataProviderName).deleteOne<
+                    TData,
+                    TVariables
+                >({
                     resource,
                     id,
                     metaData,
@@ -124,7 +127,7 @@ export const useDelete = <
                 (resolve, reject) => {
                     const doMutation = () => {
                         dataProvider(dataProviderName)
-                            .deleteOne<TData>({
+                            .deleteOne<TData, TVariables>({
                                 resource,
                                 id,
                                 metaData,

--- a/packages/core/src/hooks/data/useDeleteMany.ts
+++ b/packages/core/src/hooks/data/useDeleteMany.ts
@@ -109,7 +109,10 @@ export const useDeleteMany = <
             const undoableTimeoutPropOrContext =
                 undoableTimeout ?? undoableTimeoutContext;
             if (!(mutationModePropOrContext === "undoable")) {
-                return dataProvider(dataProviderName).deleteMany<TData>({
+                return dataProvider(dataProviderName).deleteMany<
+                    TData,
+                    TVariables
+                >({
                     resource,
                     ids,
                     metaData,
@@ -121,7 +124,7 @@ export const useDeleteMany = <
                 (resolve, reject) => {
                     const doMutation = () => {
                         dataProvider(dataProviderName)
-                            .deleteMany<TData>({
+                            .deleteMany<TData, TVariables>({
                                 resource,
                                 ids,
                                 metaData,

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -67,7 +67,7 @@ export type UseListProps<TData, TError> = {
  *
  */
 export const useList = <
-    TData = BaseRecord,
+    TData extends BaseRecord = BaseRecord,
     TError extends HttpError = HttpError,
 >({
     resource,


### PR DESCRIPTION
hooks was giving type errors because generic type parameters not passed

-   [ ] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
