### PR TITLE
feat(docs): add `<PropsTable>` to core components

### DIFF
--- a/documentation/docs/api-reference/core/components/accessControl/canAccess.md
+++ b/documentation/docs/api-reference/core/components/accessControl/canAccess.md
@@ -15,7 +15,7 @@ import { CanAccess } from "@pankod/refine-core";
     fallback={<CustomFallback />}
 >
     <YourComponent />
-</CanAccess>;
+</CanAccess>
 ```
 
 ## API Reference

--- a/documentation/docs/api-reference/core/components/accessControl/canAccess.md
+++ b/documentation/docs/api-reference/core/components/accessControl/canAccess.md
@@ -7,7 +7,7 @@ siderbar_label: <CanAccess>
 `<CanAccess />` is a wrapper component that uses `useCan` to check for access control. It takes the parameters that `can` method takes and also a `fallback`. It renders its children if the access control returns true and if access control returns false renders `fallback` if provided.
 
 ```tsx
-import { CanAccess } from "@pankod/refine-core"
+import { CanAccess } from "@pankod/refine-core";
 <CanAccess
     resource="posts"
     action="edit"
@@ -15,16 +15,11 @@ import { CanAccess } from "@pankod/refine-core"
     fallback={<CustomFallback />}
 >
     <YourComponent />
-</CanAccess>
+</CanAccess>;
 ```
 
 ## API Reference
 
 ### Properties
 
-| Property                                                                                            | Description                                     | Type        | Default |
-| --------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ----------- | ------- |
-| <div className="required-block"><div>resource</div> <div className=" required">Required</div></div> | Resource name for API data interactions         | `string`    |         |
-| action <div className="required">Required</div>                                                     | Intenden action on resource                     | `string`    |         |
-| params                                                                                              | Parameters associated with the resource         | `any`       |         |
-| fallback                                                                                            | Content to show if access control returns false | `ReactNode` |         |
+<PropsTable module="@pankod/refine-core/CanAccess"/>

--- a/documentation/docs/api-reference/core/components/auth-page.md
+++ b/documentation/docs/api-reference/core/components/auth-page.md
@@ -113,7 +113,6 @@ render(<App />);
 -   `"forgotPassword"` - type of the forgot password page.
 -   `"updatePassword"` - type of the update password page.
 
-
 ### Login
 
 You can use the following props for the `<AuthPage>` component when the type is `"login"`:
@@ -154,6 +153,7 @@ render(<App/>);
 ```
 
 ### Register
+
 The register page will be used to register new users. You can use the following props for the `<AuthPage>` component when the type is `"register"`:
 
 ```tsx live disableScroll hideCode url=http://localhost:3000/login previewHeight=390px
@@ -193,6 +193,7 @@ render(<App/>);
 ```
 
 ### ForgotPassword
+
 The `forgotPassword` type is a page that allows users to reset their passwords. You can use this page to reset your password.
 
 ```tsx live url=http://localhost:3000/forgot-password
@@ -232,6 +233,7 @@ render(<App />);
 ```
 
 ### UpdatePassword
+
 The `updatePassword` type is the page used to update the password of the user.
 
 ```tsx live url=http://localhost:3000/update-password
@@ -271,7 +273,9 @@ render(<App />);
 ```
 
 ## Props
+
 ### `providers`
+
 :::info
 `providers` property is only available for types `login` and `register`.
 :::
@@ -283,7 +287,12 @@ setInitialRoutes(["/login"]);
 setRefineProps({ Sider: () => null });
 
 // visible-block-start
-import { Refine, useRouterContext, useNavigation, AuthPage } from "@pankod/refine-core";
+import {
+    Refine,
+    useRouterContext,
+    useNavigation,
+    AuthPage,
+} from "@pankod/refine-core";
 import routerProvider from "@pankod/refine-react-router-v6";
 
 import { authProvider } from "./authProvider";
@@ -339,8 +348,7 @@ const LoginPage = () => {
             ]}
         />
     );
-
-}
+};
 
 const App = () => {
     return (
@@ -356,9 +364,7 @@ const App = () => {
     );
 };
 // visible-block-end
-render(
-    <App />,
-);
+render(<App />);
 ```
 
 ### `rememberMe`
@@ -395,7 +401,8 @@ const App = () => {
                                 padding: 3,
                             }}
                         >
-                            <input name="CustomRememberMe" type="checkbox" /> Custom remember me
+                            <input name="CustomRememberMe" type="checkbox" />{" "}
+                            Custom remember me
                         </div>
                     }
                 />
@@ -407,11 +414,8 @@ const App = () => {
     );
 };
 // visible-block-end
-render(
-    <App />,
-);
+render(<App />);
 ```
-
 
 ### `loginLink`
 
@@ -529,7 +533,7 @@ const App = () => {
                 ...routerProvider,
                 routes: [
                     { path: "/register", element: <Auth type="register" /> },
-                ]
+                ],
             }}
             // highlight-next-line
             LoginPage={Auth}
