### PR TITLE
fix(mantine): use correct hooks in auth pages

### DIFF
--- a/.changeset/blue-turkeys-hear.md
+++ b/.changeset/blue-turkeys-hear.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mantine": patch
+---
+
+Fixed incorrectly used hooks in AuthPage component

--- a/packages/mantine/src/components/pages/auth/components/forgotPassword/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/forgotPassword/index.tsx
@@ -3,7 +3,11 @@ import {
     ForgotPasswordPageProps,
     ForgotPasswordFormTypes,
 } from "@pankod/refine-core";
-import { useLogin, useTranslate, useRouterContext } from "@pankod/refine-core";
+import {
+    useTranslate,
+    useRouterContext,
+    useForgotPassword,
+} from "@pankod/refine-core";
 import {
     Box,
     Card,
@@ -62,7 +66,7 @@ export const ForgotPasswordPage: React.FC<ResetPassworProps> = ({
     const { getInputProps, onSubmit } = form;
 
     const { mutate: forgotPassword, isLoading } =
-        useLogin<ForgotPasswordFormTypes>();
+        useForgotPassword<ForgotPasswordFormTypes>();
 
     const CardContent = (
         <Card style={cardStyles} {...(contentProps ?? {})}>

--- a/packages/mantine/src/components/pages/auth/components/register/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/register/index.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { RegisterPageProps, RegisterFormTypes } from "@pankod/refine-core";
-import { useLogin, useTranslate, useRouterContext } from "@pankod/refine-core";
+import {
+    useTranslate,
+    useRouterContext,
+    useRegister,
+} from "@pankod/refine-core";
 import {
     Box,
     Card,
@@ -60,7 +64,7 @@ export const RegisterPage: React.FC<RegisterProps> = ({
     });
     const { onSubmit, getInputProps } = form;
 
-    const { mutate: register, isLoading } = useLogin<RegisterFormTypes>();
+    const { mutate: register, isLoading } = useRegister<RegisterFormTypes>();
 
     const renderProviders = () => {
         if (providers && providers.length > 0) {

--- a/packages/mantine/src/components/pages/auth/components/updatePassword/index.tsx
+++ b/packages/mantine/src/components/pages/auth/components/updatePassword/index.tsx
@@ -3,7 +3,7 @@ import {
     UpdatePasswordPageProps,
     UpdatePasswordFormTypes,
 } from "@pankod/refine-core";
-import { useLogin, useTranslate } from "@pankod/refine-core";
+import { useUpdatePassword, useTranslate } from "@pankod/refine-core";
 import {
     Box,
     Card,
@@ -59,7 +59,7 @@ export const UpdatePasswordPage: React.FC<UpdatePassworProps> = ({
     const { getInputProps, onSubmit } = form;
 
     const { mutate: updatePassword, isLoading } =
-        useLogin<UpdatePasswordFormTypes>();
+        useUpdatePassword<UpdatePasswordFormTypes>();
 
     const CardContent = (
         <Card style={cardStyles} {...(contentProps ?? {})}>


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

- Updated forgotPassword in refine-mantine to use the expected hook `useForgotPassword()`
- Updated resetPassword in refine-mantine to use the expected hook `useResetPassword()`
- Updated updatePassword in refine-mantine to use the expected hook `useUpdatePassword()`

### Test plan (required)

Demonstrate the code is solid. If not, please add `WIP:` in its title.

### Closing issues

closes #2768 

### Self Check before Merge

Please check all items below before review.

-   [X] Corresponding issues are created/updated or not needed
-   [X] Docs are updated/provided or not needed
-   [X] Examples are updated/provided or not needed
-   [X] TypeScript definitions are updated/provided or not needed
-   [X] Tests are updated/provided or not needed
-   [X] Changesets are provided or not needed
