### PR TITLE
feat: `dataProviderName` in `resource.options`

### DIFF
--- a/.changeset/hot-jokes-lick.md
+++ b/.changeset/hot-jokes-lick.md
@@ -1,0 +1,24 @@
+---
+"@pankod/refine-core": minor
+---
+
+Added `dataProviderName` property to resource options. Now you can define default data provider per resource.
+
+**Usage**
+
+```ts
+<Refine
+    dataProvider={{
+        default: myProvider,
+        second: mySecondProvider,
+    }}
+    resources={[
+        {
+            name: "posts",
+            options: {
+                dataProviderName: "second",
+            },
+        }
+    ]}
+/>
+```

--- a/documentation/docs/api-reference/core/components/refine-config.md
+++ b/documentation/docs/api-reference/core/components/refine-config.md
@@ -130,6 +130,7 @@ These components will receive some properties.
 type OptionsProps<TExtends = { [key: string]: any }> = TExtends & {
     label?: string;
     route?: string;
+    dataProviderName?: string;
     hide?: boolean;
 }
 
@@ -250,6 +251,10 @@ Name to show in the menu. Plural form of the resource name is shown by default.
 #### `route`
 
 Custom route name
+
+#### `dataProviderName`
+
+Default data provider name to use for the resource. If not specified, the default data provider will be used.
 
 #### `hide`
 

--- a/documentation/docs/api-reference/core/interfaces.md
+++ b/documentation/docs/api-reference/core/interfaces.md
@@ -248,6 +248,7 @@ ButtonProps
 | ------------- | -------- |
 | label?        | `string` |
 | route?        | `string` |
+| dataProviderName? | `string` |
 | [key: string] | `any`    |
 
 ## ResourceItemProps

