### PR TITLE
fix(core) : `useSelect` fetches all data

### DIFF
--- a/.changeset/metal-nails-shop.md
+++ b/.changeset/metal-nails-shop.md
@@ -1,0 +1,7 @@
+---
+"@pankod/refine-core": minor
+---
+
+Added `useSelect()`, setState handler functions are memoized
+
+Fixed when `queryOptions.enabled = true` on `useSelect()`, fetches all data. #2691

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { QueryObserverResult, UseQueryOptions } from "@tanstack/react-query";
 import uniqBy from "lodash/uniqBy";
 import debounce from "lodash/debounce";
@@ -133,14 +133,17 @@ export const useSelect = <
         ? defaultValue
         : [defaultValue];
 
-    const defaultValueQueryOnSuccess = (data: GetManyResponse<TData>) => {
-        setSelectedOptions(
-            data.data.map((item) => ({
-                label: get(item, optionLabel),
-                value: get(item, optionValue),
-            })),
-        );
-    };
+    const defaultValueQueryOnSuccess = useCallback(
+        (data: GetManyResponse<TData>) => {
+            setSelectedOptions(
+                data.data.map((item) => ({
+                    label: get(item, optionLabel),
+                    value: get(item, optionValue),
+                })),
+            );
+        },
+        [optionLabel, optionValue],
+    );
 
     const defaultValueQueryOptions =
         defaultValueQueryOptionsFromProps ?? (queryOptions as any);
@@ -161,14 +164,19 @@ export const useSelect = <
         dataProviderName,
     });
 
-    const defaultQueryOnSuccess = (data: GetListResponse<TData>) => {
-        setOptions(
-            data.data.map((item) => ({
-                label: get(item, optionLabel),
-                value: get(item, optionValue),
-            })),
-        );
-    };
+    const defaultQueryOnSuccess = useCallback(
+        (data: GetListResponse<TData>) => {
+            {
+                setOptions(
+                    data.data.map((item) => ({
+                        label: get(item, optionLabel),
+                        value: get(item, optionValue),
+                    })),
+                );
+            }
+        },
+        [optionLabel, optionValue],
+    );
 
     const queryResult = useList<TData, TError>({
         resource,

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -152,8 +152,10 @@ export const useSelect = <
         resource,
         ids: defaultValues,
         queryOptions: {
-            enabled: defaultValues.length > 0,
             ...defaultValueQueryOptions,
+            enabled:
+                defaultValues.length > 0 &&
+                (defaultValueQueryOptionsFromProps?.enabled ?? true),
             onSuccess: (data) => {
                 defaultValueQueryOnSuccess(data);
                 defaultValueQueryOptions?.onSuccess?.(data);


### PR DESCRIPTION
`queryOptions` was override `useMany`'s enabled prop. Because of that `useMany` was triggering without `defaultValues` and and it was fetching all the data.

@vinclou Thanks for the issue 🚀 

### Test plan (required)
![image](https://user-images.githubusercontent.com/23058882/195057042-94c98b01-bbe9-40b8-8247-1e061a7e3e2f.png)

### Closing issues
closes #2692

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
