### PR TITLE
feat(mantine): add clearable prop to useSelect

### DIFF
--- a/.changeset/rotten-pets-approve.md
+++ b/.changeset/rotten-pets-approve.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mantine": patch
+---
+
+Added `clearable` prop to `useSelect` hook that is `true` by default.

--- a/packages/mantine/src/hooks/useSelect/index.ts
+++ b/packages/mantine/src/hooks/useSelect/index.ts
@@ -31,6 +31,7 @@ export const useSelect = <
             onSearchChange: onSearch,
             searchable: true,
             filterDataOnExactSearchMatch: true,
+            clearable: true,
         },
         queryResult,
         defaultValueQueryResult,


### PR DESCRIPTION
Add the clearable prop to useSelect return value.

### Test plan (required)

The test are not effected.

### Closing issues

.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
