### PR TITLE
feat(core): mark `default` key required for multiple data providers

### DIFF
--- a/.changeset/rude-laws-lie.md
+++ b/.changeset/rude-laws-lie.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+Mark `default` key as required for multiple data providers in `dataProvider` prop of `<Refine />` component.

--- a/packages/core/src/contexts/data/IDataContext.ts
+++ b/packages/core/src/contexts/data/IDataContext.ts
@@ -289,6 +289,6 @@ export interface IDataContextProvider {
 }
 
 export interface IDataMultipleContextProvider {
-    default?: IDataContextProvider;
+    default: IDataContextProvider;
     [key: string]: IDataContextProvider | any;
 }


### PR DESCRIPTION
Mark `default` key as required for multiple data providers in `dataProvider` prop of `<Refine />` component.

Docs will be updated in a separate branch.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
