### PR TITLE
fix: missing exports on `@pankod/refine-react-router-v6`

### DIFF
--- a/.changeset/tough-masks-fly.md
+++ b/.changeset/tough-masks-fly.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-react-router-v6": patch
+---
+
+Add missing `BrowserRouterComponent` export to `@pankod/refine-react-router-v6` package.

--- a/packages/react-router-v6/src/index.ts
+++ b/packages/react-router-v6/src/index.ts
@@ -61,4 +61,4 @@ const RouterProvider: IReactRouterProvider = {
 };
 export default RouterProvider;
 
-export { MemoryRouterComponent, HashRouterComponent };
+export { MemoryRouterComponent, HashRouterComponent, BrowserRouterComponent };


### PR DESCRIPTION
Add missing `BrowserRouterComponent` export to `@pankod/refine-react-router-v6` package.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
