### PR TITLE
fix: "/store" suffix to the end of Medusa API URL

### DIFF
--- a/.changeset/pink-files-explain.md
+++ b/.changeset/pink-files-explain.md
@@ -1,0 +1,5 @@
+---
+"@pankod/refine-medusa": patch
+---
+
+Fixed adding `/store` suffix to the end of Medusa API URL

--- a/examples/store/pages/_app.tsx
+++ b/examples/store/pages/_app.tsx
@@ -35,7 +35,7 @@ function MyApp({
                 DashboardPage={Dashboard}
                 authProvider={authProvider(PROXY_URL)}
                 routerProvider={routerProvider}
-                dataProvider={dataProvider(API_URL)}
+                dataProvider={dataProvider(PROXY_URL)}
                 resources={[
                     {
                         name: "dummy",

--- a/packages/medusa/src/dataProvider/index.ts
+++ b/packages/medusa/src/dataProvider/index.ts
@@ -59,8 +59,6 @@ const DataProvider = (
     apiUrl: string,
     httpClient: AxiosInstance = axiosInstance,
 ): Required<DataProviderType> => {
-    httpClient.defaults.baseURL = `${apiUrl}/store`;
-
     return {
         getList: async ({
             resource,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

By default, we added `/store` suffix to the end of Medusa API URL. This prevented the user from using a different path.

### Test plan (required)

![Screen Shot 2022-10-19 at 09 26 03](https://user-images.githubusercontent.com/1110414/196613132-fc5583bd-d20b-4bba-8ce4-967060629b47.png)

<!-- Make sure tests pass. -->

### Closing issues

- #2822

### Self Check before Merge

Please check all items below before review.

-   [x] Corresponding issues are created/updated or not needed
-   [x] Docs are updated/provided or not needed
-   [x] Examples are updated/provided or not needed
-   [x] TypeScript definitions are updated/provided or not needed
-   [x] Tests are updated/provided or not needed
-   [x] Changesets are provided or not needed
