### PR TITLE
fix(core): `useSelect`'s overriden `onSearch` prop not calling when value is empty

### DIFF
--- a/.changeset/stupid-trains-smile.md
+++ b/.changeset/stupid-trains-smile.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-core": patch
+---
+
+fix: `useSelect()`'s overridden `onSearch` function is not calling when value is empty.

--- a/packages/core/src/hooks/useSelect/index.spec.ts
+++ b/packages/core/src/hooks/useSelect/index.spec.ts
@@ -296,6 +296,55 @@ describe("useSelect Hook", () => {
         });
     });
 
+    it("should onSearchFromProp work as expected", async () => {
+        const getListMock = jest.fn(() =>
+            Promise.resolve({ data: [], total: 0 }),
+        );
+
+        const { result } = renderHook(
+            () =>
+                useSelect({
+                    resource: "posts",
+                    onSearch: (value) => {
+                        return [
+                            {
+                                field: "title",
+                                operator: "contains",
+                                value,
+                            },
+                        ];
+                    },
+                }),
+            {
+                wrapper: TestWrapper({
+                    dataProvider: {
+                        default: {
+                            ...MockJSONServer.default!,
+                            getList: getListMock,
+                        },
+                    },
+                    resources: [{ name: "posts" }],
+                }),
+            },
+        );
+
+        const { onSearch } = result.current;
+
+        onSearch("1");
+        await waitFor(() => {
+            expect(getListMock).toBeCalledTimes(2);
+        });
+
+        onSearch("");
+        await waitFor(() => {
+            expect(getListMock).toBeCalledTimes(3);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queryResult.isSuccess).toBeTruthy();
+        });
+    });
+
     it("should invoke queryOptions methods successfully", async () => {
         const mockFunc = jest.fn();
 

--- a/packages/core/src/hooks/useSelect/index.ts
+++ b/packages/core/src/hooks/useSelect/index.ts
@@ -93,7 +93,7 @@ export type UseSelectProps<TData, TError> = {
 export type UseSelectReturnType<TData extends BaseRecord = BaseRecord> = {
     queryResult: QueryObserverResult<GetListResponse<TData>>;
     defaultValueQueryResult: QueryObserverResult<GetManyResponse<TData>>;
-    onSearch: (value: string | undefined) => void;
+    onSearch: (value: string) => void;
     options: Option[];
 };
 
@@ -196,14 +196,15 @@ export const useSelect = <
         dataProviderName,
     });
 
-    const onSearch = (value: string | undefined) => {
-        if (!value) {
-            setSearch([]);
+    const onSearch = (value: string) => {
+        if (onSearchFromProp) {
+            setSearch(onSearchFromProp(value));
             return;
         }
 
-        if (onSearchFromProp) {
-            setSearch(onSearchFromProp(value));
+        if (!value) {
+            setSearch([]);
+            return;
         } else {
             setSearch([
                 {


### PR DESCRIPTION
`useSelect()`'s overridden `onSearch` function is not calling when value is empty.
To solve that, conditions flow reordered.

### Test plan (required)
![image](https://user-images.githubusercontent.com/23058882/195058969-a1cd118d-db06-494f-9353-0e0648ff858b.png)

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
