### PR TITLE
feat(core): add query client prop to refine

### DIFF
--- a/.changeset/strange-emus-begin.md
+++ b/.changeset/strange-emus-begin.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": minor
+---
+
+add query client prop to refine

--- a/.changeset/strange-emus-begin.md
+++ b/.changeset/strange-emus-begin.md
@@ -2,7 +2,7 @@
 "@pankod/refine-core": minor
 ---
 
-`clientConfig` property now accepts `QueryClient` instance - #2670
+`clientConfig` property now accepts `QueryClient` instance - #2665
 
 # Usage
 

--- a/.changeset/strange-emus-begin.md
+++ b/.changeset/strange-emus-begin.md
@@ -2,4 +2,21 @@
 "@pankod/refine-core": minor
 ---
 
-add query client prop to refine
+`clientConfig` property now accepts `QueryClient` instance - #2670
+
+# Usage
+
+```tsx
+import { QueryClient } from "@tanstack/react-query";
+const queryClient = new QueryClient();
+const App: React.FC = () => (
+    <Refine
+        ...
+        options={{
+            reactQuery: {
+                clientConfig: queryClient
+            },
+        }}
+    />
+);
+```

--- a/documentation/docs/api-reference/core/components/refine-config.md
+++ b/documentation/docs/api-reference/core/components/refine-config.md
@@ -476,6 +476,27 @@ const App: React.FC = () => (
 );
 ```
 
+Also, you can implement your own [QueryClient](https://react-query.tanstack.com/reference/QueryClient#queryclient).
+
+```tsx
+import { QueryClient } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
+
+const App: React.FC = () => (
+    <Refine
+        ...
+        // highlight-start
+        options={{
+            reactQuery: {
+                clientConfig: queryClient
+            },
+        }}
+        // highlight-end
+    />
+);
+```
+
 #### `devtoolConfig`
 
 Config for customize React Query Devtools. If you want to disable the Devtools, set `devtoolConfig` to `false`.
@@ -749,3 +770,7 @@ const App: React.FC = () => (
 ```
 
 [routerprovider]: /api-reference/core/providers/router-provider.md
+
+```
+
+```

--- a/documentation/docs/api-reference/core/components/refine-config.md
+++ b/documentation/docs/api-reference/core/components/refine-config.md
@@ -770,7 +770,3 @@ const App: React.FC = () => (
 ```
 
 [routerprovider]: /api-reference/core/providers/router-provider.md
-
-```
-
-```

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -180,6 +180,10 @@ export const Refine: React.FC<RefineProps> = ({
     });
 
     const queryClient = useDeepMemo(() => {
+        if (reactQueryWithDefaults.clientConfig instanceof QueryClient) {
+            return reactQueryWithDefaults.clientConfig;
+        }
+
         return new QueryClient({
             ...reactQueryWithDefaults.clientConfig,
             defaultOptions: {

--- a/packages/core/src/contexts/refine/IRefineContext.ts
+++ b/packages/core/src/contexts/refine/IRefineContext.ts
@@ -1,6 +1,6 @@
 import { RefineProps } from "@components/containers";
 import React, { ReactNode } from "react";
-import { QueryClientConfig } from "@tanstack/react-query";
+import { QueryClientConfig, QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import {
@@ -24,7 +24,7 @@ export interface IRefineOptions {
         afterEdit?: RedirectAction;
     };
     reactQuery?: {
-        clientConfig?: QueryClientConfig;
+        clientConfig?: QueryClientConfig | InstanceType<typeof QueryClient>;
         devtoolConfig?: React.ComponentProps<typeof ReactQueryDevtools> | false;
     };
 }

--- a/packages/core/src/definitions/helpers/handleRefineOptions/index.spec.ts
+++ b/packages/core/src/definitions/helpers/handleRefineOptions/index.spec.ts
@@ -1,6 +1,7 @@
 import { handleRefineOptions } from ".";
 import { defaultRefineOptions } from "@contexts/refine";
 import { IRefineOptions } from "src/interfaces";
+import { QueryClient } from "@tanstack/react-query";
 
 describe("handleRefineOptions", () => {
     it("should return the default options if no options are provided", () => {
@@ -170,6 +171,24 @@ describe("handleRefineOptions", () => {
             afterClone: "show",
             afterCreate: "list",
             afterEdit: "list",
+        });
+    });
+
+    it("it should return provided query client", () => {
+        const queryClient = new QueryClient();
+
+        const options: IRefineOptions = {
+            reactQuery: {
+                clientConfig: queryClient,
+                devtoolConfig: false,
+            },
+        };
+
+        const { reactQueryWithDefaults } = handleRefineOptions({ options });
+
+        expect(reactQueryWithDefaults).toEqual({
+            clientConfig: queryClient,
+            devtoolConfig: false,
         });
     });
 });

--- a/packages/core/src/definitions/helpers/handleRefineOptions/index.ts
+++ b/packages/core/src/definitions/helpers/handleRefineOptions/index.ts
@@ -1,4 +1,4 @@
-import { QueryClientConfig } from "@tanstack/react-query";
+import { QueryClient, QueryClientConfig } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import { defaultRefineOptions } from "@contexts/refine";
@@ -27,7 +27,7 @@ type HandleRefineOptionsReturnValues = {
     optionsWithDefaults: IRefineContextOptions;
     disableTelemetryWithDefault: boolean;
     reactQueryWithDefaults: {
-        clientConfig: QueryClientConfig;
+        clientConfig: QueryClientConfig | InstanceType<typeof QueryClient>;
         devtoolConfig: false | React.ComponentProps<typeof ReactQueryDevtools>;
     };
 };


### PR DESCRIPTION
From now, **refine** can take react-query's [QueryClient](https://tanstack.com/query/v4/docs/reference/QueryClient) as a prop for more flexible react-query implementations.

Thanks to @jsbrain for the idea 🚀 

[Documentation Page](https://refine.dev/docs/api-reference/core/components/refine-config/#reactquery)

### Test plan (required)
![image](https://user-images.githubusercontent.com/23058882/194554069-989ca273-5e0d-4c29-8f00-1ee285ac32a5.png)

### Closing issues
closes #2665



-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