@@ -591,8 +595,11 @@ const App = () => {
             routerProvider={{
                 ...routerProvider,
                 routes: [
-                    { path: "/forgot-password", element: <Auth type="forgotPassword" /> },
-                ]
+                    {
+                        path: "/forgot-password",
+                        element: <Auth type="forgotPassword" />,
+                    },
+                ],
             }}
             // highlight-next-line
             LoginPage={Auth}
@@ -630,7 +637,8 @@ const App = () => {
                     // highlight-start
                     wrapperProps={{
                         style: {
-                            background: "linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)",
+                            background:
+                                "linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)",
                             position: "absolute",
                             top: "0px",
                             right: "0px",
@@ -675,7 +683,8 @@ const App = () => {
                     // highlight-start
                     contentProps={{
                         style: {
-                            background: "linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)",
+                            background:
+                                "linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)",
                         },
                     }}
                     // highlight-end
@@ -800,22 +809,12 @@ render(<App />);
 
 ### Properties
 
-| Property           | Description                                                                         | Type                                                          |
-| ------------------ | ----------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| type               | Render `<AuthPage>` forms by `type` property.                                       | `login` \| `register` \| `forgotPassword` \| `updatePassword` |
-| providers          | Render auth logins if `type` is `"login"`.                                          | [`IProvider[]`](#interface)                                   |
-| registerLink       | A custom node that will be rendered as a register link to the `<AuthPage>`.         | `React.ReactNode`                                             |
-| loginLink          | A custom node that will be rendered as a link to the `<AuthPage>`.                  | `React.ReactNode`                                             |
-| forgotPasswordLink | A custom node that will be rendered as a forgot password link to the `<AuthPage>`.  | `React.ReactNode`                                             |
-| wrapperProps       | Wrapper element props.                                                              | [`HTMLDivElement`]                                            |
-| contentProps       | Content wrapper element props.                                                      | [`HTMLDivElement`]                                            |
-| formProps          | Props for the form component.                                                       | [`HTMLFormElement`]                                           |
-| renderContent      | Gives you default content you can use it to add some extra elements to the content. | `function(content: React.ReactNode) => React.ReactNode`       |
+<PropsTable module="@pankod/refine-core/AuthPage"/>
 
 ### Interface
 
 ```tsx
-interface IProvider {
+interface OAuthProvider {
     name: string;
     icon?: React.ReactNode;
     label?: string;

--- a/documentation/docs/api-reference/core/components/auth/authenticated.md
+++ b/documentation/docs/api-reference/core/components/auth/authenticated.md
@@ -3,27 +3,29 @@ id: authenticated
 title: <Authenticated>
 ---
 
-`<Authenticated>` is the component form of [`useAuthenticated`][useAuthenticated]. It internally uses [`useAuthenticated`][useAuthenticated] to provide it's functionality.
+`<Authenticated>` is the component form of [`useAuthenticated`][useauthenticated]. It internally uses [`useAuthenticated`][useauthenticated] to provide it's functionality.
 
 ```tsx
-import { Authenticated } from "@pankod/refine-core"
+import { Authenticated } from "@pankod/refine-core";
 
 <Authenticated>
     <YourComponent />
-</Authenticated>
+</Authenticated>;
 ```
 
-For an example use, see [Custom Pages Example][Custom Pages Example] and [it's explanation][Custom Pages Explanation].
+For an example use, see [Custom Pages Example][custom pages example] and [it's explanation][custom pages explanation].
 
 ## API Reference
 
 ### Properties
+
+<PropsTable module="@pankod/refine-core/Authenticated"/>
 
 | Property | Description                                                           | Type        | Default |
 | -------- | --------------------------------------------------------------------- | ----------- | ------- |
 | fallback | Content to show if user is not logged in. If undefined, routes to `/` | `ReactNode` |         |
 | loading  | Content to show while checking whether user is logged in              | `ReactNode` |         |
 
-[useAuthenticated]: /api-reference/core/hooks/auth/useAuthenticated.md
-[Custom Pages Explanation]: /advanced-tutorials/custom-pages.md#authenticated-custom-pages
-[Custom Pages Example]: /examples/custom-pages.md
+[useauthenticated]: /api-reference/core/hooks/auth/useAuthenticated.md
+[custom pages explanation]: /advanced-tutorials/custom-pages.md#authenticated-custom-pages
+[custom pages example]: /examples/custom-pages.md

--- a/documentation/docs/api-reference/core/components/layout-wrapper.md
+++ b/documentation/docs/api-reference/core/components/layout-wrapper.md
@@ -69,14 +69,7 @@ In this example, we hide the left sider only for this page. The rest should look
 
 ### Properties
 
-| Property      | Description                                           | Type       | Default |
-| ------------- | ----------------------------------------------------- | ---------- | ------- |
-| Layout        | Outer component that renders other components         | `React.FC` | \*      |
-| Sider         | [Custom sider to use][refine#sider]                   | `React.FC` | \*      |
-| Header        | [Custom header to use][refine#header]                 | `React.FC` | \*      |
-| Title         | [Custom title to use][refine#title]                   | `React.FC` | \*      |
-| Footer        | [Custom footer to use][refine#footer]                 | `React.FC` | \*      |
-| OffLayoutArea | [Custom off layout area to use][refine#offlayoutarea] | `React.FC` | \*      |
+<PropsTable module="@pankod/refine-core/LayoutWrapper"/>
 
 > `*`: These props have default values in `RefineContext` and can also be set on **<[Refine][refine]>** component.
 

--- a/documentation/docs/api-reference/core/components/refine-config.md
+++ b/documentation/docs/api-reference/core/components/refine-config.md
@@ -774,4 +774,10 @@ const App: React.FC = () => (
 );
 ```
 
+## API Reference
+
+### Properties
+    
+<PropsTable module="@pankod/refine-core/Refine"/>
+
 [routerprovider]: /api-reference/core/providers/router-provider.md

--- a/packages/core/src/components/authenticated/index.tsx
+++ b/packages/core/src/components/authenticated/index.tsx
@@ -3,7 +3,13 @@ import React from "react";
 import { useAuthenticated, useNavigation, useRouterContext } from "@hooks";
 
 export type AuthenticatedProps = {
+    /**
+     * Content to show if user is not logged in. If undefined, routes to `/`
+     */
     fallback?: React.ReactNode;
+    /**
+     * Content to show while checking whether user is logged in
+     */
     loading?: React.ReactNode;
     children: React.ReactNode;
 };

--- a/packages/core/src/components/canAccess/index.tsx
+++ b/packages/core/src/components/canAccess/index.tsx
@@ -4,6 +4,9 @@ import { useCan } from "@hooks";
 import { CanParams } from "../../interfaces";
 
 export type CanAccessProps = CanParams & {
+    /**
+     * Content to show if access control returns `false`
+     */
     fallback?: React.ReactNode;
     children: React.ReactNode;
 };

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -51,6 +51,11 @@ interface QueryClientConfig {
 }
 export interface RefineProps {
     /**
+     * `resources` is the main building block of a refine app. A resource represents an entity in an endpoint in the API.
+     * @type [`ResourceProps[]`](/docs/api-reference/core/components/refine-config/#resources)
+     */
+    resources?: ResourceProps[];
+    /**
      * `authProvider` handles authentication logic like login, logout flow and checking user credentials. It is an object with methods that refine uses when necessary.
      * @type [`AuthProvider`](/docs/api-reference/core/providers/auth-provider/)
      */
@@ -85,11 +90,6 @@ export interface RefineProps {
      * @type [`AuditLogProvider`](/docs/api-reference/core/providers/audit-log-provider#overview)
      */
     auditLogProvider?: AuditLogProvider;
-    /**
-     * `resources` is the main building block of a refine app. A resource represents an entity in an endpoint in the API.
-     * @type [`ResourceProps[]`](/docs/api-reference/core/components/refine-config/#resources)
-     */
-    resources?: ResourceProps[];
     /**
      * `i18nProvider` property lets you add i18n support to your app. Making you able to use any i18n framework.
      * @type [`i18nProvider`](/docs/api-reference/core/providers/i18n-provider/)

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -117,6 +117,7 @@ export interface RefineProps {
     ReadyPage?: React.FC;
     /**
      * `mutationMode` determines which mode the mutations run with. (e.g. useUpdate, useDelete).
+     * @deprecated `mutationMode` property is deprecated at this level. Use it from within `options` instead.
      * @type [`MutationMode`](/docs/api-reference/core/components/refine-config/#mutationmode)
      * @default "pessimistic"
      */

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -50,77 +50,177 @@ interface QueryClientConfig {
     defaultOptions?: DefaultOptions;
 }
 export interface RefineProps {
+    /**
+     * `authProvider` handles authentication logic like login, logout flow and checking user credentials. It is an object with methods that refine uses when necessary.
+     * @type [`AuthProvider`](/docs/api-reference/core/providers/auth-provider/)
+     */
     authProvider?: AuthProvider;
+    /**
+     * A `dataProvider` is the place where a refine app communicates with an API. Data providers also act as adapters for refine, making it possible for it to consume different API's and data services.
+     * @type [`IDataContextProvider` | `IDataMultipleContextProvider`](/docs/api-reference/core/providers/data-provider/)
+     */
     dataProvider: IDataContextProvider | IDataMultipleContextProvider;
+    /**
+     * **refine** lets you add Realtime support to your app via `liveProvider`. It can be used to update and show data in Realtime throughout your app.
+     * @type [`ILiveContext`](/docs/api-reference/core/providers/live-provider/)
+     */
     liveProvider?: ILiveContext;
+    /**
+     * **refine** needs some router functions to create resource pages, handle navigation, etc. This provider allows you to use the router library you want
+     * @type [`IRouterProvider`](/docs/api-reference/core/providers/router-provider/)
+     */
     routerProvider: IRouterProvider;
+    /**
+     * `notificationProvider` handles notification logics. It is an object with methods that refine uses when necessary.
+     * @type [`NotificationProvider` | `(() => NotificationProvider)`](/docs/api-reference/core/providers/notification-provider/)
+     */
     notificationProvider?: NotificationProvider | (() => NotificationProvider);
+    /**
+     * `accessControlProvider` is the entry point for implementing access control for refine apps.
+     * @type [`AccessControlProvider`](/docs/api-reference/core/providers/accessControl-provider/)
+     */
     accessControlProvider?: AccessControlProvider;
+    /**
+     * **refine** allows you to track changes in your data and keep track of who made the changes.
+     * @type [`AuditLogProvider`](/docs/api-reference/core/providers/audit-log-provider#overview)
+     */
     auditLogProvider?: AuditLogProvider;
+    /**
+     * `resources` is the main building block of a refine app. A resource represents an entity in an endpoint in the API.
+     * @type [`ResourceProps[]`](/docs/api-reference/core/components/refine-config/#resources)
+     */
     resources?: ResourceProps[];
+    /**
+     * `i18nProvider` property lets you add i18n support to your app. Making you able to use any i18n framework.
+     * @type [`i18nProvider`](/docs/api-reference/core/providers/i18n-provider/)
+     */
     i18nProvider?: I18nProvider;
+    /**
+     * A custom error component.
+     * @type [`ReactNode`](/docs/api-reference/core/components/refine-config/#catchall)
+     */
     catchAll?: React.ReactNode;
+    /**
+     * Custom login component can be passed to the `LoginPage` property.
+     * @type [`React.FC`](/docs/api-reference/core/components/refine-config/#loginpage)
+     */
     LoginPage?: React.FC;
+    /**
+     * A custom dashboard page can be passed to the `DashboardPage` prop which is accessible on root route.
+     * @type [`React.FC<DashboardPageProps>`](/docs/api-reference/core/components/refine-config/#dashboardpage)
+     */
     DashboardPage?: React.FC<DashboardPageProps>;
+    /**
+     * Custom ready page component can be set by passing to `ReadyPage` property.
+     * @type [`React.FC`](/docs/api-reference/core/components/refine-config/#readypage)
+     */
     ReadyPage?: React.FC;
-    /** 
-        @deprecated `mutationMode` property is deprecated at this level. Use it from within `options` instead.
-        @example  `options={{ mutationMode: "optimistic" }}`
-        @see https://refine.dev/docs/core/components/refine-config/#mutationmode
+    /**
+     * `mutationMode` determines which mode the mutations run with. (e.g. useUpdate, useDelete).
+     * @type [`MutationMode`](/docs/api-reference/core/components/refine-config/#mutationmode)
+     * @default "pessimistic"
      */
     mutationMode?: MutationMode;
     /** 
+     * List query parameter values can be edited manually by typing directly in the URL. To activate this feature syncWithLocation needs to be set to true.
         @deprecated `syncWithLocation` property is deprecated at this level. Use it from within `options` instead.
         @example  `options={{ syncWithLocation: true }}`
         @see https://refine.dev/docs/core/components/refine-config/#syncwithlocation
+     *  @type [`boolean`](/docs/api-reference/core/components/refine-config/#syncwithlocation)
      */
     syncWithLocation?: boolean;
     /** 
+     *  When you have unsaved changes and try to leave the current page, **refine** shows a confirmation modal box.
         @deprecated `warnwhenunsavedchanges` property is deprecated at this level. Use it from within `options` instead.
         @example  `options={{ warnwhenunsavedchanges: true }}`
         @see https://refine.dev/docs/core/components/refine-config/#warnwhenunsavedchanges
+    *   @type [`boolean`](/docs/api-reference/core/components/refine-config/#warnwhenunsavedchanges)
      */
     warnWhenUnsavedChanges?: boolean;
     /** 
+     *  The duration of the timeout period in undoable mode, shown in milliseconds. Mutations can be cancelled during this period.
         @deprecated `undoableTimeout` property is deprecated at this level. Use it from within `options` instead.
         @example  `options={{ undoableTimeout: 5000 }}`
         @see https://refine.dev/docs/core/components/refine-config/#undoabletimeout
+    *   @type [`number`](/docs/api-reference/core/components/refine-config/#undoabletimeout)
      */
     undoableTimeout?: number;
+    /**
+     * Default layout can be customized by passing the `Layout` property.
+     * @type [`React.FC<LayoutProps>`](/docs/api-reference/core/components/refine-config/#layout)
+     */
     Layout?: React.FC<LayoutProps>;
+    /**
+     * The default sidebar can be customized by using refine hooks and passing custom components to `Sider` property.
+     * @type [`React.FC`](/docs/api-reference/core/components/refine-config/#sider)
+     */
     Sider?: React.FC;
+    /**
+     * The default app header can be customized by passing the `Header` property.
+     * @type [`React.FC`](/docs/api-reference/core/components/refine-config/#header)
+     */
     Header?: React.FC;
+    /**
+     *The default app footer can be customized by passing the `Footer` property.
+     * @type [`React.FC`](/docs/api-reference/core/components/refine-config/#footer)
+     */
     Footer?: React.FC;
+    /**
+     * The component wanted to be placed out of app layout structure can be set by passing to `OffLayoutArea` prop.
+     * @type [`React.FC`](/docs/api-reference/core/components/refine-config/#offlayoutarea)
+     */
     OffLayoutArea?: React.FC;
+    /**
+     * TThe app title can be set by passing the `Title` property.
+     * @type [`React.FC<TitleProps>`](/docs/api-reference/core/components/refine-config/#title)
+     */
     Title?: React.FC<TitleProps>;
     /** 
-        @deprecated `reactQueryClientConfig` property is deprecated. Use `clientConfig` in `reactQuery` in `options` instead.
+     *  Config for React Query client that refine uses.
+        @deprecated `reactQueryClientConfig` property is deprecated. Use `clientConfig` in `reactQuery` in [`options`](/docs/api-reference/core/components/refine-config/#options) instead.
         @example  `options={{ reactQuery: { clientConfig: { queryCache: new QueryCache() } } }}`
         @see https://refine.dev/docs/core/components/refine-config/#clientconfig
+          @type [`QueryClientConfig` | `false`](/docs/api-reference/core/components/refine-config/#reactquery)
      */
     reactQueryClientConfig?: QueryClientConfig;
     /** 
-        @deprecated `reactQueryDevtoolConfig` property is deprecated. Use `devtoolConfig` in `reactQuery` in `options` instead.
+     *  Config for customize React Query Devtools.
+        @deprecated `reactQueryDevtoolConfig` property is deprecated. Use `devtoolConfig` in `reactQuery` in [`options`](/docs/api-reference/core/components/refine-config/#options) instead.
         @example  `options={{ reactQuery: { devtoolConfig: false } }}`
         @see https://refine.dev/docs/core/components/refine-config/#devtoolConfig
+        @type [`ReactQueryDevtools` | `false`](/docs/api-reference/core/components/refine-config/#devtoolconfig)
      */
     reactQueryDevtoolConfig?:
         | React.ComponentProps<typeof ReactQueryDevtools>
         | false;
 
     /** 
-        @deprecated `liveMode` property is deprecated. Use it from within `options` instead.
+     *  Whether to update data automatically (auto) or not (manual) if a related live event is received. The off value is used to avoid creating a subscription.
+        @deprecated `liveMode` property is deprecated. Use it from within [`options`](/docs/api-reference/core/components/refine-config/#options) instead.
         @example  `options={{ liveMode: "auto" }}`
         @see https://refine.dev/docs/core/components/refine-config/#livemode
+        @type [`LiveModeProps["liveMode"]`](/docs/api-reference/core/components/refine-config/#livemode)
      */
     liveMode?: LiveModeProps["liveMode"];
+    /**
+     * Callback to handle all live events.
+     * @type [`(event: LiveEvent) => void`](/docs/api-reference/core/providers/live-provider/#onliveevent)
+     */
     onLiveEvent?: LiveModeProps["onLiveEvent"];
     children?: React.ReactNode;
     /** 
-        @deprecated `disableTelemetry` property is deprecated. Use it from within `options` instead.
+        @deprecated `disableTelemetry` property is deprecated. Use it from within [`options`](/docs/api-reference/core/components/refine-config/#options) instead.
         @example  `options={{ disableTelemetry: true }}`
      */
+    /**
+     * **refine** implements a simple and transparent telemetry module for collecting usage statistics defined in a very limited scope. This telemetry module is used to improve the refine experience.
+     * @type [`boolean`](/docs/api-reference/core/components/refine-config/#disabletelemetry)
+     */
     disableTelemetry?: boolean;
+    /**
+     * `options` is used to configure the app.
+     * @type [`IRefineOptions`](/docs/api-reference/core/components/refine-config/#options-1)
+     * */
     options?: IRefineOptions;
 }
 

--- a/packages/core/src/components/containers/refine/index.tsx
+++ b/packages/core/src/components/containers/refine/index.tsx
@@ -50,31 +50,32 @@ interface QueryClientConfig {
     defaultOptions?: DefaultOptions;
 }
 export interface RefineProps {
+    children?: React.ReactNode;
     /**
      * `resources` is the main building block of a refine app. A resource represents an entity in an endpoint in the API.
      * @type [`ResourceProps[]`](/docs/api-reference/core/components/refine-config/#resources)
      */
     resources?: ResourceProps[];
     /**
-     * `authProvider` handles authentication logic like login, logout flow and checking user credentials. It is an object with methods that refine uses when necessary.
-     * @type [`AuthProvider`](/docs/api-reference/core/providers/auth-provider/)
+     * **refine** needs some router functions to create resource pages, handle navigation, etc. This provider allows you to use the router library you want
+     * @type [`IRouterProvider`](/docs/api-reference/core/providers/router-provider/)
      */
-    authProvider?: AuthProvider;
+    routerProvider: IRouterProvider;
     /**
      * A `dataProvider` is the place where a refine app communicates with an API. Data providers also act as adapters for refine, making it possible for it to consume different API's and data services.
      * @type [`IDataContextProvider` | `IDataMultipleContextProvider`](/docs/api-reference/core/providers/data-provider/)
      */
     dataProvider: IDataContextProvider | IDataMultipleContextProvider;
     /**
+     * `authProvider` handles authentication logic like login, logout flow and checking user credentials. It is an object with methods that refine uses when necessary.
+     * @type [`AuthProvider`](/docs/api-reference/core/providers/auth-provider/)
+     */
+    authProvider?: AuthProvider;
+    /**
      * **refine** lets you add Realtime support to your app via `liveProvider`. It can be used to update and show data in Realtime throughout your app.
      * @type [`ILiveContext`](/docs/api-reference/core/providers/live-provider/)
      */
     liveProvider?: ILiveContext;
-    /**
-     * **refine** needs some router functions to create resource pages, handle navigation, etc. This provider allows you to use the router library you want
-     * @type [`IRouterProvider`](/docs/api-reference/core/providers/router-provider/)
-     */
-    routerProvider: IRouterProvider;
     /**
      * `notificationProvider` handles notification logics. It is an object with methods that refine uses when necessary.
      * @type [`NotificationProvider` | `(() => NotificationProvider)`](/docs/api-reference/core/providers/notification-provider/)
@@ -116,37 +117,6 @@ export interface RefineProps {
      */
     ReadyPage?: React.FC;
     /**
-     * `mutationMode` determines which mode the mutations run with. (e.g. useUpdate, useDelete).
-     * @deprecated `mutationMode` property is deprecated at this level. Use it from within `options` instead.
-     * @type [`MutationMode`](/docs/api-reference/core/components/refine-config/#mutationmode)
-     * @default "pessimistic"
-     */
-    mutationMode?: MutationMode;
-    /** 
-     * List query parameter values can be edited manually by typing directly in the URL. To activate this feature syncWithLocation needs to be set to true.
-        @deprecated `syncWithLocation` property is deprecated at this level. Use it from within `options` instead.
-        @example  `options={{ syncWithLocation: true }}`
-        @see https://refine.dev/docs/core/components/refine-config/#syncwithlocation
-     *  @type [`boolean`](/docs/api-reference/core/components/refine-config/#syncwithlocation)
-     */
-    syncWithLocation?: boolean;
-    /** 
-     *  When you have unsaved changes and try to leave the current page, **refine** shows a confirmation modal box.
-        @deprecated `warnwhenunsavedchanges` property is deprecated at this level. Use it from within `options` instead.
-        @example  `options={{ warnwhenunsavedchanges: true }}`
-        @see https://refine.dev/docs/core/components/refine-config/#warnwhenunsavedchanges
-    *   @type [`boolean`](/docs/api-reference/core/components/refine-config/#warnwhenunsavedchanges)
-     */
-    warnWhenUnsavedChanges?: boolean;
-    /** 
-     *  The duration of the timeout period in undoable mode, shown in milliseconds. Mutations can be cancelled during this period.
-        @deprecated `undoableTimeout` property is deprecated at this level. Use it from within `options` instead.
-        @example  `options={{ undoableTimeout: 5000 }}`
-        @see https://refine.dev/docs/core/components/refine-config/#undoabletimeout
-    *   @type [`number`](/docs/api-reference/core/components/refine-config/#undoabletimeout)
-     */
-    undoableTimeout?: number;
-    /**
      * Default layout can be customized by passing the `Layout` property.
      * @type [`React.FC<LayoutProps>`](/docs/api-reference/core/components/refine-config/#layout)
      */
@@ -176,6 +146,22 @@ export interface RefineProps {
      * @type [`React.FC<TitleProps>`](/docs/api-reference/core/components/refine-config/#title)
      */
     Title?: React.FC<TitleProps>;
+    /**
+     * Callback to handle all live events.
+     * @type [`(event: LiveEvent) => void`](/docs/api-reference/core/providers/live-provider/#onliveevent)
+     */
+    onLiveEvent?: LiveModeProps["onLiveEvent"];
+    /**
+     * `options` is used to configure the app.
+     * @type [`IRefineOptions`](/docs/api-reference/core/components/refine-config/#options-1)
+     * */
+    options?: IRefineOptions;
+    /**
+     * **refine** implements a simple and transparent telemetry module for collecting usage statistics defined in a very limited scope. This telemetry module is used to improve the refine experience.
+     * @deprecated  `disableTelemetry`  property is deprecated. Use it from within [`options`](/docs/api-reference/core/components/refine-config/#options) instead.
+     * @type [`boolean`](/docs/api-reference/core/components/refine-config/#disabletelemetry)
+     */
+    disableTelemetry?: boolean;
     /** 
      *  Config for React Query client that refine uses.
         @deprecated `reactQueryClientConfig` property is deprecated. Use `clientConfig` in `reactQuery` in [`options`](/docs/api-reference/core/components/refine-config/#options) instead.
@@ -185,44 +171,59 @@ export interface RefineProps {
      */
     reactQueryClientConfig?: QueryClientConfig;
     /** 
-     *  Config for customize React Query Devtools.
-        @deprecated `reactQueryDevtoolConfig` property is deprecated. Use `devtoolConfig` in `reactQuery` in [`options`](/docs/api-reference/core/components/refine-config/#options) instead.
-        @example  `options={{ reactQuery: { devtoolConfig: false } }}`
-        @see https://refine.dev/docs/core/components/refine-config/#devtoolConfig
-        @type [`ReactQueryDevtools` | `false`](/docs/api-reference/core/components/refine-config/#devtoolconfig)
-     */
+           *  Config for customize React Query Devtools.
+              @deprecated `reactQueryDevtoolConfig` property is deprecated. Use `devtoolConfig` in `reactQuery` in [`options`](/docs/api-reference/core/components/refine-config/#options) instead.
+              @example  `options={{ reactQuery: { devtoolConfig: false } }}`
+              @see https://refine.dev/docs/core/components/refine-config/#devtoolConfig
+              @type [`ReactQueryDevtools` | `false`](/docs/api-reference/core/components/refine-config/#devtoolconfig)
+           */
     reactQueryDevtoolConfig?:
         | React.ComponentProps<typeof ReactQueryDevtools>
         | false;
 
     /** 
-     *  Whether to update data automatically (auto) or not (manual) if a related live event is received. The off value is used to avoid creating a subscription.
-        @deprecated `liveMode` property is deprecated. Use it from within [`options`](/docs/api-reference/core/components/refine-config/#options) instead.
-        @example  `options={{ liveMode: "auto" }}`
-        @see https://refine.dev/docs/core/components/refine-config/#livemode
-        @type [`LiveModeProps["liveMode"]`](/docs/api-reference/core/components/refine-config/#livemode)
-     */
+           *  Whether to update data automatically (auto) or not (manual) if a related live event is received. The off value is used to avoid creating a subscription.
+              @deprecated `liveMode` property is deprecated. Use it from within [`options`](/docs/api-reference/core/components/refine-config/#options) instead.
+              @example  `options={{ liveMode: "auto" }}`
+              @see https://refine.dev/docs/core/components/refine-config/#livemode
+              @type [`LiveModeProps["liveMode"]`](/docs/api-reference/core/components/refine-config/#livemode)
+           */
     liveMode?: LiveModeProps["liveMode"];
-    /**
-     * Callback to handle all live events.
-     * @type [`(event: LiveEvent) => void`](/docs/api-reference/core/providers/live-provider/#onliveevent)
-     */
-    onLiveEvent?: LiveModeProps["onLiveEvent"];
-    children?: React.ReactNode;
     /** 
         @deprecated `disableTelemetry` property is deprecated. Use it from within [`options`](/docs/api-reference/core/components/refine-config/#options) instead.
         @example  `options={{ disableTelemetry: true }}`
      */
     /**
-     * **refine** implements a simple and transparent telemetry module for collecting usage statistics defined in a very limited scope. This telemetry module is used to improve the refine experience.
-     * @type [`boolean`](/docs/api-reference/core/components/refine-config/#disabletelemetry)
+     * `mutationMode` determines which mode the mutations run with. (e.g. useUpdate, useDelete).
+     * @deprecated `mutationMode` property is deprecated at this level. Use it from within `options` instead.
+     * @type [`MutationMode`](/docs/api-reference/core/components/refine-config/#mutationmode)
+     * @default "pessimistic"
      */
-    disableTelemetry?: boolean;
-    /**
-     * `options` is used to configure the app.
-     * @type [`IRefineOptions`](/docs/api-reference/core/components/refine-config/#options-1)
-     * */
-    options?: IRefineOptions;
+    mutationMode?: MutationMode;
+    /** 
+       * List query parameter values can be edited manually by typing directly in the URL. To activate this feature syncWithLocation needs to be set to true.
+          @deprecated `syncWithLocation` property is deprecated at this level. Use it from within `options` instead.
+          @example  `options={{ syncWithLocation: true }}`
+          @see https://refine.dev/docs/core/components/refine-config/#syncwithlocation
+       *  @type [`boolean`](/docs/api-reference/core/components/refine-config/#syncwithlocation)
+       */
+    syncWithLocation?: boolean;
+    /** 
+       *  When you have unsaved changes and try to leave the current page, **refine** shows a confirmation modal box.
+          @deprecated `warnwhenunsavedchanges` property is deprecated at this level. Use it from within `options` instead.
+          @example  `options={{ warnwhenunsavedchanges: true }}`
+          @see https://refine.dev/docs/core/components/refine-config/#warnwhenunsavedchanges
+      *   @type [`boolean`](/docs/api-reference/core/components/refine-config/#warnwhenunsavedchanges)
+       */
+    warnWhenUnsavedChanges?: boolean;
+    /** 
+       *  The duration of the timeout period in undoable mode, shown in milliseconds. Mutations can be cancelled during this period.
+          @deprecated `undoableTimeout` property is deprecated at this level. Use it from within `options` instead.
+          @example  `options={{ undoableTimeout: 5000 }}`
+          @see https://refine.dev/docs/core/components/refine-config/#undoabletimeout
+      *   @type [`number`](/docs/api-reference/core/components/refine-config/#undoabletimeout)
+       */
+    undoableTimeout?: number;
 }
 
 /**

--- a/packages/core/src/components/layoutWrapper/index.tsx
+++ b/packages/core/src/components/layoutWrapper/index.tsx
@@ -9,11 +9,35 @@ import {
 import { LayoutProps, TitleProps } from "../../interfaces";
 
 export interface LayoutWrapperProps {
+    /**
+     * Outer component that renders other components
+     * @default *
+     */
     Layout?: React.FC<LayoutProps>;
+    /**
+     * [Custom sider to use](/api-reference/core/components/refine-config.md#sider)
+     * @default *
+     */
     Sider?: React.FC;
+    /**
+     * [Custom header to use](/api-reference/core/components/refine-config.md#header)
+     * @default *
+     */
     Header?: React.FC;
+    /**
+     * [Custom title to use](/api-reference/core/components/refine-config.md#title)
+     * @default *
+     */
     Title?: React.FC<TitleProps>;
+    /**
+     * [Custom footer to use](/api-reference/core/components/refine-config.md#footer)
+     * @default *
+     */
     Footer?: React.FC;
+    /**
+     * [Custom off layout area to use](/api-reference/core/components/refine-config.md#offlayoutarea)
+     * @default *
+     */
     OffLayoutArea?: React.FC;
     children: React.ReactNode;
 }

--- a/packages/core/src/interfaces/auth.tsx
+++ b/packages/core/src/interfaces/auth.tsx
@@ -46,6 +46,7 @@ export type AuthPageProps<
           type?: "login";
           /**
            * @description Providers array for login with third party auth services.
+           * @type [OAuthProvider](/docs/api-reference/core/components/auth-page/#interface)
            * @optional
            */
           providers?: OAuthProvider[];


### PR DESCRIPTION
<PropsTable/> added to following docs.
1. [CanAccess](https://refine.dev/docs/api-reference/core/components/accessControl/can-access/)
2. [AuthPage](https://refine.dev/docs/api-reference/core/components/auth-page/)
3. [Refine](https://refine.dev/docs/api-reference/core/components/refine-config/)
4. [Authenticated](https://refine.dev/docs/api-reference/core/components/auth/authenticated/)


-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
