### PR TITLE
fix(hasura): add missing nested field support to or filters

### DIFF
--- a/.changeset/tender-bottles-chew.md
+++ b/.changeset/tender-bottles-chew.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-hasura": patch
+---
+
+Added nested property filter support for `or` filters.

--- a/packages/hasura/src/dataProvider/index.ts
+++ b/packages/hasura/src/dataProvider/index.ts
@@ -136,10 +136,12 @@ export const generateFilters: any = (filters?: CrudFilters) => {
                         `Operator ${val.operator} is not supported`,
                     );
                 }
-                if (!filterObject.hasOwnProperty(val.field)) {
-                    filterObject[val.field] = {};
-                }
-                filterObject[val.field][mapedOperator] = val.value;
+
+                const fieldsArray = val.field.split(".");
+                const fieldsWithOperator = [...fieldsArray, val.operator];
+                const value = handleFilterValue(val.operator, val.value);
+                setWith(filterObject, fieldsWithOperator, value, Object);
+
                 orFilter.push(filterObject);
             });
 


### PR DESCRIPTION
Added nested property filter support for `or` filters.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
