### PR TITLE
[DOC] Update Refine wraps Outlet

### DIFF
--- a/documentation/docs/advanced-tutorials/ssr/remix.md
+++ b/documentation/docs/advanced-tutorials/ssr/remix.md
@@ -22,7 +22,7 @@ npx superplate-cli -o refine-remix my-refine-remix-app
 
 ## Usage
 
-`<Refine>` should be wrapped in your `<Outlet>` component located in `app/root.tsx`. This way your [routes][remixroutes] are integrated to **refine**.
+`<Refine>` should wrap your `<Outlet>` component located in `app/root.tsx`. This way your [routes][remixroutes] are integrated to **refine**.
 
 ```tsx title="app/root.tsx"
 import type { MetaFunction } from "@remix-run/node";


### PR DESCRIPTION
This closes #2671 

Problem:
In [Remix SSR Doc](https://github.com/pankod/refine/blob/master/documentation/docs/advanced-tutorials/ssr/remix.md)
it should say that `Refine` wraps Outlet, and not vice versa

Solution: 
This rewords the doc

### Self Check before Merge

Please check all items below before review.

-   [X] Corresponding issues are created/updated or not needed
-   [X] Docs are updated/provided or not needed
-   [X] Examples are updated/provided or not needed
-   [X] TypeScript definitions are updated/provided or not needed
-   [X] Tests are updated/provided or not needed
-   [X] Changesets are provided or not needed
