### PR TITLE
feat(docs): add props table to core hooks

### DIFF
--- a/documentation/docs/api-reference/core/hooks/live/useSubscription.md
+++ b/documentation/docs/api-reference/core/hooks/live/useSubscription.md
@@ -25,3 +25,9 @@ useSubscription({
 
 You can publish events with [`usePublish`](/api-reference/core/hooks/live/usePublish.md).
 :::
+
+## API Reference
+
+### Properties
+
+<PropsTable module="@pankod/refine-core/useSubscription"  />

--- a/documentation/docs/api-reference/core/hooks/resource/useResource.md
+++ b/documentation/docs/api-reference/core/hooks/resource/useResource.md
@@ -13,28 +13,24 @@ const { resources } = useResource();
 // it also returns the resource with the props you provide as resourceNameOrRouteName.
 
 const { resource } = useResource({
-         resourceNameOrRouteName
-     });
+    resourceNameOrRouteName,
+});
 ```
 
 ## API Reference
 
 ### Properties
 
-| Key                   | Description                                                                                                                                                        | Type                                                        | Default                                                                              |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| resourceNameOrRouteName                                                                                   | Determines which resource to use for redirection | `string`                                                                                                                              | Resource name that it reads from route                           |
-| recordItemId                                                                                              | Adds `id` to the end of the URL                  | [`BaseKey`](/api-reference/core/interfaces.md#basekey)                                                                                              | Record id that it reads from route                               |
+<PropsTable module="@pankod/refine-core/useResource"  />
 
 ### Return value
 
-| Description | Type                             |
-| ----------- | -------------------------------- |
-| resources   | [`IResourceItem[]`](#interfaces) |
-| resource   | [`IResourceItem`](#interfaces) |
-| resourceName   | `string` |
-| id   | [`BaseKey`](/api-reference/core/interfaces.md#basekey) |
-
+| Description  | Type                                                   |
+| ------------ | ------------------------------------------------------ |
+| resources    | [`IResourceItem[]`](#interfaces)                       |
+| resource     | [`IResourceItem`](#interfaces)                         |
+| resourceName | `string`                                               |
+| id           | [`BaseKey`](/api-reference/core/interfaces.md#basekey) |
 
 #### Interfaces
 
@@ -46,9 +42,12 @@ type OptionsProps<TExtends = { [key: string]: any }> = TExtends & {
     auditLog?: {
         permissions?: AuditLogPermissions[number][] | string[];
     };
-}
+};
 
-interface IResourceComponentsProps<TCrudData = any, TOptionsPropsExtends = { [key: string]: any }> {
+interface IResourceComponentsProps<
+    TCrudData = any,
+    TOptionsPropsExtends = { [key: string]: any },
+> {
     canCreate?: boolean;
     canEdit?: boolean;
     canDelete?: boolean;

--- a/documentation/docs/api-reference/core/hooks/resource/useResourceWithRoute.md
+++ b/documentation/docs/api-reference/core/hooks/resource/useResourceWithRoute.md
@@ -17,9 +17,8 @@ const resourceWithRoute = useResourceWithRoute();
 
 ### Return value
 
-| Description       | Type                                                                        |
-| ----------------- | --------------------------------------------------------------------------- |
+| Description       | Type                                                                                      |
+| ----------------- | ----------------------------------------------------------------------------------------- |
 | resourceWithRoute | [`(route: string) => IResourceItem`](/api-reference/core/interfaces.md#resourceitemprops) |
-
 
 > The `canCreate`, `canShow` and `canEdit` properties are defined automatically if the `create`, `show` and `edit` components are defined on the `resources` property in `<Refine>`.

--- a/documentation/docs/api-reference/core/hooks/ui/useModal.md
+++ b/documentation/docs/api-reference/core/hooks/ui/useModal.md
@@ -15,27 +15,27 @@ You can use `visible` state to show or hide the modal. The `show` and `close` fu
 
 Let's see an example:
 
-```tsx  title="src/pages/posts/list.tsx"
+```tsx title="src/pages/posts/list.tsx"
 import {
-// highlight-next-line
+    // highlight-next-line
     useModal,
 } from "@pankod/refine-core";
 
 export const PostList: React.FC = () => {
-// highlight-next-line
+    // highlight-next-line
     const { visible, show, close } = useModal();
 
     return (
         <>
-// highlight-start
+            // highlight-start
             <button onClick={show}>Show Modal</button>
-            {visible && 
-            <YourModalComponent>
-                <p>Dummy Modal Content</p>
-                <button onClick={close}>Close Modal</button>
-            </YourModalComponent>
-            }
-// highlight-end
+            {visible && (
+                <YourModalComponent>
+                    <p>Dummy Modal Content</p>
+                    <button onClick={close}>Close Modal</button>
+                </YourModalComponent>
+            )}
+            // highlight-end
         </>
     );
 };
@@ -51,10 +51,7 @@ We also created a `<button>` to close the `<YourModalComponent>` and gave the on
 
 ### Properties
 
-| Property       | Description                     | Type      | Default |
-| -------------- | ------------------------------- | --------- | ------- |
-| defaultVisible | Modal's default `visible` state | `boolean` | `false` |
-
+<PropsTable module="@pankod/refine-core/useModal"  />
 
 ### Return Value
 
@@ -71,4 +68,4 @@ We also created a `<button>` to close the `<YourModalComponent>` and gave the on
     title="refine-use-modal-example"
 ></iframe>
 
-[Modal]: https://ant.design/components/modal/#API
+[modal]: https://ant.design/components/modal/#API

--- a/packages/core/src/hooks/live/useSubscription/index.ts
+++ b/packages/core/src/hooks/live/useSubscription/index.ts
@@ -12,8 +12,24 @@ import {
 } from "../../../interfaces";
 
 export type UseSubscriptionProps = {
+    /**
+     * Channel name to subscribe.
+     */
     channel: string;
+    /**
+     * Callback that is run when new events from subscription arrive.
+     */
     onLiveEvent: (event: LiveEvent) => void;
+    /**
+     * Type of events to subscribe. `"*"` means all events.
+     * @type Array<"deleted" | "updated" | "created" | "*" | string>
+     */
+    types?: LiveEvent["type"][];
+    /**
+     * Determines subscription should subscribe or not.
+     * @type Array<"deleted" | "updated" | "created" | "*" | string>
+     */
+    enabled?: boolean;
     params?: {
         ids?: BaseKey[];
         id?: BaseKey;
@@ -26,8 +42,6 @@ export type UseSubscriptionProps = {
         resource?: string;
         [key: string]: any;
     };
-    types?: LiveEvent["type"][];
-    enabled?: boolean;
 };
 
 export const useSubscription = ({

--- a/packages/core/src/hooks/modal/useModal/index.tsx
+++ b/packages/core/src/hooks/modal/useModal/index.tsx
@@ -7,6 +7,9 @@ export type useModalReturnType = {
 };
 
 export type useModalProps = {
+    /**
+     * Initial state of the modal
+     */
     defaultVisible?: boolean;
 };
 

--- a/packages/core/src/hooks/resource/useResource/index.ts
+++ b/packages/core/src/hooks/resource/useResource/index.ts
@@ -6,10 +6,19 @@ import { useRouterContext, useResourceWithRoute } from "@hooks";
 
 export type UseResourcePropsType = {
     /**
+     * Determines which resource to use for redirection
      * @deprecated resourceName deprecated. Use resourceNameOrRouteName instead # https://github.com/pankod/refine/issues/1618
      */
     resourceName?: string;
+    /**
+     * Determines which resource to use for redirection
+     * @default Resource name that it reads from route
+     */
     resourceNameOrRouteName?: string;
+    /**
+     * Adds id to the end of the URL
+     * @deprecated resourceName deprecated. Use resourceNameOrRouteName instead # https://github.com/pankod/refine/issues/1618
+     */
     recordItemId?: BaseKey;
 };
 


### PR DESCRIPTION
<PropsTable/> added to following docs.
1. [useSubscription](https://refine.dev/docs/api-reference/core/hooks/live/useSubscription/)
2. [useResource](https://refine.dev/docs/api-reference/core/hooks/resource/useResource/)
5. [useModal](https://refine.dev/docs/examples/ui/useModal/)



-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