--- a/packages/core/src/contexts/resource/IResourceContext.ts
+++ b/packages/core/src/contexts/resource/IResourceContext.ts
@@ -12,6 +12,7 @@ export interface IResourceContext {
 type OptionsProps<TExtends = { [key: string]: any }> = TExtends & {
     label?: string;
     route?: string;
+    dataProviderName?: string;
     auditLog?: {
         permissions?: AuditLogPermissions[number][] | string[];
     };

--- a/packages/core/src/definitions/helpers/index.ts
+++ b/packages/core/src/definitions/helpers/index.ts
@@ -10,3 +10,4 @@ export { humanizeString } from "./humanizeString";
 export { handleRefineOptions } from "./handleRefineOptions";
 export { redirectPage } from "./redirectPage";
 export { sequentialPromises } from "./sequentialPromises";
+export { pickDataProvider } from "./pickDataProvider";

--- a/packages/core/src/definitions/helpers/pickDataProvider/index.spec.ts
+++ b/packages/core/src/definitions/helpers/pickDataProvider/index.spec.ts
@@ -1,0 +1,45 @@
+import { IResourceItem } from "@contexts/resource";
+import { pickDataProvider } from ".";
+
+describe("pickDataProvider", () => {
+    it("should return the dataProvider from the params", () => {
+        expect(pickDataProvider("resourceName", "custom-provider", [])).toBe(
+            "custom-provider",
+        );
+    });
+    it("should return default if resource is not found in resources and no dataprovidername is provided", () => {
+        expect(pickDataProvider("resourceName", undefined, [])).toBe("default");
+    });
+    it("should return resource's dataprovidername", () => {
+        const resources: IResourceItem[] = [
+            {
+                name: "resourceName",
+                options: {
+                    dataProviderName: "custom-provider",
+                },
+            },
+        ];
+
+        expect(pickDataProvider("resourceName", undefined, resources)).toBe(
+            "custom-provider",
+        );
+    });
+    it("should return dataprovidername from params even if resource matches", () => {
+        const resources: IResourceItem[] = [
+            {
+                name: "resourceName",
+                options: {
+                    dataProviderName: "custom-provider",
+                },
+            },
+        ];
+
+        expect(
+            pickDataProvider(
+                "resourceName",
+                "other-custom-provider",
+                resources,
+            ),
+        ).toBe("other-custom-provider");
+    });
+});

--- a/packages/core/src/definitions/helpers/pickDataProvider/index.ts
+++ b/packages/core/src/definitions/helpers/pickDataProvider/index.ts
@@ -1,0 +1,19 @@
+import { IResourceItem } from "@contexts/resource";
+
+export const pickDataProvider = (
+    resourceName?: string,
+    dataProviderName?: string,
+    resources?: IResourceItem[],
+) => {
+    if (dataProviderName) {
+        return dataProviderName;
+    }
+
+    const resource = resources?.find((item) => item.name === resourceName);
+
+    if (resource?.options?.dataProviderName) {
+        return resource.options.dataProviderName;
+    }
+
+    return "default";
+};

--- a/packages/core/src/hooks/data/useCreate.ts
+++ b/packages/core/src/hooks/data/useCreate.ts
@@ -1,5 +1,6 @@
 import { useMutation, UseMutationResult } from "@tanstack/react-query";
 import pluralize from "pluralize";
+import { pickDataProvider } from "@definitions/helpers";
 
 import {
     CreateResponse,
@@ -10,6 +11,7 @@ import {
     IQueryKeys,
 } from "../../interfaces";
 import {
+    useResource,
     useTranslate,
     useCheckError,
     usePublish,
@@ -75,6 +77,8 @@ export const useCreate = <
     const dataProvider = useDataProvider();
     const invalidateStore = useInvalidate();
 
+    const { resources } = useResource();
+
     const translate = useTranslate();
     const publish = usePublish();
     const { log } = useLog();
@@ -92,7 +96,9 @@ export const useCreate = <
             metaData,
             dataProviderName,
         }: useCreateParams<TVariables>) => {
-            return dataProvider(dataProviderName).create<TData, TVariables>({
+            return dataProvider(
+                pickDataProvider(resource, dataProviderName, resources),
+            ).create<TData, TVariables>({
                 resource,
                 variables: values,
                 metaData,
@@ -135,7 +141,11 @@ export const useCreate = <
 
                 invalidateStore({
                     resource,
-                    dataProviderName,
+                    dataProviderName: pickDataProvider(
+                        resource,
+                        dataProviderName,
+                        resources,
+                    ),
                     invalidates,
                 });
 
@@ -156,7 +166,11 @@ export const useCreate = <
                     resource,
                     data: values,
                     meta: {
-                        dataProviderName,
+                        dataProviderName: pickDataProvider(
+                            resource,
+                            dataProviderName,
+                            resources,
+                        ),
                         id: data?.data?.id ?? undefined,
                         ...rest,
                     },

--- a/packages/core/src/hooks/data/useCreateMany.ts
+++ b/packages/core/src/hooks/data/useCreateMany.ts
@@ -9,6 +9,7 @@ import {
     IQueryKeys,
 } from "../../interfaces";
 import {
+    useResource,
     useTranslate,
     usePublish,
     useHandleNotification,
@@ -16,6 +17,7 @@ import {
     useInvalidate,
 } from "@hooks";
 import pluralize from "pluralize";
+import { pickDataProvider } from "@definitions/helpers";
 
 type useCreateManyParams<TVariables> = {
     resource: string;
@@ -55,6 +57,7 @@ export const useCreateMany = <
 >(): UseCreateManyReturnType<TData, TError, TVariables> => {
     const dataProvider = useDataProvider();
 
+    const { resources } = useResource();
     const translate = useTranslate();
     const publish = usePublish();
     const handleNotification = useHandleNotification();
@@ -71,7 +74,9 @@ export const useCreateMany = <
             metaData,
             dataProviderName,
         }: useCreateManyParams<TVariables>) =>
-            dataProvider(dataProviderName).createMany<TData, TVariables>({
+            dataProvider(
+                pickDataProvider(resource, dataProviderName, resources),
+            ).createMany<TData, TVariables>({
                 resource,
                 variables: values,
                 metaData,
@@ -112,7 +117,11 @@ export const useCreateMany = <
 
                 invalidateStore({
                     resource,
-                    dataProviderName,
+                    dataProviderName: pickDataProvider(
+                        resource,
+                        dataProviderName,
+                        resources,
+                    ),
                     invalidates,
                 });
 

--- a/packages/core/src/hooks/data/useList.ts
+++ b/packages/core/src/hooks/data/useList.ts
@@ -15,13 +15,14 @@ import {
     LiveModeProps,
 } from "../../interfaces";
 import {
+    useResource,
     useCheckError,
     useHandleNotification,
     useResourceSubscription,
     useTranslate,
     useDataProvider,
 } from "@hooks";
-import { queryKeys } from "@definitions/helpers";
+import { queryKeys, pickDataProvider } from "@definitions/helpers";
 
 export interface UseListConfig {
     pagination?: Pagination;
@@ -84,9 +85,16 @@ export const useList = <
     GetListResponse<TData>,
     TError
 > => {
+    const { resources } = useResource();
     const dataProvider = useDataProvider();
-    const queryKey = queryKeys(resource, dataProviderName, metaData);
-    const { getList } = dataProvider(dataProviderName);
+    const queryKey = queryKeys(
+        resource,
+        pickDataProvider(resource, dataProviderName, resources),
+        metaData,
+    );
+    const { getList } = dataProvider(
+        pickDataProvider(resource, dataProviderName, resources),
+    );
 
     const translate = useTranslate();
     const { mutate: checkError } = useCheckError();

--- a/packages/core/src/hooks/data/useMany.ts
+++ b/packages/core/src/hooks/data/useMany.ts
@@ -14,13 +14,14 @@ import {
     SuccessErrorNotification,
 } from "../../interfaces";
 import {
+    useResource,
     useTranslate,
     useCheckError,
     useResourceSubscription,
     useHandleNotification,
     useDataProvider,
 } from "@hooks";
-import { queryKeys } from "@definitions/helpers";
+import { queryKeys, pickDataProvider } from "@definitions/helpers";
 
 export type UseManyProps<TData, TError> = {
     /**
@@ -76,10 +77,17 @@ export const useMany = <
 }: UseManyProps<TData, TError>): QueryObserverResult<
     GetManyResponse<TData>
 > => {
+    const { resources } = useResource();
     const dataProvider = useDataProvider();
-    const queryKey = queryKeys(resource, dataProviderName, metaData);
+    const queryKey = queryKeys(
+        resource,
+        pickDataProvider(resource, dataProviderName, resources),
+        metaData,
+    );
 
-    const { getMany } = dataProvider(dataProviderName);
+    const { getMany } = dataProvider(
+        pickDataProvider(resource, dataProviderName, resources),
+    );
 
     const translate = useTranslate();
     const { mutate: checkError } = useCheckError();

--- a/packages/core/src/hooks/data/useOne.ts
+++ b/packages/core/src/hooks/data/useOne.ts
@@ -14,13 +14,14 @@ import {
     SuccessErrorNotification,
 } from "../../interfaces";
 import {
+    useResource,
     useCheckError,
     useTranslate,
     useResourceSubscription,
     useHandleNotification,
     useDataProvider,
 } from "@hooks";
-import { queryKeys } from "@definitions";
+import { queryKeys, pickDataProvider } from "@definitions";
 
 export type UseOneProps<TData, TError> = {
     /**
@@ -74,10 +75,17 @@ export const useOne = <
     liveParams,
     dataProviderName,
 }: UseOneProps<TData, TError>): QueryObserverResult<GetOneResponse<TData>> => {
+    const { resources } = useResource();
     const dataProvider = useDataProvider();
-    const queryKey = queryKeys(resource, dataProviderName, metaData);
+    const queryKey = queryKeys(
+        resource,
+        pickDataProvider(resource, dataProviderName, resources),
+        metaData,
+    );
 
-    const { getOne } = dataProvider(dataProviderName);
+    const { getOne } = dataProvider(
+        pickDataProvider(resource, dataProviderName, resources),
+    );
     const translate = useTranslate();
     const { mutate: checkError } = useCheckError();
     const handleNotification = useHandleNotification();

--- a/packages/core/src/hooks/export/index.ts
+++ b/packages/core/src/hooks/export/index.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import {
+    useResource,
     useResourceWithRoute,
     useRouterContext,
     useDataProvider,
@@ -12,7 +13,7 @@ import {
     CrudFilters,
     MetaDataQuery,
 } from "../../interfaces";
-import { userFriendlyResourceName } from "@definitions";
+import { userFriendlyResourceName, pickDataProvider } from "@definitions";
 import { ExportToCsv, Options } from "export-to-csv-fix-source-map";
 
 type UseExportOptionsType<
@@ -90,6 +91,8 @@ export const useExport = <
 }: UseExportOptionsType<TData, TVariables> = {}): UseExportReturnType => {
     const [isLoading, setIsLoading] = useState(false);
 
+    const { resources } = useResource();
+
     const resourceWithRoute = useResourceWithRoute();
     const dataProvider = useDataProvider();
 
@@ -107,7 +110,9 @@ export const useExport = <
         "plural",
     )}-${new Date().toLocaleString()}`;
 
-    const { getList } = dataProvider(dataProviderName);
+    const { getList } = dataProvider(
+        pickDataProvider(resource, dataProviderName, resources),
+    );
 
     const triggerExport = async () => {
         setIsLoading(true);

--- a/packages/core/src/hooks/invalidate/index.tsx
+++ b/packages/core/src/hooks/invalidate/index.tsx
@@ -1,7 +1,8 @@
 import { useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
-import { queryKeys } from "@definitions";
+import { useResource } from "@hooks/resource";
+import { queryKeys, pickDataProvider } from "@definitions";
 import { BaseKey, IQueryKeys } from "../../interfaces";
 
 export type UseInvalidateProp = {
@@ -12,6 +13,7 @@ export type UseInvalidateProp = {
 };
 
 export const useInvalidate = (): ((props: UseInvalidateProp) => void) => {
+    const { resources } = useResource();
     const queryClient = useQueryClient();
 
     const invalidate = useCallback(
@@ -24,7 +26,10 @@ export const useInvalidate = (): ((props: UseInvalidateProp) => void) => {
             if (invalidates === false) {
                 return;
             }
-            const queryKey = queryKeys(resource, dataProviderName);
+            const queryKey = queryKeys(
+                resource,
+                pickDataProvider(resource, dataProviderName, resources),
+            );
 
             invalidates.forEach((key) => {
                 switch (key) {


### PR DESCRIPTION
Added `dataProviderName` property to resource options. This way we can define default data providers per resource.
### Test plan (required)

<img width="762" alt="Screen Shot 2022-10-07 at 16 42 47" src="https://user-images.githubusercontent.com/11361964/194567843-d6b95341-3107-4b87-98b6-6ff50190a565.png">

<img width="762" alt="Screen Shot 2022-10-07 at 16 43 27" src="https://user-images.githubusercontent.com/11361964/194567963-800fe8a7-8df4-48f9-afbc-811239f30091.png">

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
