### PR TITLE
docs: Fix enforcement ladder link in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -127,6 +127,6 @@ at [https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org
 [v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
+[Mozilla CoC]: https://github.com/mozilla/inclusion/blob/master/code-of-conduct-enforcement/consequence-ladder.md
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
Fixed the link to Mozilla enforcement ladder doc in CODE_OF_CONDUCT.md
Closes #2804 

### Self Check before Merge

Please check all items below before review.

-   [X] Corresponding issues are created/updated or not needed
-   [X] Docs are updated/provided or not needed
-   [X] Examples are updated/provided or not needed
-   [X] TypeScript definitions are updated/provided or not needed
-   [X] Tests are updated/provided or not needed
-   [X] Changesets are provided or not needed
