### PR TITLE
fix: providers property empty array state

### DIFF
--- a/.changeset/stupid-carrots-exercise.md
+++ b/.changeset/stupid-carrots-exercise.md
@@ -1,0 +1,7 @@
+---
+"@pankod/refine-antd": patch
+"@pankod/refine-mantine": patch
+"@pankod/refine-mui": patch
+---
+
+Fixed `providers` property empty array state in `<AuthPage />` component

--- a/packages/antd/src/components/pages/auth/components/login/index.tsx
+++ b/packages/antd/src/components/pages/auth/components/login/index.tsx
@@ -51,7 +51,7 @@ export const LoginPage: React.FC<LoginProps> = ({
     );
 
     const renderProviders = () => {
-        if (providers) {
+        if (providers && providers.length > 0) {
             return (
                 <>
                     {providers.map((provider) => {

--- a/packages/antd/src/components/pages/auth/components/register/index.tsx
+++ b/packages/antd/src/components/pages/auth/components/register/index.tsx
@@ -52,7 +52,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
     );
 
     const renderProviders = () => {
-        if (providers) {
+        if (providers && providers.length > 0) {
             return (
                 <>
                     {providers.map((provider) => {

--- a/packages/mantine/src/components/pages/auth/components/login/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/login/index.tsx
@@ -66,7 +66,7 @@ export const LoginPage: React.FC<LoginProps> = ({
     const { mutate: login, isLoading } = useLogin<LoginFormTypes>();
 
     const renderProviders = () => {
-        if (providers) {
+        if (providers && providers.length > 0) {
             return (
                 <>
                     <Stack spacing={8}>

--- a/packages/mantine/src/components/pages/auth/components/register/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/register/index.tsx
@@ -63,7 +63,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
     const { mutate: register, isLoading } = useLogin<RegisterFormTypes>();
 
     const renderProviders = () => {
-        if (providers) {
+        if (providers && providers.length > 0) {
             return (
                 <>
                     <Stack spacing={8}>

--- a/packages/mui/src/components/pages/auth/components/login/index.tsx
+++ b/packages/mui/src/components/pages/auth/components/login/index.tsx
@@ -58,7 +58,7 @@ export const LoginPage: React.FC<LoginProps> = ({
     const { Link } = useRouterContext();
 
     const renderProviders = () => {
-        if (providers) {
+        if (providers && providers.length > 0) {
             return (
                 <>
                     {providers.map((provider: any) => {

--- a/packages/mui/src/components/pages/auth/components/register/index.tsx
+++ b/packages/mui/src/components/pages/auth/components/register/index.tsx
@@ -60,7 +60,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
     const { Link } = useRouterContext();
 
     const renderProviders = () => {
-        if (providers) {
+        if (providers && providers.length > 0) {
             return (
                 <>
                     {providers.map((provider: any) => {


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:
Divider renders when empty array is sent to providers

![Screen Shot 2022-10-11 at 14 41 46](https://user-images.githubusercontent.com/1110414/195080732-38351ff1-3b5b-41bf-8c8f-e2e5853da41e.png)

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
