### PR TITLE
fix(mui): login link alignment on forgot password

### DIFF
--- a/.changeset/happy-keys-return.md
+++ b/.changeset/happy-keys-return.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-mui": patch
+---
+
+Fix login link alignment on forgot password page.

--- a/packages/mui/src/components/pages/auth/components/forgotPassword/index.tsx
+++ b/packages/mui/src/components/pages/auth/components/forgotPassword/index.tsx
@@ -108,7 +108,7 @@ export const ForgotPasswordPage: React.FC<ForgotPasswordProps> = ({
                         autoComplete="email"
                     />
                     {loginLink ?? (
-                        <Box>
+                        <Box textAlign="right">
                             <Typography variant="body2" component="span">
                                 {translate(
                                     "pages.register.buttons.haveAccount",


### PR DESCRIPTION
Fix login link alignment on forgot password page.