### PR TITLE
docs: fix punctuation mistakes in benchmarks doc

### DIFF
--- a/documentation/docs/further-readings/benchmarks.md
+++ b/documentation/docs/further-readings/benchmarks.md
@@ -3,9 +3,9 @@ id: benchmarks
 title: Benchmarks
 ---
 
-Many **refine** projects involve to migrate an existing vanilla React application to **refine** framework. By collecting data from various migration projects, we were able to do some benchmarking by comparing codebases. 
+Many **refine** projects involve migrating an existing vanilla React application to the **refine** framework. By collecting data from various migration projects, we were able to do some benchmarking by comparing codebases. 
 
-**refine** makes your codebase significantly smaller, by eliminating redundant code such as _reducers_, _actions_ and _unit tests_.  We've measured significant reduction in project size in terms of *"lines of code"* and *"number of files"*:
+**refine** makes your codebase significantly smaller, by eliminating redundant code such as _reducers_, _actions_, and _unit tests_.  We've measured a significant reduction in project size in terms of *"lines of code"* and *"number of files"*:
 
 <div align="center">
 


### PR DESCRIPTION
Fixed some punctuation mistakes in benchmark documentation. 