### PR TITLE
docs(mantine): add breadcrumb component doc

### DIFF
--- a/documentation/docs/api-reference/mantine/components/breadcrumb.md
+++ b/documentation/docs/api-reference/mantine/components/breadcrumb.md
@@ -1,0 +1,242 @@
+---
+id: breadcrumb
+title: Breadcrumb
+---
+
+```tsx live shared
+setRefineProps({
+    Sider: () => null,
+    notificationProvider: RefineMantine.notificationProvider,
+});
+
+const Wrapper = ({ children }) => {
+    return (
+        <RefineMantine.MantineProvider
+            theme={RefineMantine.LightTheme}
+            withNormalizeCSS
+            withGlobalStyles
+        >
+            <RefineMantine.Global
+                styles={{ body: { WebkitFontSmoothing: "auto" } }}
+            />
+            <RefineMantine.NotificationsProvider position="top-right">
+                {children}
+            </RefineMantine.NotificationsProvider>
+        </RefineMantine.MantineProvider>
+    );
+};
+
+const PostIcon = (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        className="icon icon-tabler icon-tabler-list"
+        width={18}
+        height={18}
+        viewBox="0 0 24 24"
+        strokeWidth="2"
+        stroke="currentColor"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+    >
+        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+        <line x1={9} y1={6} x2={20} y2={6}></line>
+        <line x1={9} y1={12} x2={20} y2={12}></line>
+        <line x1={9} y1={18} x2={20} y2={18}></line>
+        <line x1={5} y1={6} x2={5} y2="6.01"></line>
+        <line x1={5} y1={12} x2={5} y2="12.01"></line>
+        <line x1={5} y1={18} x2={5} y2="18.01"></line>
+    </svg>
+);
+```
+
+A breadcrumb displays the current location within a hierarchy. It allows going back to states higher up in the hierarchy. `<Breadcrumb>` component built with Ant Design's [Breadcrumb][mantine-breadcrumb] components using the [`useBreadcrumb`](/api-reference/core/hooks/useBreadcrumb.md) hook.
+
+:::info
+You can refer to the [source-code][source-code] of the `<Breadcrumb>` component to see how it is built. You can also create your custom breadcrumb component inspired by the source code.
+:::
+
+## Properties
+
+### `breadcrumbProps`
+
+`<Breadcrumb>` component uses the Ant Design [Breadcrumb][mantine-breadcrumb] component so it can be configured with the `breadcrumbProps` property.
+
+```tsx live url=http://localhost:3000/posts/show/123 previewHeight=280px
+setInitialRoutes(["/posts/show/123"]);
+import { Refine } from "@pankod/refine-core";
+import { Layout, ShowButton } from "@pankod/refine-mantine";
+import routerProvider from "@pankod/refine-react-router-v6";
+import dataProvider from "@pankod/refine-simple-rest";
+
+// visible-block-start
+import { Show, Breadcrumb } from "@pankod/refine-mantine";
+
+const PostShow: React.FC = () => {
+    return (
+        <Show
+            // highlight-next-line
+            breadcrumb={<Breadcrumb breadcrumbProps={{ separator: "-" }} />}
+        >
+            <p>Rest of your page here</p>
+        </Show>
+    );
+};
+// visible-block-end
+
+const App = () => {
+    return (
+        <Refine
+            routerProvider={routerProvider}
+            dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
+            Layout={Layout}
+            DashboardPage={() => <p>Dashboard Page</p>}
+            resources={[
+                {
+                    name: "posts",
+                    show: PostShow,
+                    list: () => (
+                        <div>
+                            <p>This page is empty.</p>
+                            <ShowButton recordItemId="123">
+                                Show Item 123
+                            </ShowButton>
+                        </div>
+                    ),
+                    icon: PostIcon,
+                },
+            ]}
+        />
+    );
+};
+render(
+    <Wrapper>
+        <App />
+    </Wrapper>,
+);
+```
+
+### `showHome`
+
+If your application has a [DashboardPage](/api-reference/core/components/refine-config.md#dashboardpage), the home button is shown to the top of the hierarchy by default. If you don't want to show the home button, you can set `showHome` to `false`.
+
+```tsx live url=http://localhost:3000/posts/show/123 previewHeight=280px
+setInitialRoutes(["/posts/show/123"]);
+import { Refine } from "@pankod/refine-core";
+import { Layout, ShowButton } from "@pankod/refine-mantine";
+import routerProvider from "@pankod/refine-react-router-v6";
+import dataProvider from "@pankod/refine-simple-rest";
+
+// visible-block-start
+import { Show, Breadcrumb } from "@pankod/refine-mantine";
+
+const PostShow: React.FC = () => {
+    return (
+        <Show
+            // highlight-next-line
+            breadcrumb={<Breadcrumb showHome={false} />}
+        >
+            <p>Rest of your page here</p>
+        </Show>
+    );
+};
+// visible-block-end
+
+const App = () => {
+    return (
+        <Refine
+            routerProvider={routerProvider}
+            dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
+            Layout={Layout}
+            DashboardPage={() => <p>Dashboard Page</p>}
+            resources={[
+                {
+                    name: "posts",
+                    show: PostShow,
+                    list: () => (
+                        <div>
+                            <p>This page is empty.</p>
+                            <ShowButton recordItemId="123">
+                                Show Item 123
+                            </ShowButton>
+                        </div>
+                    ),
+                    icon: PostIcon,
+                },
+            ]}
+        />
+    );
+};
+render(
+    <Wrapper>
+        <App />
+    </Wrapper>,
+);
+```
+
+### `hideIcons`
+
+If you don't want to show the resource icons on the breadcrumb, you can set `hideIcons` to `true`.
+
+```tsx live url=http://localhost:3000/posts/show/123 previewHeight=280px
+setInitialRoutes(["/posts/show/123"]);
+import { Refine } from "@pankod/refine-core";
+import { Layout, ShowButton } from "@pankod/refine-mantine";
+import routerProvider from "@pankod/refine-react-router-v6";
+import dataProvider from "@pankod/refine-simple-rest";
+
+// visible-block-start
+import { Show, Breadcrumb } from "@pankod/refine-mantine";
+
+const PostShow: React.FC = () => {
+    return (
+        <Show
+            // highlight-next-line
+            breadcrumb={<Breadcrumb hideIcons />}
+        >
+            <p>Rest of your page here</p>
+        </Show>
+    );
+};
+// visible-block-end
+
+const App = () => {
+    return (
+        <Refine
+            routerProvider={routerProvider}
+            dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
+            Layout={Layout}
+            DashboardPage={() => <p>Dashboard Page</p>}
+            resources={[
+                {
+                    name: "posts",
+                    show: PostShow,
+                    list: () => (
+                        <div>
+                            <p>This page is empty.</p>
+                            <ShowButton recordItemId="123">
+                                Show Item 123
+                            </ShowButton>
+                        </div>
+                    ),
+                    icon: PostIcon,
+                },
+            ]}
+        />
+    );
+};
+render(
+    <Wrapper>
+        <App />
+    </Wrapper>,
+);
+```
+
+## API Reference
+
+### Properties
+
+<PropsTable module="@pankod/refine-mantine/Breadcrumb" />
+
+[mantine-breadcrumb]: https://mantine.dev/core/breadcrumbs/
+[source-code]: https://github.com/pankod/refine/blob/master/packages/mantine/src/components/breadcrumb/index.tsx

--- a/documentation/docs/api-reference/mantine/components/breadcrumb.md
+++ b/documentation/docs/api-reference/mantine/components/breadcrumb.md
@@ -4,8 +4,14 @@ title: Breadcrumb
 ---
 
 ```tsx live shared
+const { default: routerProvider } = RefineReactRouterV6;
+const { default: simpleRest } = RefineSimpleRest;
 setRefineProps({
+    routerProvider,
+    dataProvider: simpleRest("https://api.fake-rest.refine.dev"),
+    Layout: RefineMantine.Layout,
     Sider: () => null,
+    DashboardPage: () => <p>Dashboard Page</p>,
     notificationProvider: RefineMantine.notificationProvider,
 });
 
@@ -50,7 +56,7 @@ const PostIcon = (
 );
 ```
 
-A breadcrumb displays the current location within a hierarchy. It allows going back to states higher up in the hierarchy. `<Breadcrumb>` component built with Ant Design's [Breadcrumb][mantine-breadcrumb] components using the [`useBreadcrumb`](/api-reference/core/hooks/useBreadcrumb.md) hook.
+A breadcrumb displays the current location within a hierarchy. It allows going back to states higher up in the hierarchy. `<Breadcrumb>` component built with Mantine [Breadcrumb][mantine-breadcrumb] components using the [`useBreadcrumb`](/api-reference/core/hooks/useBreadcrumb.md) hook.
 
 :::info
 You can refer to the [source-code][source-code] of the `<Breadcrumb>` component to see how it is built. You can also create your custom breadcrumb component inspired by the source code.
@@ -60,14 +66,12 @@ You can refer to the [source-code][source-code] of the `<Breadcrumb>` component 
 
 ### `breadcrumbProps`
 
-`<Breadcrumb>` component uses the Ant Design [Breadcrumb][mantine-breadcrumb] component so it can be configured with the `breadcrumbProps` property.
+`<Breadcrumb>` component uses the Mantine [Breadcrumb][mantine-breadcrumb] component so it can be configured with the `breadcrumbProps` property.
 
 ```tsx live url=http://localhost:3000/posts/show/123 previewHeight=280px
 setInitialRoutes(["/posts/show/123"]);
 import { Refine } from "@pankod/refine-core";
-import { Layout, ShowButton } from "@pankod/refine-mantine";
-import routerProvider from "@pankod/refine-react-router-v6";
-import dataProvider from "@pankod/refine-simple-rest";
+import { ShowButton } from "@pankod/refine-mantine";
 
 // visible-block-start
 import { Show, Breadcrumb } from "@pankod/refine-mantine";
@@ -87,10 +91,6 @@ const PostShow: React.FC = () => {
 const App = () => {
     return (
         <Refine
-            routerProvider={routerProvider}
-            dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
-            Layout={Layout}
-            DashboardPage={() => <p>Dashboard Page</p>}
             resources={[
                 {
                     name: "posts",
@@ -123,9 +123,7 @@ If your application has a [DashboardPage](/api-reference/core/components/refine-
 ```tsx live url=http://localhost:3000/posts/show/123 previewHeight=280px
 setInitialRoutes(["/posts/show/123"]);
 import { Refine } from "@pankod/refine-core";
-import { Layout, ShowButton } from "@pankod/refine-mantine";
-import routerProvider from "@pankod/refine-react-router-v6";
-import dataProvider from "@pankod/refine-simple-rest";
+import { ShowButton } from "@pankod/refine-mantine";
 
 // visible-block-start
 import { Show, Breadcrumb } from "@pankod/refine-mantine";
@@ -145,10 +143,6 @@ const PostShow: React.FC = () => {
 const App = () => {
     return (
         <Refine
-            routerProvider={routerProvider}
-            dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
-            Layout={Layout}
-            DashboardPage={() => <p>Dashboard Page</p>}
             resources={[
                 {
                     name: "posts",
@@ -181,9 +175,7 @@ If you don't want to show the resource icons on the breadcrumb, you can set `hid
 ```tsx live url=http://localhost:3000/posts/show/123 previewHeight=280px
 setInitialRoutes(["/posts/show/123"]);
 import { Refine } from "@pankod/refine-core";
-import { Layout, ShowButton } from "@pankod/refine-mantine";
-import routerProvider from "@pankod/refine-react-router-v6";
-import dataProvider from "@pankod/refine-simple-rest";
+import { ShowButton } from "@pankod/refine-mantine";
 
 // visible-block-start
 import { Show, Breadcrumb } from "@pankod/refine-mantine";
@@ -203,10 +195,6 @@ const PostShow: React.FC = () => {
 const App = () => {
     return (
         <Refine
-            routerProvider={routerProvider}
-            dataProvider={dataProvider("https://api.fake-rest.refine.dev")}
-            Layout={Layout}
-            DashboardPage={() => <p>Dashboard Page</p>}
             resources={[
                 {
                     name: "posts",

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -392,6 +392,7 @@ module.exports = {
                                         "api-reference/mantine/components/basic-views/show",
                                     ],
                                 },
+                                "api-reference/mantine/components/breadcrumb",
                                 {
                                     type: "category",
                                     label: "Buttons",


### PR DESCRIPTION
Added `<BreadCrumb/>` documentation.

### Test plan (required)

When the documents change, the tests do not affect.

<!-- Make sure tests pass. -->

### Closing issues

.

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
