### PR TITLE
feat(nhost): add missing filters

### DIFF
--- a/.changeset/sharp-rice-film.md
+++ b/.changeset/sharp-rice-film.md
@@ -1,0 +1,7 @@
+---
+"@pankod/refine-nhost": minor
+---
+
+Added missing implementations for `nnull`, `startswith`, `startswiths`, `nstartswith`, `nstartswiths`, `endswith`, `endswiths`, `nendswith` and `nendswiths` filters by `_similar`, `_nsimilar`, `_regex` and `_iregex` filters from Nhost.
+
+Added nested property filter support for `or` filters.

--- a/packages/nhost/src/dataProvider/index.ts
+++ b/packages/nhost/src/dataProvider/index.ts
@@ -49,7 +49,11 @@ export type HasuraFilterCondition =
     | "_nlike"
     | "_ilike"
     | "_nilike"
-    | "_is_null";
+    | "_is_null"
+    | "_similar"
+    | "_nsimilar"
+    | "_regex"
+    | "_iregex";
 
 const hasuraFilters: Record<CrudOperators, HasuraFilterCondition | undefined> =
     {
@@ -69,16 +73,39 @@ const hasuraFilters: Record<CrudOperators, HasuraFilterCondition | undefined> =
         or: "_or",
         between: undefined,
         nbetween: undefined,
-        nnull: undefined,
-        startswith: undefined,
-        nstartswith: undefined,
-        startswiths: undefined,
-        nstartswiths: undefined,
-        endswith: undefined,
-        nendswith: undefined,
-        endswiths: undefined,
-        nendswiths: undefined,
+        nnull: "_is_null",
+        startswith: "_iregex",
+        nstartswith: "_iregex",
+        endswith: "_iregex",
+        nendswith: "_iregex",
+        startswiths: "_similar",
+        nstartswiths: "_nsimilar",
+        endswiths: "_similar",
+        nendswiths: "_nsimilar",
     };
+
+export const handleFilterValue = (operator: CrudOperators, value: any) => {
+    switch (operator) {
+        case "startswiths":
+        case "nstartswiths":
+            return `${value}%`;
+        case "endswiths":
+        case "nendswiths":
+            return `%${value}`;
+        case "startswith":
+            return `^${value}`;
+        case "nstartswith":
+            return `^(?!${value})`;
+        case "endswith":
+            return `${value}$`;
+        case "nendswith":
+            return `(?<!${value})$`;
+        case "nnull":
+            return false;
+        default:
+            return value;
+    }
+};
 
 export const generateFilters: any = (filters?: CrudFilters) => {
     if (!filters) {
@@ -96,7 +123,8 @@ export const generateFilters: any = (filters?: CrudFilters) => {
         if (filter.operator !== "or") {
             const fieldsArray = filter.field.split(".");
             const fieldsWithOperator = [...fieldsArray, operator];
-            setWith(resultFilter, fieldsWithOperator, filter.value, Object);
+            const value = handleFilterValue(filter.operator, filter.value);
+            setWith(resultFilter, fieldsWithOperator, value, Object);
         } else {
             const orFilter: any = [];
 
@@ -109,10 +137,12 @@ export const generateFilters: any = (filters?: CrudFilters) => {
                         `Operator ${val.operator} is not supported`,
                     );
                 }
-                if (!filterObject.hasOwnProperty(val.field)) {
-                    filterObject[val.field] = {};
-                }
-                filterObject[val.field][mapedOperator] = val.value;
+
+                const fieldsArray = val.field.split(".");
+                const fieldsWithOperator = [...fieldsArray, val.operator];
+                const value = handleFilterValue(val.operator, val.value);
+                setWith(filterObject, fieldsWithOperator, value, Object);
+
                 orFilter.push(filterObject);
             });
 


### PR DESCRIPTION
Added missing implementations for `nnull`, `startswith`, `startswiths`, `nstartswith`, `nstartswiths`, `endswith`, `endswiths`, `nendswith` and `nendswiths` filters by `_similar`, `_nsimilar`, `_regex` and `_iregex` filters from Nhost.

Added nested property filter support for `or` filters.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
