### PR TITLE
docs: add ctl params for StackBlitz iframe embeds

### DIFF
--- a/documentation/blog/2021-11-12-issue-tracker-refine.md
+++ b/documentation/blog/2021-11-12-issue-tracker-refine.md
@@ -1604,7 +1604,7 @@ For other examples and articles that will interest you with refine:  [https://re
 
 ## Live StackBlitz Example
 
-<iframe src="https://stackblitz.com/github/pankod/refine/tree/master/examples/blog/issueTracker/?embed=1&view=preview&theme=dark&preset=node"
+<iframe src="https://stackblitz.com/github/pankod/refine/tree/master/examples/blog/issueTracker/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="sveltekit-crud-app"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/blog/2022-02-22-refine-invoice-genarator.md
+++ b/documentation/blog/2022-02-22-refine-invoice-genarator.md
@@ -894,7 +894,7 @@ We created our `Client` and `Contact` pages. Now, let's create a Client with **r
 
 `Password`: demodemo
 
-<iframe src="https://stackblitz.com/github/pankod/refine/tree/master/examples/blog/invoiceGenerator/?embed=1&view=preview&theme=dark&preset=node"
+<iframe src="https://stackblitz.com/github/pankod/refine/tree/master/examples/blog/invoiceGenerator/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-invoice-genarator-basics"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/blog/2022-03-01-refine-invoice-genarator-p2.md
+++ b/documentation/blog/2022-03-01-refine-invoice-genarator-p2.md
@@ -899,7 +899,7 @@ export const PdfLayout: React.FC<PdfProps> = ({ record }) => {
 PDF download may not work in codeSandbox mode. With [**this**](https://n59710.csb.app/invoices) link, you can open the example in the browser and try it.
 :::
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/invoiceGenerator?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/invoiceGenerator?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-select-example"
 ></iframe>

--- a/documentation/blog/2022-07-21-admin-panel-with-materialui-and-strapi.md
+++ b/documentation/blog/2022-07-21-admin-panel-with-materialui-and-strapi.md
@@ -1088,7 +1088,7 @@ Username: demo@refine.dev
 
 Password: demodemo
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/material-ui/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/material-ui/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-material-ui-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/blog/2022-08-23-mui-usedatagrid.md
+++ b/documentation/blog/2022-08-23-mui-usedatagrid.md
@@ -839,7 +839,7 @@ Where to go next? Check the useDataGrid hook documentation [here](https://refine
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/mui-datagrid/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/mui-datagrid/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-mui-datagrid-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/blog/2022-08-26-react-content-filtering.md
+++ b/documentation/blog/2022-08-26-react-content-filtering.md
@@ -626,7 +626,7 @@ Feel free to modify the app with your own custom features. Play around with diff
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/refine-filtering/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/refine-filtering/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-search-and-filtering-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/blog/2022-09-02-sveltekit-crud-app.md
+++ b/documentation/blog/2022-09-02-sveltekit-crud-app.md
@@ -455,7 +455,7 @@ Throughout this tutorial, we've implemented how to create a CRUD application usi
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/sveltekit-crud/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/sveltekit-crud/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="sveltekit-crud-app"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/blog/2022-09-13-react-memo.md
+++ b/documentation/blog/2022-09-13-react-memo.md
@@ -356,7 +356,7 @@ In the next article, we will turn our attention back to the `<Blog />` component
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/react-memoization-memo/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/react-memoization-memo/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="react-memoization-memo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/blog/2022-09-16-react-use-memo.md
+++ b/documentation/blog/2022-09-16-react-use-memo.md
@@ -200,7 +200,7 @@ In the next post, we will demonstrate the use of `useCallback()` hook.
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/react-memoization-memo/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/react-memoization-memo/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="react-memoization-memo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/blog/2022-09-20-react-use-callback.md
+++ b/documentation/blog/2022-09-20-react-use-callback.md
@@ -215,7 +215,7 @@ In this article, we looked at how re-renders of a parent component lead to viola
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/react-memoization-memo/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/react-memoization-memo/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="react-memoization-memo"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/blog/2022-09-27-react-hook-form-validation.md
+++ b/documentation/blog/2022-09-27-react-hook-form-validation.md
@@ -931,7 +931,7 @@ There you have it, we’ve successfully built a form that can validate input val
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/refine-react-hook-form/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/refine-react-hook-form/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-react-hook-form"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/blog/2022-10-07-responsive-navbar.md
+++ b/documentation/blog/2022-10-07-responsive-navbar.md
@@ -533,7 +533,7 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/responsive-navbar/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/blog/responsive-navbar/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="responsive-navbar"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/advanced-tutorials/access-control.md
+++ b/documentation/docs/advanced-tutorials/access-control.md
@@ -530,7 +530,7 @@ export const PostList: React.FC = () => {
 
 ### Casbin
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/accessControl/casbin/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/accessControl/casbin/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="access-control-casbin-react"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
@@ -539,7 +539,7 @@ export const PostList: React.FC = () => {
 
 ### Cerbos
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/accessControl/cerbos/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/accessControl/cerbos/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="access-control-cerbos-react"
 ></iframe>

--- a/documentation/docs/advanced-tutorials/auth/auth0.md
+++ b/documentation/docs/advanced-tutorials/auth/auth0.md
@@ -225,7 +225,7 @@ We can use it with the `user` from the `useAuth0` hook.
 
 Auth0 example doesn't work in StackBlitz embed mode. With [this](https://ussft.csb.app/) link, you can open the example in the browser and try it.
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authProvider/auth0?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authProvider/auth0?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-auth0-example"
 ></iframe>

--- a/documentation/docs/advanced-tutorials/custom-layout.md
+++ b/documentation/docs/advanced-tutorials/custom-layout.md
@@ -124,7 +124,7 @@ This example demonstrated how to configure a global layout. To learn how to use 
 
 Here's how it looks in the end:
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/topMenuLayout?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/topMenuLayout?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-top-menu-layout-example"
 ></iframe>

--- a/documentation/docs/advanced-tutorials/custom-pages.md
+++ b/documentation/docs/advanced-tutorials/custom-pages.md
@@ -829,7 +829,7 @@ export const PostReview = () => {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customPages?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customPages?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="custom-pages-example"
 ></iframe>

--- a/documentation/docs/advanced-tutorials/data-provider/appwrite.md
+++ b/documentation/docs/advanced-tutorials/data-provider/appwrite.md
@@ -830,7 +830,7 @@ Username: `demo@refine.dev`
 Password: `demodemo`
 
 <iframe
-    src="https://stackblitz.com/github/pankod/refine/tree/master/examples/dataProvider/appwrite?embed=1&view=preview&theme=dark&preset=node"
+    src="https://stackblitz.com/github/pankod/refine/tree/master/examples/dataProvider/appwrite?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-appwrite-example"
 ></iframe>

--- a/documentation/docs/advanced-tutorials/data-provider/strapi-v4.md
+++ b/documentation/docs/advanced-tutorials/data-provider/strapi-v4.md
@@ -788,7 +788,7 @@ Username: demo@refine.dev
 
 Password: demodemo
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/strapi-v4/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/strapi-v4/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-strapi-v4-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/advanced-tutorials/data-provider/supabase.md
+++ b/documentation/docs/advanced-tutorials/data-provider/supabase.md
@@ -1277,7 +1277,7 @@ If you filter based on a table from an inner join, you will need to use `.select
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/supabase/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/supabase/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-supabase-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/advanced-tutorials/forms/save-and-continue.md
+++ b/documentation/docs/advanced-tutorials/forms/save-and-continue.md
@@ -359,7 +359,7 @@ We used the `redirect` method to perform the redirection, which returns from [`u
 
 ## Live StackBlitz Example
 
-<iframe src="https://stackblitz.com/github/pankod/refine/tree/master/examples/form/headless/saveAndContinue?embed=1&view=preview&theme=dark&preset=node"
+<iframe src="https://stackblitz.com/github/pankod/refine/tree/master/examples/form/headless/saveAndContinue?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-validation-example-app"
 ></iframe>

--- a/documentation/docs/advanced-tutorials/import-export/csv-export.md
+++ b/documentation/docs/advanced-tutorials/import-export/csv-export.md
@@ -79,7 +79,7 @@ Manually running the `triggerExport` function is another option.
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/importExport/antd?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/importExport/antd?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-import-export-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/advanced-tutorials/import-export/csv-import.md
+++ b/documentation/docs/advanced-tutorials/import-export/csv-import.md
@@ -166,7 +166,7 @@ Depending on the [`batchSize`][batchsize] option, posts can get sent one by one 
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/importExport/antd?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/importExport/antd?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-import-export-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/advanced-tutorials/multi-level-menu/multi-level-menu.md
+++ b/documentation/docs/advanced-tutorials/multi-level-menu/multi-level-menu.md
@@ -161,7 +161,7 @@ You can review the example to examine the multi-level menu concept in more detai
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/multi-level-menu)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/multi-level-menu?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/multi-level-menu?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-multi-level-menu-example"
 ></iframe>

--- a/documentation/docs/advanced-tutorials/multi-tenancy/appwrite.md
+++ b/documentation/docs/advanced-tutorials/multi-tenancy/appwrite.md
@@ -648,7 +648,7 @@ In this guide and in our example app, we talked about how we can build Multitena
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/multi-tenancy/appwrite?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/multi-tenancy/appwrite?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="cake-house"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/advanced-tutorials/multi-tenancy/strapi.md
+++ b/documentation/docs/advanced-tutorials/multi-tenancy/strapi.md
@@ -696,7 +696,7 @@ Username: `refine-demo`
 
 Password: `demodemo`
 
-<iframe loading="lazy" src="https://stackblitz.com/github/pankod/refine/tree/master/examples/multi-tenancy/strapi?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com/github/pankod/refine/tree/master/examples/multi-tenancy/strapi?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="strapi-multi-tenant-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/advanced-tutorials/mutation-mode.md
+++ b/documentation/docs/advanced-tutorials/mutation-mode.md
@@ -121,7 +121,7 @@ mutate({
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//refine-example-mutation-mode-yh7nb?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//refine-example-mutation-mode-yh7nb?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-example-mutation-mode"
 ></iframe>

--- a/documentation/docs/advanced-tutorials/real-time.md
+++ b/documentation/docs/advanced-tutorials/real-time.md
@@ -459,7 +459,7 @@ useSubscription({
 
 ## Live Condesandbox Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/ably/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/ably/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-ably-example"
 ></iframe>

--- a/documentation/docs/advanced-tutorials/search/list-search.md
+++ b/documentation/docs/advanced-tutorials/search/list-search.md
@@ -242,7 +242,7 @@ When the form is submitted, the `onSearch` method runs and we get the search for
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/list/useSimpleList?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/list/useSimpleList?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-simple-list-example"
 ></iframe>

--- a/documentation/docs/advanced-tutorials/search/search.md
+++ b/documentation/docs/advanced-tutorials/search/search.md
@@ -296,7 +296,7 @@ By doing the same implementation on your other resources, you can search more th
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/search?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/search?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-search-example"
 ></iframe>

--- a/documentation/docs/advanced-tutorials/search/table-search.md
+++ b/documentation/docs/advanced-tutorials/search/table-search.md
@@ -123,7 +123,7 @@ const { searchFormProps } = useTable<IPost, HttpError, { title: string; createdA
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/tableFilter?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/tableFilter?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-table-filter-example"
 ></iframe>

--- a/documentation/docs/advanced-tutorials/ssr/nextjs.md
+++ b/documentation/docs/advanced-tutorials/ssr/nextjs.md
@@ -398,7 +398,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/refine-next/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/refine-next/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-next"
 ></iframe>

--- a/documentation/docs/advanced-tutorials/upload/base64-upload.md
+++ b/documentation/docs/advanced-tutorials/upload/base64-upload.md
@@ -128,7 +128,7 @@ An edit form can be made by using the `<Edit>` component instead of `<Create>` w
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/antd/multipart?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/antd/multipart?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-base64-upload-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/advanced-tutorials/upload/multipart-upload.md
+++ b/documentation/docs/advanced-tutorials/upload/multipart-upload.md
@@ -374,7 +374,7 @@ export const PostCreate: React.FC = () => {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/antd/multipart?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/antd/multipart?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-multipart-upload-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/advanced-tutorials/web3/ethereum-signin.md
+++ b/documentation/docs/advanced-tutorials/web3/ethereum-signin.md
@@ -415,7 +415,7 @@ We can now request to send ethereum through our **refine** dashboard and also vi
 <br/>
 
 ## Live StackBlitz Example
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/web3/ethereumLogin?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/web3/ethereumLogin?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="signin-with-ethereum"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/api-reference/antd/components/fields/markdown.md
+++ b/documentation/docs/api-reference/antd/components/fields/markdown.md
@@ -65,7 +65,7 @@ interface IPost {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/inputs/customInputs?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/inputs/customInputs?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-inputs-example"
 ></iframe>

--- a/documentation/docs/api-reference/antd/components/filter-dropdown.md
+++ b/documentation/docs/api-reference/antd/components/filter-dropdown.md
@@ -168,7 +168,7 @@ If [syncWithLocation](/api-reference/core/components/refine-config.md#syncwithlo
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useTable?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useTable?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-table-example"
 ></iframe>

--- a/documentation/docs/api-reference/antd/components/inputs/custom-inputs.md
+++ b/documentation/docs/api-reference/antd/components/inputs/custom-inputs.md
@@ -97,7 +97,7 @@ export const PostEdit: React.FC = (props) => {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/inputs/customInputs?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/inputs/customInputs?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-inputs-example"
 ></iframe>

--- a/documentation/docs/api-reference/antd/customization/layout.md
+++ b/documentation/docs/api-reference/antd/customization/layout.md
@@ -125,7 +125,7 @@ This example demonstrated how to configure a global layout. To learn how to use 
 
 Here's how it looks in the end:
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/topMenuLayout?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/topMenuLayout?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-top-menu-layout-example"
     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/api-reference/antd/customization/theme.md
+++ b/documentation/docs/api-reference/antd/customization/theme.md
@@ -163,7 +163,7 @@ All variable overrides configured in `lessOptions.modifyVars` always have higher
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/customTheme/antd?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/customTheme/antd?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-theme-example"
 ></iframe>

--- a/documentation/docs/api-reference/antd/hooks/field/useCheckboxGroup.md
+++ b/documentation/docs/api-reference/antd/hooks/field/useCheckboxGroup.md
@@ -212,7 +212,7 @@ const { selectProps } = useSelect({
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useCheckboxGroup?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useCheckboxGroup?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-use-checkbox-group-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/api-reference/antd/hooks/field/useRadioGroup.md
+++ b/documentation/docs/api-reference/antd/hooks/field/useRadioGroup.md
@@ -219,7 +219,7 @@ const { selectProps } = useSelect({
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useRadioGroup?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useRadioGroup?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-use-radio-group-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/api-reference/antd/hooks/field/useSelect.md
+++ b/documentation/docs/api-reference/antd/hooks/field/useSelect.md
@@ -304,14 +304,14 @@ const { selectProps } = useSelect({
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useSelect/antd/basic?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useSelect/antd/basic?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-select-example"
 ></iframe>
 
 ## Live StackBlitz Infinite Loading Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useSelect/antd/infiniteLoading?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useSelect/antd/infiniteLoading?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-select-example"
 ></iframe>

--- a/documentation/docs/api-reference/antd/hooks/form/useDrawerForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useDrawerForm.md
@@ -267,7 +267,7 @@ The `saveButtonProps` and `deleteButtonProps` gives us the ability of saving and
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useDrawerForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useDrawerForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-use-drawer-form-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/api-reference/antd/hooks/form/useForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useForm.md
@@ -164,7 +164,7 @@ const { clone } = useNavigation();
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-form-example"
 ></iframe>

--- a/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useModalForm.md
@@ -244,7 +244,7 @@ Don't forget to pass the record id to `show` to fetch the record data. This is n
 
 ## Live StackBlitz Example
 
-   <iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useModalForm?embed=1&view=preview&theme=dark&preset=node"
+   <iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useModalForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-use-modal-form-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/api-reference/antd/hooks/form/useStepsForm.md
+++ b/documentation/docs/api-reference/antd/hooks/form/useStepsForm.md
@@ -470,7 +470,7 @@ export const PostCreate: React.FC = () => {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useStepsForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useStepsForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-steps-form-example"
 ></iframe>

--- a/documentation/docs/api-reference/antd/hooks/table/useEditableTable.md
+++ b/documentation/docs/api-reference/antd/hooks/table/useEditableTable.md
@@ -352,7 +352,7 @@ export const PostList: React.FC = () => {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useEditableTable?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useEditableTable?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-use-editable-table-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/api-reference/antd/hooks/table/useTable.md
+++ b/documentation/docs/api-reference/antd/hooks/table/useTable.md
@@ -411,7 +411,7 @@ Filters we give to `initialFilter` are default filters. In order to prevent filt
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useTable?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useTable?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-use-table-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/api-reference/core/hooks/import-export/useImport.md
+++ b/documentation/docs/api-reference/core/hooks/import-export/useImport.md
@@ -219,7 +219,7 @@ Now, parsed data is mapped to conform our APIs requirements.
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/core/useImport?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/core/useImport?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-modal-example"
 ></iframe>

--- a/documentation/docs/api-reference/core/hooks/ui/useModal.md
+++ b/documentation/docs/api-reference/core/hooks/ui/useModal.md
@@ -63,7 +63,7 @@ We also created a `<button>` to close the `<YourModalComponent>` and gave the on
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/core/useModal?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/core/useModal?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-modal-example"
 ></iframe>

--- a/documentation/docs/api-reference/core/hooks/useSelect.md
+++ b/documentation/docs/api-reference/core/hooks/useSelect.md
@@ -254,7 +254,7 @@ const { options } = useSelect({
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/core/useSelect?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/core/useSelect?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-select-example"
 ></iframe>

--- a/documentation/docs/api-reference/core/providers/accessControl-provider.md
+++ b/documentation/docs/api-reference/core/providers/accessControl-provider.md
@@ -192,7 +192,7 @@ These buttons will be disabled if access control returns `{ can: false }`
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/accessControl/casbin?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/accessControl/casbin?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="access-control-casbin-react"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/api-reference/core/providers/audit-log-provider.md
+++ b/documentation/docs/api-reference/core/providers/audit-log-provider.md
@@ -455,7 +455,7 @@ In this case, only events will be created for the `create` mutation.
 
 ## Live StackBlitz Example
 
-<iframe src="https://stackblitz.com/github/pankod/refine/tree/master/examples/auditLogProvider?embed=1&view=preview&theme=dark&preset=node"
+<iframe src="https://stackblitz.com/github/pankod/refine/tree/master/examples/auditLogProvider?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-audit-log-provider-example"
 ></iframe>

--- a/documentation/docs/api-reference/core/providers/auth-provider.md
+++ b/documentation/docs/api-reference/core/providers/auth-provider.md
@@ -898,7 +898,7 @@ These hooks can be used with the `authProvider` authentication and authorization
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authentication/antd?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authentication/antd?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-authentication-example"
 ></iframe>

--- a/documentation/docs/api-reference/core/providers/i18n-provider.md
+++ b/documentation/docs/api-reference/core/providers/i18n-provider.md
@@ -814,7 +814,7 @@ export interface IPost {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/i18n/react?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/i18n/react?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-i18n-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/api-reference/core/providers/notification-provider.md
+++ b/documentation/docs/api-reference/core/providers/notification-provider.md
@@ -301,7 +301,7 @@ close?.("displayed-notification-key");
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/reactToastify?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/reactToastify?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-react-toastify-example"
 ></iframe>

--- a/documentation/docs/api-reference/mantine/hooks/form/useDrawerForm.md
+++ b/documentation/docs/api-reference/mantine/hooks/form/useDrawerForm.md
@@ -566,7 +566,7 @@ export const EditPostDrawer: React.FC<
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useDrawerForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useDrawerForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="mantine-use-drawer-form-example"
 ></iframe>

--- a/documentation/docs/api-reference/mantine/hooks/form/useForm.md
+++ b/documentation/docs/api-reference/mantine/hooks/form/useForm.md
@@ -116,7 +116,7 @@ const {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="mantine-use-form-example"
 ></iframe>

--- a/documentation/docs/api-reference/mantine/hooks/form/useModalForm.md
+++ b/documentation/docs/api-reference/mantine/hooks/form/useModalForm.md
@@ -552,7 +552,7 @@ export const EditPostModal: React.FC<
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useModalForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useModalForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
   style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
   title="mantine-use-modal-form-example"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/api-reference/mantine/hooks/form/useStepsForm.md
+++ b/documentation/docs/api-reference/mantine/hooks/form/useStepsForm.md
@@ -449,7 +449,7 @@ export const PostEdit: React.FC = () => {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useStepsForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useStepsForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="mantine-use-steps-form-example"
 ></iframe>

--- a/documentation/docs/api-reference/mantine/hooks/useSelect.md
+++ b/documentation/docs/api-reference/mantine/hooks/useSelect.md
@@ -332,7 +332,7 @@ const { selectProps } = useSelect({
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/base/mantine?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/base/mantine?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-select-example"
 ></iframe>

--- a/documentation/docs/api-reference/mui/components/fields/markdown.md
+++ b/documentation/docs/api-reference/mui/components/fields/markdown.md
@@ -63,7 +63,7 @@ interface IPost {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/inputs/customInputs?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/inputs/customInputs?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-inputs-example"
 ></iframe>

--- a/documentation/docs/api-reference/mui/hooks/useAutocomplete.md
+++ b/documentation/docs/api-reference/mui/hooks/useAutocomplete.md
@@ -327,7 +327,7 @@ const { autocompleteProps } = useAutocomplete({
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useSelect/mui?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useSelect/mui?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-select-example"
 ></iframe>

--- a/documentation/docs/api-reference/mui/hooks/useDataGrid.md
+++ b/documentation/docs/api-reference/mui/hooks/useDataGrid.md
@@ -460,7 +460,7 @@ export const PostsList: React.FC = () => {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/useDataGrid?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/useDataGrid?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-data-grid-example"
 ></iframe>

--- a/documentation/docs/examples/access-control/casbin.md
+++ b/documentation/docs/examples/access-control/casbin.md
@@ -10,7 +10,7 @@ Access Control is a complex topic with a variety of sophisticated solutions that
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/accessControl/casbin)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/accessControl/casbin?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/accessControl/casbin?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="access-control-casbin-react"
 ></iframe>

--- a/documentation/docs/examples/access-control/cerbos.md
+++ b/documentation/docs/examples/access-control/cerbos.md
@@ -10,7 +10,7 @@ Access Control is a complex topic with a variety of sophisticated solutions that
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/accessControl/cerbos)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/accessControl/cerbos?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/accessControl/cerbos?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="access-control-cerbos-react"
 ></iframe>

--- a/documentation/docs/examples/auth-provider/auth0.md
+++ b/documentation/docs/examples/auth-provider/auth0.md
@@ -12,7 +12,7 @@ Auth0 example doesn't work in StackBlitz embed mode. With [this](https://ussft.c
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/authProvider/auth0)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authProvider/auth0?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authProvider/auth0?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-auth0-example"
 ></iframe>

--- a/documentation/docs/examples/auth-provider/google-auth.md
+++ b/documentation/docs/examples/auth-provider/google-auth.md
@@ -8,7 +8,7 @@ You can use Google Login to control access and provide identity for your app. Th
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/authProvider/googleLogin)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authProvider/googleLogin?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authProvider/googleLogin?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-google-login-example"
 ></iframe>

--- a/documentation/docs/examples/auth-provider/otpLogin.md
+++ b/documentation/docs/examples/auth-provider/otpLogin.md
@@ -8,7 +8,7 @@ A one-time password(OTP) is a password that has two fundamental properties : it 
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/authProvider/otpLogin)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authProvider/otpLogin?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authProvider/otpLogin?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-otp-login-example"
 ></iframe>

--- a/documentation/docs/examples/authentication/antd.md
+++ b/documentation/docs/examples/authentication/antd.md
@@ -9,7 +9,7 @@ You can create your own Authentication approach using **refine**. You can custom
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/authentication/antd)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authentication/antd?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authentication/antd?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-authentication-example"
 ></iframe>

--- a/documentation/docs/examples/authentication/headless.md
+++ b/documentation/docs/examples/authentication/headless.md
@@ -9,7 +9,7 @@ You can create your own Authentication approach using **refine**. You can custom
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/authentication/headless)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authentication/headless?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authentication/headless?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-headless-authentication-example"
 ></iframe>

--- a/documentation/docs/examples/authentication/mantine.md
+++ b/documentation/docs/examples/authentication/mantine.md
@@ -9,7 +9,7 @@ You can create your own Authentication approach using **refine**. You can custom
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/authentication/mantine)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authentication/mantine?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authentication/mantine?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-mantine-authentication-example"
 ></iframe>

--- a/documentation/docs/examples/authentication/mui.md
+++ b/documentation/docs/examples/authentication/mui.md
@@ -9,7 +9,7 @@ You can create your own Authentication approach using **refine**. You can custom
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/authentication/mui)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authentication/mui?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/authentication/mui?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-mantine-authentication-example"
 ></iframe>

--- a/documentation/docs/examples/calendar.md
+++ b/documentation/docs/examples/calendar.md
@@ -9,7 +9,7 @@ In this example you can see how Ant Design's [Calendar](https://ant.design/compo
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/calendar)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/calendar?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/calendar?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-tutorial"
 ></iframe>

--- a/documentation/docs/examples/command-palette.md
+++ b/documentation/docs/examples/command-palette.md
@@ -13,7 +13,7 @@ Try it out – press cmd+k (macOS) or ctrl+k (Linux/Windows).
 
 [View kbar Example Source](https://github.com/pankod/refine/tree/master/examples/commandPalette/kbar)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/commandPalette/kbar?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/commandPalette/kbar?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-footer-example"
 ></iframe>

--- a/documentation/docs/examples/core/useImport.md
+++ b/documentation/docs/examples/core/useImport.md
@@ -12,7 +12,7 @@ The `useImport` hook was created by **refine** to help you import CSV files. You
 
 [View useImport Example Source](https://github.com/pankod/refine/tree/master/examples/core/useImport)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/core/useImport?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/core/useImport?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-footer-example"
 ></iframe>

--- a/documentation/docs/examples/core/useModal.md
+++ b/documentation/docs/examples/core/useModal.md
@@ -12,7 +12,7 @@ Using the `useModal` hook that comes with the **headless** version of **refine**
 
 [View useModal Example Source](https://github.com/pankod/refine/tree/master/examples/core/useModal)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/core/useModal?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/core/useModal?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-footer-example"
 ></iframe>

--- a/documentation/docs/examples/core/useSelect.md
+++ b/documentation/docs/examples/core/useSelect.md
@@ -8,7 +8,7 @@ example-tags: [headless,refine-hooks]
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/core/useSelect)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/core/useSelect?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/core/useSelect?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-footer-example"
 ></iframe>

--- a/documentation/docs/examples/custom-pages.md
+++ b/documentation/docs/examples/custom-pages.md
@@ -9,7 +9,7 @@ The feature to modify your project in detail is a major benefit of using **refin
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/customPages)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customPages?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customPages?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="custom-pages-example"
 ></iframe>

--- a/documentation/docs/examples/customization/customFooter.md
+++ b/documentation/docs/examples/customization/customFooter.md
@@ -9,7 +9,7 @@ In your **refine** project, you can modify the design in a few simple steps. Wit
 
 [View Custom Footer Example Source](https://github.com/pankod/refine/tree/master/examples/customization/customFooter)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/customFooter?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/customFooter?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-footer-example"
 ></iframe>

--- a/documentation/docs/examples/customization/customLogin.md
+++ b/documentation/docs/examples/customization/customLogin.md
@@ -9,7 +9,7 @@ With **refine**, you may customize your Login pages to match your own case and d
 
 [View Custom Login Page Example Source](https://github.com/pankod/refine/tree/master/examples/customization/customLogin)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/customLogin?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/customLogin?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-login-example"
 ></iframe>

--- a/documentation/docs/examples/customization/customSider.md
+++ b/documentation/docs/examples/customization/customSider.md
@@ -9,7 +9,7 @@ Creating your own `Sider Menu` with **refine** is quite simple. We have customiz
 
 [View Custom Sider Example Source](https://github.com/pankod/refine/tree/master/examples/customization/customSider)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/customSider?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/customSider?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-custom-sider-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/customization/offLayoutArea.md
+++ b/documentation/docs/examples/customization/offLayoutArea.md
@@ -9,7 +9,7 @@ With **refine**, you may manage your entire project. It does not limit you in an
 
 [View Off Layout Example Source](https://github.com/pankod/refine/tree/master/examples/customization/offLayoutArea)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/offLayoutArea?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/offLayoutArea?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-off-layout-area-example"
 ></iframe>

--- a/documentation/docs/examples/customization/rtl.md
+++ b/documentation/docs/examples/customization/rtl.md
@@ -9,7 +9,7 @@ This example shows how to use **refine** to manage and customize the content of 
 
 [View RTL Example Source](https://github.com/pankod/refine/tree/master/examples/customization/rtl)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/rtl?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/rtl?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-rtl-example"
 ></iframe>

--- a/documentation/docs/examples/customization/topMenuLayout.md
+++ b/documentation/docs/examples/customization/topMenuLayout.md
@@ -9,7 +9,7 @@ example-tags: [antd,customization]
 
 [View Top Menu Layout Example Source](https://github.com/pankod/refine/tree/master/examples/customization/topMenuLayout)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/topMenuLayout?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/topMenuLayout?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-top-menu-layout-example"
 ></iframe>

--- a/documentation/docs/examples/data-provider/airtable.md
+++ b/documentation/docs/examples/data-provider/airtable.md
@@ -8,7 +8,7 @@ By using **refine**`s full-featured [Airtable](https://www.airtable.com/) Data P
 
 [View Airtable Example Source](https://github.com/pankod/refine/tree/master/examples/dataProvider/airtable)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/airtable?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/airtable?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-airtable-example"
 ></iframe>

--- a/documentation/docs/examples/data-provider/altogic.md
+++ b/documentation/docs/examples/data-provider/altogic.md
@@ -8,7 +8,7 @@ example-tags: [antd,data-provider,altogic]
 
 [View Altogic Example Source](https://github.com/pankod/refine/tree/master/examples/dataProvider/altogic)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/altogic?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/altogic?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-strapi-example"
 ></iframe>

--- a/documentation/docs/examples/data-provider/appwrite.md
+++ b/documentation/docs/examples/data-provider/appwrite.md
@@ -11,7 +11,7 @@ Connect your [Appwrite](https://appwrite.io/) database with [**refine** Appwrite
 **Username**: `demo@refine.dev`  
 **Password**: `demodemo`
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/appwrite?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/appwrite?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-appwrite-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/data-provider/directus.md
+++ b/documentation/docs/examples/data-provider/directus.md
@@ -13,7 +13,7 @@ Directus Data Provider is developed by the community. We would like to thank [ts
 -   `Username`: demo@demo.com
 -   `Password`: 123456
 
-<iframe loading="lazy" src="https://stackblitz.com//github/tspvivek/refine-directus/tree/master/example?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/tspvivek/refine-directus/tree/master/example?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-directus"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/data-provider/hasura.md
+++ b/documentation/docs/examples/data-provider/hasura.md
@@ -8,7 +8,7 @@ Any REST or GraphQL custom backend work integrated with **refine**. **refine** [
 
 [View Hasura Example Source](https://github.com/pankod/refine/tree/master/examples/dataProvider/hasura)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/hasura?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/hasura?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-hasura-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/data-provider/multiple.md
+++ b/documentation/docs/examples/data-provider/multiple.md
@@ -8,7 +8,7 @@ example-tags: [antd,data-provider]
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/dataProvider/multiple)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/multiple?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/multiple?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-multiple-data-provider-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/data-provider/nestjsxCrud.md
+++ b/documentation/docs/examples/data-provider/nestjsxCrud.md
@@ -8,7 +8,7 @@ example-tags: [antd,data-provider,nestJsx-crud]
 
 [View Nestjsx Crud Example Source](https://github.com/pankod/refine/tree/master/examples/dataProvider/nestjsxCrud)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/nestjsxCrud?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/nestjsxCrud?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-nestjsx-crud-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/data-provider/nhost.md
+++ b/documentation/docs/examples/data-provider/nhost.md
@@ -10,7 +10,7 @@ example-tags: [antd,data-provider,nhost,auth-provider,graphql]
 **Username**: info@refine.dev  
 **Password**: demodemo
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/nhost?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/nhost?embed=1&view=preview&theme=dark&preset=node&ctl=1"
   style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
   title="refine-nhost-example"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/data-provider/strapi-graphql.md
+++ b/documentation/docs/examples/data-provider/strapi-graphql.md
@@ -8,7 +8,7 @@ example-tags: [antd,data-provider,strapi,graphql,auth-provider]
 
 [View Strapi-GraphQL Example Source](https://github.com/pankod/refine/tree/master/examples/dataProvider/strapi-graphql)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/strapi-graphql?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/strapi-graphql?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-graphql-example"
 ></iframe>

--- a/documentation/docs/examples/data-provider/strapi-v4.md
+++ b/documentation/docs/examples/data-provider/strapi-v4.md
@@ -11,7 +11,7 @@ example-tags: [antd,data-provider,strapi,strapi-v4,auth-provider]
 **Username**: demo@refine.dev  
 **Password**: demodemo
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/strapi-v4?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/strapi-v4?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-strapi-example"
 ></iframe>

--- a/documentation/docs/examples/data-provider/strapi.md
+++ b/documentation/docs/examples/data-provider/strapi.md
@@ -11,7 +11,7 @@ This example demonstrates how to quickly connect your [Strapi](https://strapi.io
 **Username**: demo@refine.dev  
 **Password**: demodemo
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/strapi?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/strapi?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-strapi-example"
 ></iframe>

--- a/documentation/docs/examples/data-provider/supabase.md
+++ b/documentation/docs/examples/data-provider/supabase.md
@@ -12,7 +12,7 @@ Connect your [Supabase](https://supabase.com/) database with **refine** Supabase
 StackBlitz environment does not allow Realtime features to work.
 :::
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/supabase?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/dataProvider/supabase?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-supabase-example"
 ></iframe>

--- a/documentation/docs/examples/e2e-testing.md
+++ b/documentation/docs/examples/e2e-testing.md
@@ -9,7 +9,7 @@ End-to-end testing (E2E Testing) is a method for examining whether an applicatio
 
 [View E2E Testing Example Source](https://github.com/pankod/refine/tree/master/examples/e2e)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/e2e?embed=1&file=cypress/integration/sider.spec.js&view=editor&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/e2e?embed=1&file=cypress/integration/sider.spec.js&view=editor&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-e2e-testing"
 ></iframe>

--- a/documentation/docs/examples/field/useCheckboxGroup.md
+++ b/documentation/docs/examples/field/useCheckboxGroup.md
@@ -11,7 +11,7 @@ The **refine** `useCheckboxGroup` hook allows you to manage your data in the for
 
 [View useCheckboxGroup Example Source](https://github.com/pankod/refine/tree/master/examples/field/useCheckboxGroup)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useCheckboxGroup?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useCheckboxGroup?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-checkbox-group-example"
 ></iframe>

--- a/documentation/docs/examples/field/useRadioGroup.md
+++ b/documentation/docs/examples/field/useRadioGroup.md
@@ -11,7 +11,7 @@ You can use the **refine** `useRadioGroup` hook to manage your data in a source 
 
 [View useRadioGroup Example Source](https://github.com/pankod/refine/tree/master/examples/field/useRadioGroup)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useRadioGroup?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useRadioGroup?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-radio-group-example"
 ></iframe>

--- a/documentation/docs/examples/field/useSelect.md
+++ b/documentation/docs/examples/field/useSelect.md
@@ -11,7 +11,7 @@ When records in a resource need to be used as select options, the **refine** `us
 
 [View useSelect Example Source](https://github.com/pankod/refine/tree/master/examples/field/useSelect/antd/basic)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useSelect/antd/basic?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/field/useSelect/antd/basic?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-select-example"
 ></iframe>

--- a/documentation/docs/examples/form/antd/custom-form-validation.md
+++ b/documentation/docs/examples/form/antd/custom-form-validation.md
@@ -10,7 +10,7 @@ You can make basic validations with Ant Design [Form.Item](https://ant.design/co
 
 [View Custom Form Validation Example Source](https://github.com/pankod/refine/tree/master/examples/form/antd/customValidation)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/customValidation?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/customValidation?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-validation-example-app"
 ></iframe>

--- a/documentation/docs/examples/form/antd/useDrawerForm.md
+++ b/documentation/docs/examples/form/antd/useDrawerForm.md
@@ -10,7 +10,7 @@ example-tags: [form,antd]
 
 [View useDrawerForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/antd/useDrawerForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useDrawerForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useDrawerForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-drawer-form-example"
 ></iframe>

--- a/documentation/docs/examples/form/antd/useForm.md
+++ b/documentation/docs/examples/form/antd/useForm.md
@@ -10,7 +10,7 @@ example-tags: [form,antd]
 
 [View useForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/antd/useForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-form-example"
 ></iframe>

--- a/documentation/docs/examples/form/antd/useModalForm.md
+++ b/documentation/docs/examples/form/antd/useModalForm.md
@@ -10,7 +10,7 @@ With the `useModalForm` hook, you can manage a form inside of your modal compone
 
 [View useModalForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/antd/useModalForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useModalForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useModalForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
   style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
   title="refine-use-modal-form-example"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/form/antd/useStepsForm.md
+++ b/documentation/docs/examples/form/antd/useStepsForm.md
@@ -10,7 +10,7 @@ The `useStepsForm` hook is a method that allows you to split your form into mult
 
 [View useSteps Example Source](https://github.com/pankod/refine/tree/master/examples/form/antd/useStepsForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useStepsForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/antd/useStepsForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-steps-form-example"
 ></iframe>

--- a/documentation/docs/examples/form/headless/save-and-continue.md
+++ b/documentation/docs/examples/form/headless/save-and-continue.md
@@ -13,7 +13,7 @@ We have three save options: `Save`, `Save and continue editing` and `Save and ad
 
 [View Save and Continue Example Source](https://github.com/pankod/refine/tree/master/examples/form/headless/saveAndContinue)
 
-<iframe src="https://stackblitz.com/github/pankod/refine/tree/master/examples/form/headless/saveAndContinue?embed=1&view=preview&theme=dark&preset=node"
+<iframe src="https://stackblitz.com/github/pankod/refine/tree/master/examples/form/headless/saveAndContinue?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-validation-example-app"
 ></iframe>

--- a/documentation/docs/examples/form/mantine/useDrawerForm.md
+++ b/documentation/docs/examples/form/mantine/useDrawerForm.md
@@ -10,7 +10,7 @@ example-tags: [form,mantine]
 
 [View Drawer Form Example Source](https://github.com/pankod/refine/tree/master/examples/form/mantine/useDrawerForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useDrawerForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useDrawerForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="mantine-use-drawer-form-example"
 ></iframe>

--- a/documentation/docs/examples/form/mantine/useForm.md
+++ b/documentation/docs/examples/form/mantine/useForm.md
@@ -10,7 +10,7 @@ example-tags: [form,mantine]
 
 [View useForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/mantine/useForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="mantine-use-form-example"
 ></iframe>

--- a/documentation/docs/examples/form/mantine/useModalForm.md
+++ b/documentation/docs/examples/form/mantine/useModalForm.md
@@ -10,7 +10,7 @@ example-tags: [form,mantine]
 
 [View useModalForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/mantine/useModalForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useModalForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useModalForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
   style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
   title="mantine-use-modal-form-example"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/form/mantine/useStepsForm.md
+++ b/documentation/docs/examples/form/mantine/useStepsForm.md
@@ -10,7 +10,7 @@ example-tags: [form,mantine]
 
 [View useStepsForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/mantine/useStepsForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useStepsForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mantine/useStepsForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="mantine-use-steps-form-example"
 ></iframe>

--- a/documentation/docs/examples/form/mui/useDrawerForm.md
+++ b/documentation/docs/examples/form/mui/useDrawerForm.md
@@ -10,7 +10,7 @@ example-tags: [form,mui,react-hook-form]
 
 [View Drawer Form Example Source](https://github.com/pankod/refine/tree/master/examples/form/mui/useDrawerForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mui/useDrawerForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mui/useDrawerForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="mui-use-drawer-form"
 ></iframe>

--- a/documentation/docs/examples/form/mui/useForm.md
+++ b/documentation/docs/examples/form/mui/useForm.md
@@ -10,7 +10,7 @@ example-tags: [form,mui,react-hook-form]
 
 [View useForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/mui/useForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mui/useForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mui/useForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="mui-use-form"
 ></iframe>

--- a/documentation/docs/examples/form/mui/useModalForm.md
+++ b/documentation/docs/examples/form/mui/useModalForm.md
@@ -10,7 +10,7 @@ example-tags: [form,mui,react-hook-form]
 
 [View useModalForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/mui/useModalForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mui/useModalForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mui/useModalForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
   style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
   title="mui-use-modal-form"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/form/mui/useStepsForm.md
+++ b/documentation/docs/examples/form/mui/useStepsForm.md
@@ -10,7 +10,7 @@ example-tags: [form,mui,react-hook-form]
 
 [View useStepsForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/mui/useStepsForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mui/useStepsForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/mui/useStepsForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="mui-use-steps-form"
 ></iframe>

--- a/documentation/docs/examples/form/react-hook-form/useForm.md
+++ b/documentation/docs/examples/form/react-hook-form/useForm.md
@@ -10,7 +10,7 @@ example-tags: [form,headless,react-hook-form]
 
 [View useForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/reactHookForm/useForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/reactHookForm/useForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/reactHookForm/useForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-react-hook-form-example"
 ></iframe>

--- a/documentation/docs/examples/form/react-hook-form/useModalForm.md
+++ b/documentation/docs/examples/form/react-hook-form/useModalForm.md
@@ -10,7 +10,7 @@ example-tags: [form,headless,react-hook-form]
 
 [View useModalForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/reactHookForm/useModalForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/reactHookForm/useStepsForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/reactHookForm/useStepsForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-react-hook-form-example"
 ></iframe>

--- a/documentation/docs/examples/form/react-hook-form/useStepsForm.md
+++ b/documentation/docs/examples/form/react-hook-form/useStepsForm.md
@@ -10,7 +10,7 @@ example-tags: [form,headless,react-hook-form]
 
 [View useStepsForm Example Source](https://github.com/pankod/refine/tree/master/examples/form/reactHookForm/useStepsForm)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/reactHookForm/useStepsForm?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/reactHookForm/useStepsForm?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-react-hook-form-example"
 ></iframe>

--- a/documentation/docs/examples/i18n/i18n-nextjs.md
+++ b/documentation/docs/examples/i18n/i18n-nextjs.md
@@ -10,7 +10,7 @@ example-tags: [next.js,i18n,antd]
 
 [View i18n-Nextjs Example Source](https://github.com/pankod/refine/tree/master/examples/i18n/nextjs)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/i18n/nextjs/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/i18n/nextjs/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
 style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-i18n-example"
 ></iframe>

--- a/documentation/docs/examples/i18n/i18n-react.md
+++ b/documentation/docs/examples/i18n/i18n-react.md
@@ -10,7 +10,7 @@ example-tags: [antd,i18n]
 
 [View i18n-React Example Source](https://github.com/pankod/refine/tree/master/examples/i18n/react)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/i18n/react?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/i18n/react?embed=1&view=preview&theme=dark&preset=node&ctl=1"
 style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-i18n-example"
 ></iframe>

--- a/documentation/docs/examples/import-export.md
+++ b/documentation/docs/examples/import-export.md
@@ -13,7 +13,7 @@ example-tags: [antd,import,export,refine-hooks,data-provider]
 
 [View Import-Export CSV Example Source](https://github.com/pankod/refine/tree/master/examples/importExport/antd)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/importExport/antd?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/importExport/antd?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-import-export-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/inputs/customInput.md
+++ b/documentation/docs/examples/inputs/customInput.md
@@ -11,7 +11,7 @@ When working with form data, **refine** uses Ant Design's Form component. Ant De
 
 [View Custom Input Example Source](https://github.com/pankod/refine/tree/master/examples/inputs/customInputs)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/inputs/customInputs?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/inputs/customInputs?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-inputs-example"
 ></iframe>

--- a/documentation/docs/examples/inputs/datePicker.md
+++ b/documentation/docs/examples/inputs/datePicker.md
@@ -9,7 +9,7 @@ While creating a record with **refine**, you may use the Ant Design [Date Picker
 
 [View DatePicker Example Source](https://github.com/pankod/refine/tree/master/examples/inputs/datePicker)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/inputs/datePicker/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/inputs/datePicker/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-date-picker-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/javascript.md
+++ b/documentation/docs/examples/javascript.md
@@ -9,7 +9,7 @@ Refine supports you to develop with JavaScript. All features of **refine** can b
 
 [View **refine** JavaScript Example Source](https://github.com/pankod/refine/tree/master/examples/javascript)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/javascript?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/javascript?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="javascript-example"
 ></iframe>

--- a/documentation/docs/examples/list/useSimpleList.md
+++ b/documentation/docs/examples/list/useSimpleList.md
@@ -11,7 +11,7 @@ example-tags: [antd,refine-hooks]
 
 [View useSimpleList Example Source](https://github.com/pankod/refine/tree/master/examples/list/useSimpleList)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/list/useSimpleList?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/list/useSimpleList?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-simple-list-example"
 ></iframe>

--- a/documentation/docs/examples/live-provider/ably.md
+++ b/documentation/docs/examples/live-provider/ably.md
@@ -8,7 +8,7 @@ The [liveProvider](/docs/advanced-tutorials/real-time/) is a powerful tool for d
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/ably)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/ably/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/ably/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-ably-example"
 ></iframe>

--- a/documentation/docs/examples/multi-level-menu/multi-level-menu.md
+++ b/documentation/docs/examples/multi-level-menu/multi-level-menu.md
@@ -8,7 +8,7 @@ The multi-level menu will provide you with the necessary infrastructure to creat
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/multi-level-menu)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/multi-level-menu?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/multi-level-menu?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-multi-level-menu-example"
 ></iframe>

--- a/documentation/docs/examples/multi-tenancy/appwrite.md
+++ b/documentation/docs/examples/multi-tenancy/appwrite.md
@@ -10,7 +10,7 @@ In this example, we've shown how to build a Multi-Tenant app using the [Appwrite
 
 [View Appwrite Multi-Tenancy Example Source](https://github.com/pankod/refine/tree/master/examples/multi-tenancy/appwrite)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/multi-tenancy/appwrite?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/multi-tenancy/appwrite?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="cake-house"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/next-js/next-js.md
+++ b/documentation/docs/examples/next-js/next-js.md
@@ -10,7 +10,7 @@ example-tags: [next.js,router-provider,antd]
 
 [View Next.js Example Source](https://github.com/pankod/refine/tree/master/examples/refine-next)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/i18n/nextjs/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/i18n/nextjs/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
 style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-nextjs-example"
 ></iframe>

--- a/documentation/docs/examples/notification-provider/react-toastify.md
+++ b/documentation/docs/examples/notification-provider/react-toastify.md
@@ -10,7 +10,7 @@ With **refine** Notification Provider, you can show notification messages in you
 
 [View React Toastify Example Source](https://github.com/pankod/refine/tree/master/examples/reactToastify)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/reactToastify/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/reactToastify/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-react-toastify-example"
 ></iframe>

--- a/documentation/docs/examples/real-world.md
+++ b/documentation/docs/examples/real-world.md
@@ -13,7 +13,7 @@ While most "todo" demos provide an excellent cursory glance at a framework's cap
 
 [View Source Code](https://github.com/pankod/refine/tree/master/examples/real-world-example)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/real-world-example?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/real-world-example?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-tutorial"
 ></iframe>

--- a/documentation/docs/examples/remix/antd.md
+++ b/documentation/docs/examples/remix/antd.md
@@ -9,7 +9,7 @@ example-tags: [remix,router-provider,antd]
 
 [View Remix + Ant Design Example Source](https://github.com/pankod/refine/tree/master/examples/remix/antd)
 
-<iframe loading="lazy" src="https://stackblitz.com/github/pankod/refine/tree/master/examples/remix/antd/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com/github/pankod/refine/tree/master/examples/remix/antd/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
 style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-remix-antd-example"
 ></iframe>

--- a/documentation/docs/examples/remix/headless.md
+++ b/documentation/docs/examples/remix/headless.md
@@ -10,7 +10,7 @@ example-tags: [remix,router-provider,headless]
 
 [View Next.js Example Source](https://github.com/pankod/refine/tree/master/examples/remix/headless)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/remix/headless/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/remix/headless/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
 style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-remix-headless-example"
 ></iframe>

--- a/documentation/docs/examples/router-provider/react-location.md
+++ b/documentation/docs/examples/router-provider/react-location.md
@@ -10,7 +10,7 @@ example-tags: [antd,router-provider,react-location]
 
 [View React Location Example Source](https://github.com/pankod/refine/tree/master/examples/react-location)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/react-location?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/react-location?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-auth0-example"
 ></iframe>

--- a/documentation/docs/examples/search/search.md
+++ b/documentation/docs/examples/search/search.md
@@ -11,7 +11,7 @@ This example explains in detail how to create a `Search` component using Ant Des
 
 [View Search Example Source](https://github.com/pankod/refine/tree/master/examples/search)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/search?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/search?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-search-example"
 ></iframe>

--- a/documentation/docs/examples/table/antd/advanced-table.md
+++ b/documentation/docs/examples/table/antd/advanced-table.md
@@ -9,7 +9,7 @@ Multiple record deletion, modification, and other features can be used simultane
 
 [View Advanced Table Example Source](https://github.com/pankod/refine/tree/master/examples/table/antd/advancedTable)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/advancedTable?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/advancedTable?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-advanced-table-example"
 ></iframe>

--- a/documentation/docs/examples/table/antd/table-filter.md
+++ b/documentation/docs/examples/table/antd/table-filter.md
@@ -10,7 +10,7 @@ By filtering your table's data you may only see the fields you want.
 
 [View Table Filter Example Source](https://github.com/pankod/refine/tree/master/examples/table/antd/tableFilter)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/tableFilter?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/tableFilter?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-table-filter-example"
 ></iframe>

--- a/documentation/docs/examples/table/antd/useDeleteMany.md
+++ b/documentation/docs/examples/table/antd/useDeleteMany.md
@@ -11,7 +11,7 @@ The `useDeleteMany` is one of **refine**'s data hooks. It removes more than one 
 
 [View useDeleteMany Table Example Source](https://github.com/pankod/refine/tree/master/examples/table/antd/useDeleteMany)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useDeleteMany?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useDeleteMany?embed=1&view=preview&theme=dark&preset=node&ctl=1"
   style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
   title="refine-use-delete-many-example"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/table/antd/useEditableTable.md
+++ b/documentation/docs/examples/table/antd/useEditableTable.md
@@ -11,7 +11,7 @@ example-tags: [table,antd,refine-hooksreact-router]
 
 [View useEditableTable Example Source](https://github.com/pankod/refine/tree/master/examples/table/antd/useEditableTable)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useEditableTable?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useEditableTable?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-editable-table-example"
 ></iframe>

--- a/documentation/docs/examples/table/antd/useTable.md
+++ b/documentation/docs/examples/table/antd/useTable.md
@@ -11,7 +11,7 @@ You may use the `useTable` hook to process your data with features compatible wi
 
 [View useTable Example Source](https://github.com/pankod/refine/tree/master/examples/table/antd/useTable)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useTable?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useTable?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-table-example"
 ></iframe>

--- a/documentation/docs/examples/table/antd/useUpdateMany.md
+++ b/documentation/docs/examples/table/antd/useUpdateMany.md
@@ -11,7 +11,7 @@ example-tags: [table,antd,refine-hooksreact-router]
 
 [View useUpdateMany Table Example Source](https://github.com/pankod/refine/tree/master/examples/table/antd/useUpdateMany)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useUpdateMany?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/antd/useUpdateMany?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-use-update-many-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/table/handsontable/basic.md
+++ b/documentation/docs/examples/table/handsontable/basic.md
@@ -11,7 +11,7 @@ This example shows you how to manage relational data, sort, and update.
 
 [View Handsontable Example Source](https://github.com/pankod/refine/tree/master/examples/table/handson)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/handson/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/handson/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-react-table-example"
 ></iframe>

--- a/documentation/docs/examples/table/mantine/advanced.md
+++ b/documentation/docs/examples/table/mantine/advanced.md
@@ -9,7 +9,7 @@ It is an example of Mantine Advanced [React Table](https://react-table.tanstack.
 
 [View Mantine Advanced React Table Example Source](https://github.com/pankod/refine/tree/master/examples/table/mantine/advanced)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mantine/advanced/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mantine/advanced/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="mantine-advanced-react-table-example"
 ></iframe>

--- a/documentation/docs/examples/table/mantine/basic.md
+++ b/documentation/docs/examples/table/mantine/basic.md
@@ -11,7 +11,7 @@ example-tags: [table,mantine,react-tablereact-router]
 
 [View Mantine React Table Example Source](https://github.com/pankod/refine/tree/master/examples/table/reactTable/basic)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mantine/basic/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mantine/basic/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="mantine-basic-react-table-example"
 ></iframe>

--- a/documentation/docs/examples/table/mui/advanced.md
+++ b/documentation/docs/examples/table/mui/advanced.md
@@ -10,7 +10,7 @@ Advanced table examples with [`useDataGrid`](/api-reference/mui/hooks/useDataGri
 
 [View advanced example source](https://github.com/pankod/refine/tree/master/examples/table/mui/advancedTable)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/advancedTable?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/advancedTable?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-data-grid-example"
 ></iframe>

--- a/documentation/docs/examples/table/mui/filter.md
+++ b/documentation/docs/examples/table/mui/filter.md
@@ -11,7 +11,7 @@ By filtering your table's data you may only see the fields you want.
 
 [View Table Filter Example Source](https://github.com/pankod/refine/tree/master/examples/mui/tableFilter)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/tableFilter?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/tableFilter?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-table-filter-example"
 ></iframe>

--- a/documentation/docs/examples/table/mui/useDataGrid.md
+++ b/documentation/docs/examples/table/mui/useDataGrid.md
@@ -14,7 +14,7 @@ You may use the `useDataGrid` hook to process your data with features compatible
 
 [View useDataGrid with `DataGrid` component example source](https://github.com/pankod/refine/tree/master/examples/table/mui/useDataGrid)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/useDataGrid?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/useDataGrid?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-data-grid-example"
 ></iframe>
@@ -23,7 +23,7 @@ You may use the `useDataGrid` hook to process your data with features compatible
 
 [View useDataGrid with `DataGridPro` component example source](https://github.com/pankod/refine/tree/master/examples/table/mui/dataGridPro)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/dataGridPro?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/dataGridPro?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-data-grid-example"
 ></iframe>

--- a/documentation/docs/examples/table/mui/useDeleteMany.md
+++ b/documentation/docs/examples/table/mui/useDeleteMany.md
@@ -11,7 +11,7 @@ The `useDeleteMany` is one of **refine**'s data hooks. It removes more than one 
 
 [View useDeleteMany Table Example Source](https://github.com/pankod/refine/tree/master/examples/table/mui/useDeleteMany)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/useDeleteMany?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/useDeleteMany?embed=1&view=preview&theme=dark&preset=node&ctl=1"
   style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
   title="refine-use-delete-many-example"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/table/mui/useUpdateMany.md
+++ b/documentation/docs/examples/table/mui/useUpdateMany.md
@@ -11,7 +11,7 @@ example-tags: [table,mui,refine-hooksreact-router]
 
 [View useUpdateMany Table Example Source](https://github.com/pankod/refine/tree/master/examples/table/mui/useUpdateMany)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/useUpdateMany?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/mui/useUpdateMany?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="refine-use-update-many-example"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/examples/table/react-table/advanced.md
+++ b/documentation/docs/examples/table/react-table/advanced.md
@@ -9,7 +9,7 @@ It is an example of Advanced [React Table](https://react-table.tanstack.com/) cr
 
 [View Advanced React Table Example Source](https://github.com/pankod/refine/tree/master/examples/table/reactTable/advanced)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/reactTable/advanced/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/reactTable/advanced/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-advanced-react-table-example"
 ></iframe>

--- a/documentation/docs/examples/table/react-table/basic.md
+++ b/documentation/docs/examples/table/react-table/basic.md
@@ -11,7 +11,7 @@ example-tags: [table,react-tablereact-router]
 
 [View React Table Example Source](https://github.com/pankod/refine/tree/master/examples/table/reactTable/basic)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/reactTable/basic/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/reactTable/basic/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-react-table-example"
 ></iframe>

--- a/documentation/docs/examples/theme.md
+++ b/documentation/docs/examples/theme.md
@@ -9,7 +9,7 @@ You can customize design and theme in your project with **refine**. In this exam
 
 [View Custom Theme Example Source](https://github.com/pankod/refine/tree/master/examples/customization/customTheme/antd)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/customTheme/antd/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/customization/customTheme/antd/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-custom-theme-example"
 ></iframe>

--- a/documentation/docs/examples/tutorial/antd-tutorial.md
+++ b/documentation/docs/examples/tutorial/antd-tutorial.md
@@ -11,7 +11,7 @@ This [tutorial](/docs/tutorials/ant-design-tutorial/) will go through process of
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/tutorial)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/tutorial/antd?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/tutorial/antd?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-tutorial"
 ></iframe>

--- a/documentation/docs/examples/tutorial/headless-tutorial.md
+++ b/documentation/docs/examples/tutorial/headless-tutorial.md
@@ -11,7 +11,7 @@ This [tutorial](/docs/tutorials/headless-tutorial/) will go through process of b
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/tutorial)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/tutorial/headless?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/tutorial/headless?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-tutorial"
 ></iframe>

--- a/documentation/docs/examples/tutorial/mui-tutorial.md
+++ b/documentation/docs/examples/tutorial/mui-tutorial.md
@@ -11,7 +11,7 @@ This [tutorial](/docs/tutorials/material-ui-tutorial/) will go through process o
 
 [View Source](https://github.com/pankod/refine/tree/master/examples/tutorial)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/tutorial/mui?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/tutorial/mui?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-tutorial"
 ></iframe>

--- a/documentation/docs/examples/ui/useModal.md
+++ b/documentation/docs/examples/ui/useModal.md
@@ -9,7 +9,7 @@ You can use the `useModal` hook to manage an Ant Design [Modal](https://ant.desi
 
 [View useModal Example Source](https://github.com/pankod/refine/tree/master/examples/ui/useModal)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/ui/useModal?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/ui/useModal?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-use-modal-example"
 ></iframe>

--- a/documentation/docs/examples/upload/antd/base64.md
+++ b/documentation/docs/examples/upload/antd/base64.md
@@ -10,7 +10,7 @@ example-tags: [antd,upload]
 
 [View Base64 Upload Example Source](https://github.com/pankod/refine/tree/master/examples/upload/base64Upload)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/antd/base64?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/antd/base64?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-base64-upload-example"
 ></iframe>

--- a/documentation/docs/examples/upload/antd/multipart.md
+++ b/documentation/docs/examples/upload/antd/multipart.md
@@ -10,7 +10,7 @@ example-tags: [antd,upload]
 
 [View Multipart Upload Example Source](https://github.com/pankod/refine/tree/master/examples/upload/multipartUpload)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/antd/multipart?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/antd/multipart?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-multipart-upload-example"
 ></iframe>

--- a/documentation/docs/examples/upload/mantine/base64.md
+++ b/documentation/docs/examples/upload/mantine/base64.md
@@ -8,7 +8,7 @@ In this example, you'll learn how to do base64 upload in **refine** with `useFor
 
 [View Base64 Upload Example Source](https://github.com/pankod/refine/tree/master/examples/upload/mantine/base64)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/mantine/base64?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/mantine/base64?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="mantine-base64-upload"
 ></iframe>

--- a/documentation/docs/examples/upload/mantine/multipart.md
+++ b/documentation/docs/examples/upload/mantine/multipart.md
@@ -8,7 +8,7 @@ In this example, you'll learn how to do multipart upload in **refine** with `use
 
 [View Multipart Upload Example Source](https://github.com/pankod/refine/tree/master/examples/upload/mantine/multipart)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/mantine/multipart?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/mantine/multipart?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="mantine-multipart-upload"
 ></iframe>

--- a/documentation/docs/examples/upload/mui/base64.md
+++ b/documentation/docs/examples/upload/mui/base64.md
@@ -8,7 +8,7 @@ In this example, you'll learn how to do base64 upload in **refine** with React H
 
 [View Base64 Upload Example Source](https://github.com/pankod/refine/tree/master/examples/upload/mui/base64)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/mui/base64?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/mui/base64?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-base64-upload-example"
 ></iframe>

--- a/documentation/docs/examples/upload/mui/multipart.md
+++ b/documentation/docs/examples/upload/mui/multipart.md
@@ -8,7 +8,7 @@ In this example, you'll learn how to do multipart upload in **refine** with Reac
 
 [View Multipart Upload Example Source](https://github.com/pankod/refine/tree/master/examples/upload/mui/multipart)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/mui/multipart?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/upload/mui/multipart?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-base64-upload-example"
 ></iframe>

--- a/documentation/docs/examples/web3/signin-ethereum.md
+++ b/documentation/docs/examples/web3/signin-ethereum.md
@@ -10,7 +10,7 @@ A web3 wallet is a type of cryptocurrency wallet that allows you to send, receiv
 
 [View Sign-In with Ethereum Example Source](https://github.com/pankod/refine/tree/master/examples/web3/ethereumLogin)
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/web3/ethereumLogin?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/web3/ethereumLogin?embed=1&view=preview&theme=dark&preset=node&ctl=1"
      style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
      title="signin-with-ethereum"
      allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"

--- a/documentation/docs/packages/documentation/command-palette.md
+++ b/documentation/docs/packages/documentation/command-palette.md
@@ -128,7 +128,7 @@ useRegisterActions(customAction);
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/commandPalette/kbar?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/commandPalette/kbar?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-kbar-example"
 ></iframe>

--- a/documentation/docs/packages/documentation/react-hook-form/useForm.md
+++ b/documentation/docs/packages/documentation/react-hook-form/useForm.md
@@ -469,7 +469,7 @@ const {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/reactHookForm/useForm/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/reactHookForm/useForm/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-react-hook-form-example"
 ></iframe>

--- a/documentation/docs/packages/documentation/react-hook-form/useModalForm.md
+++ b/documentation/docs/packages/documentation/react-hook-form/useModalForm.md
@@ -427,7 +427,7 @@ export const EditPost: React.FC<UseModalFormReturnType> = ({
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/reactHookForm/useModalForm/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/reactHookForm/useModalForm/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-react-hook-form-example"
 ></iframe>

--- a/documentation/docs/packages/documentation/react-hook-form/useStepsForm.md
+++ b/documentation/docs/packages/documentation/react-hook-form/useStepsForm.md
@@ -461,7 +461,7 @@ export const PostEdit: React.FC = () => {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/reactHookForm/useStepsForm/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/form/reactHookForm/useStepsForm/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-react-hook-form-example"
 ></iframe>

--- a/documentation/docs/packages/documentation/react-table.md
+++ b/documentation/docs/packages/documentation/react-table.md
@@ -648,7 +648,7 @@ export const PostList: React.FC = () => {
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/reactTable/basic/?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/table/reactTable/basic/?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-react-table-example"
 ></iframe>

--- a/documentation/docs/testing.md
+++ b/documentation/docs/testing.md
@@ -11,7 +11,7 @@ We strongly recommend that you write end-to-end tests of your application. **ref
 
 ## Live StackBlitz Example
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/e2e?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/e2e?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-e2e-testing"
 ></iframe>

--- a/documentation/docs/tutorials/antd.md
+++ b/documentation/docs/tutorials/antd.md
@@ -1569,7 +1569,7 @@ After adding `canDelete` prop, `<DeleteButton>` will appear in edit form.
 
 Our tutorial is complete. Below you'll find a Live StackBlitz Example displaying what we have done so far:
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/tutorial/antd?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/tutorial/antd?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-tutorial"
 ></iframe>

--- a/documentation/docs/tutorials/core.md
+++ b/documentation/docs/tutorials/core.md
@@ -2306,7 +2306,7 @@ Now you can try deleting records yourself. Just click on the delete button of th
 
 Our tutorial is complete. Below you'll find a Live StackBlitz Example displaying what we have done so far:
 
-<iframe loading="lazy" src="https://stackblitz.com/github/pankod/refine/tree/master/examples/tutorial/headless?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com/github/pankod/refine/tree/master/examples/tutorial/headless?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-headless-tutorial-example"
 ></iframe>

--- a/documentation/docs/tutorials/mui.md
+++ b/documentation/docs/tutorials/mui.md
@@ -1663,7 +1663,7 @@ After adding `canDelete` prop, `<DeleteButton>` will appear in edit form.
 
 Our tutorial is complete. Below you'll find a Live StackBlitz Example displaying what we have done so far:
 
-<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/tutorial/mui?embed=1&view=preview&theme=dark&preset=node"
+<iframe loading="lazy" src="https://stackblitz.com//github/pankod/refine/tree/master/examples/tutorial/mui?embed=1&view=preview&theme=dark&preset=node&ctl=1"
     style={{width: "100%", height:"80vh", border: "0px", borderRadius: "8px", overflow:"hidden"}}
     title="refine-tutorial"
 ></iframe>

--- a/documentation/src/components/perfect-implementation/index.js
+++ b/documentation/src/components/perfect-implementation/index.js
@@ -16,7 +16,7 @@ export const PerfectImplementation = () => {
                     )}
                 >
                     <iframe
-                        src="https://stackblitz.com/github/pankod/refine/tree/master/examples/tutorial/antd?embed=1&view=preview&theme=dark&preset=node"
+                        src="https://stackblitz.com/github/pankod/refine/tree/master/examples/tutorial/antd?embed=1&view=preview&theme=dark&preset=node&ctl=1"
                         style={{
                             width: "100%",
                             height: "70vh",


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Some refine users have reported that StackBlitz embeds are crashing their browsers. Instead of loading the iframes directly, we will leave it to the user with the "ctl" parameter


### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
