### PR TITLE
docs: refactor data provider docs

### DIFF
--- a/documentation/docs/api-reference/core/hooks/data/useCreateMany.md
+++ b/documentation/docs/api-reference/core/hooks/data/useCreateMany.md
@@ -9,6 +9,10 @@ description: useCreateMany data hook from refine is a modified version of react-
 
 It uses `createMany` method as mutation function from the [`dataProvider`](/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
+:::tip
+If your data provider didn't implement `createMany` method, `useCreateMany` will use `create` method multiple times instead.
+:::
+
 ## Features
 
 -   Shows notifications after the mutation succeeds or fails.

--- a/documentation/docs/api-reference/core/hooks/data/useDeleteMany.md
+++ b/documentation/docs/api-reference/core/hooks/data/useDeleteMany.md
@@ -9,6 +9,10 @@ description: useDeleteMany data hook from refine is a modified version of react-
 
 It uses `deleteMany` method as mutation function from the [`dataProvider`](/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
+:::tip
+If your data provider didn't implement `deleteMany` method, `useDeleteMany` will use `deleteOne` method multiple times instead.
+:::
+
 ## Features
 
 -   Shows notifications after the mutation succeeds, fails or gets canceled.

--- a/documentation/docs/api-reference/core/hooks/data/useMany.md
+++ b/documentation/docs/api-reference/core/hooks/data/useMany.md
@@ -9,6 +9,10 @@ description: useMany data hook from refine is a modified version of react-query'
 
 It uses `getMany` method as query function from the [`dataProvider`](/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
+:::tip
+If your data provider didn't implement `getMany` method, `useMany` will use `getOne` method multiple times instead.
+:::
+
 ## Usage
 
 Let's say that we have a resource named `categories`.

--- a/documentation/docs/api-reference/core/hooks/data/useUpdateMany.md
+++ b/documentation/docs/api-reference/core/hooks/data/useUpdateMany.md
@@ -7,6 +7,10 @@ description: useUpdateMany data hook from refine is a modified version of react-
 
 `useUpdateMany` is a modified version of `react-query`'s [`useMutation`](https://react-query.tanstack.com/reference/useMutation#) for multiple update mutations. It uses `updateMany` method as mutation function from the [`dataProvider`](/api-reference/core/providers/data-provider.md) which is passed to `<Refine>`.
 
+:::tip
+If your data provider didn't implement `updateMany` method, `useUpdateMany` will use `update` method multiple times instead.
+:::
+
 ## Features
 
 -   Shows notifications after the mutation succeeds, fails, or gets canceled.

--- a/documentation/docs/api-reference/core/providers/data-provider.md
+++ b/documentation/docs/api-reference/core/providers/data-provider.md
@@ -307,14 +307,14 @@ const SimpleRestDataProvider = (
     httpClient: AxiosInstance = axiosInstance,
 ): DataProvider => ({
     create: ({ resource, variables, metaData }) => Promise,
-    createMany: ({ resource, variables, metaData }) => Promise,
+    createMany?: ({ resource, variables, metaData }) => Promise,
     deleteOne: ({ resource, id, variables, metaData }) => Promise,
-    deleteMany: ({ resource, ids, variables, metaData }) => Promise,
+    deleteMany?: ({ resource, ids, variables, metaData }) => Promise,
     getList: ({ resource, pagination, sort, filters, metaData }) => Promise,
-    getMany: ({ resource, ids, metaData }) => Promise,
+    getMany?: ({ resource, ids, metaData }) => Promise,
     getOne: ({ resource, id, metaData }) => Promise,
     update: ({ resource, id, variables, metaData }) => Promise,
-    updateMany: ({ resource, ids, variables, metaData }) => Promise,
+    updateMany?: ({ resource, ids, variables, metaData }) => Promise,
     custom: ({
         url,
         method,
@@ -330,6 +330,10 @@ const SimpleRestDataProvider = (
 ```
 
 It will take the API URL as a parameter and an optional **HTTP** client. We will use **axios** as the default **HTTP** client.
+
+:::note
+    `getMany`, `createMany`, `updateMany` and `deleteMany` properties are optional. If you don't implement them, Refine will use `getOne`, `create`, `update` and `deleteOne` methods to handle multiple requests. If your API supports these methods, you can implement them to improve performance.
+:::
 
 <br/>
 

--- a/documentation/docs/api-reference/core/providers/data-provider.md
+++ b/documentation/docs/api-reference/core/providers/data-provider.md
@@ -504,7 +504,7 @@ mutate({ resource: "categories", id: "2" });
 
 ### `deleteMany`
 
-This method allows us to delete multiple items in a resource. Implementation of this method is optional. If you don't implement it, Refine will use `deleteOne` method to handle multiple requests.
+This method allows us to delete multiple items in a resource. Implementation of this method is optional. If you don't implement it, refine will use `deleteOne` method to handle multiple requests.
 
 ```ts title="dataProvider.ts"
 const SimpleRestDataProvider = (

--- a/documentation/docs/api-reference/core/providers/data-provider.md
+++ b/documentation/docs/api-reference/core/providers/data-provider.md
@@ -394,7 +394,7 @@ mutate({
 
 ### `createMany`
 
-This method allows us to create multiple items in a resource. Implementation of this method is optional. If you don't implement it, Refine will use `create` method to handle multiple requests.
+This method allows us to create multiple items in a resource. Implementation of this method is optional. If you don't implement it, refine will use `create` method to handle multiple requests.
 
 ```ts title="dataProvider.ts"
 const SimpleRestDataProvider = (

--- a/documentation/docs/api-reference/core/providers/data-provider.md
+++ b/documentation/docs/api-reference/core/providers/data-provider.md
@@ -709,7 +709,7 @@ const { data } = useOne<ICategory>({ resource: "categories", id: "1" });
 
 ### `getMany`
 
-This method allows us to retrieve multiple items in a resource. Implementation of this method is optional. If you don't implement it, Refine will use `getOne` method to handle multiple requests.
+This method allows us to retrieve multiple items in a resource. Implementation of this method is optional. If you don't implement it, refine will use `getOne` method to handle multiple requests.
 
 ```ts title="dataProvider.ts"
 import { stringify } from "query-string";

--- a/documentation/docs/api-reference/core/providers/data-provider.md
+++ b/documentation/docs/api-reference/core/providers/data-provider.md
@@ -394,7 +394,7 @@ mutate({
 
 ### `createMany`
 
-This method allows us to create multiple items in a resource.
+This method allows us to create multiple items in a resource. Implementation of this method is optional. If you don't implement it, Refine will use `create` method to handle multiple requests.
 
 ```ts title="dataProvider.ts"
 const SimpleRestDataProvider = (
@@ -404,17 +404,12 @@ const SimpleRestDataProvider = (
     ...
 // highlight-start
     createMany: async ({ resource, variables }) => {
-        const response = await Promise.all(
-            variables.map(async (param) => {
-                const { data } = await httpClient.post(
-                    `${apiUrl}/${resource}`,
-                    param,
-                );
-                return data;
-            }),
+        const response = await httpClient.post(
+            `${apiUrl}/${resource}/bulk`,
+            { values: variables },
         );
 
-        return { data: response };
+        return response;
     },
 // highlight-end
     ...
@@ -509,7 +504,7 @@ mutate({ resource: "categories", id: "2" });
 
 ### `deleteMany`
 
-This method allows us to delete multiple items in a resource.
+This method allows us to delete multiple items in a resource. Implementation of this method is optional. If you don't implement it, Refine will use `deleteOne` method to handle multiple requests.
 
 ```ts title="dataProvider.ts"
 const SimpleRestDataProvider = (
@@ -519,15 +514,10 @@ const SimpleRestDataProvider = (
     ...
 // highlight-start
     deleteMany: async ({ resource, ids }) => {
-        const response = await Promise.all(
-            ids.map(async (id) => {
-                const { data } = await httpClient.delete(
-                    `${apiUrl}/${resource}/${id}`,
-                );
-                return data;
-            }),
+        const response = await httpClient.delete(
+            `${apiUrl}/${resource}/bulk?ids=${ids.join(",")}`,
         );
-        return { data: response };
+        return response;
     },
 // highlight-end
     ...
@@ -620,7 +610,7 @@ mutate({
 
 ### `updateMany`
 
-This method allows us to update multiple items in a resource.
+This method allows us to update multiple items in a resource. Implementation of this method is optional. If you don't implement it, Refine will use `update` method to handle multiple requests.
 
 ```ts title="dataProvider.ts"
 const SimpleRestDataProvider = (
@@ -630,17 +620,11 @@ const SimpleRestDataProvider = (
     ...
 // highlight-start
     updateMany: async ({ resource, ids, variables }) => {
-        const response = await Promise.all(
-            ids.map(async (id) => {
-                const { data } = await httpClient.patch(
-                    `${apiUrl}/${resource}/${id}`,
-                    variables,
-                );
-                return data;
-            }),
+        const response = await httpClient.patch(
+            `${apiUrl}/${resource}/bulk`,
+            { ids, variables },
         );
-
-        return { data: response };
+        return response;
     },
 // highlight-end
     ...
@@ -725,7 +709,7 @@ const { data } = useOne<ICategory>({ resource: "categories", id: "1" });
 
 ### `getMany`
 
-This method allows us to retrieve multiple items in a resource.
+This method allows us to retrieve multiple items in a resource. Implementation of this method is optional. If you don't implement it, Refine will use `getOne` method to handle multiple requests.
 
 ```ts title="dataProvider.ts"
 import { stringify } from "query-string";

--- a/documentation/docs/api-reference/core/providers/data-provider.md
+++ b/documentation/docs/api-reference/core/providers/data-provider.md
@@ -610,7 +610,7 @@ mutate({
 
 ### `updateMany`
 
-This method allows us to update multiple items in a resource. Implementation of this method is optional. If you don't implement it, Refine will use `update` method to handle multiple requests.
+This method allows us to update multiple items in a resource. Implementation of this method is optional. If you don't implement it, refine will use `update` method to handle multiple requests.
 
 ```ts title="dataProvider.ts"
 const SimpleRestDataProvider = (

--- a/examples/dataProvider/multiple/src/App.tsx
+++ b/examples/dataProvider/multiple/src/App.tsx
@@ -11,6 +11,7 @@ import "@pankod/refine-antd/dist/styles.min.css";
 import { PostList } from "pages/posts";
 
 const API_URL = "https://api.fake-rest.refine.dev";
+const CATEGORIES_API_URL = "https://api.fake-rest.refine.dev";
 const FINE_FOODS_API_URL = "https://api.finefoods.refine.dev";
 
 const App: React.FC = () => {
@@ -19,12 +20,19 @@ const App: React.FC = () => {
             routerProvider={routerProvider}
             dataProvider={{
                 default: dataProvider(API_URL),
+                categories: dataProvider(CATEGORIES_API_URL),
                 fineFoods: dataProvider(FINE_FOODS_API_URL),
             }}
             resources={[
                 {
                     name: "posts",
                     list: PostList,
+                },
+                {
+                    name: "categories",
+                    options: {
+                        dataProviderName: "categories",
+                    },
                 },
             ]}
             notificationProvider={notificationProvider}


### PR DESCRIPTION
- Added Multiple data providers section to the data provider document.
- Added multiple data provider live preview
- Added usage of `resource.options.dataProviderName` to examples
- Marked `*Many` properties as optional in the documentation
- Added `*Many` note in the documentation