### PR TITLE
fix for text colour in about page when switched to dark mode

### DIFF
--- a/documentation/src/pages/about/styles.module.css
+++ b/documentation/src/pages/about/styles.module.css
@@ -1,5 +1,5 @@
 .root {
-    @apply px-5 sm:px-0 flex flex-col mx-auto justify-center items-center font-montserrat;
+    @apply px-5 sm:px-0 flex flex-col mx-auto justify-center items-center font-montserrat text-[#2A2A2A];
 }
 
 .header {


### PR DESCRIPTION
Text colour #2A2A2A has been added to style module of about page.

### Closing issues

closes #2734 

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
